### PR TITLE
feat(kanban): v0.2.0 — Jira backend driver

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.0-dev.1",
+      "version": "0.2.0-dev.2",
       "description": "Kanban workflow for Claude Code — task lifecycle through kanban.json",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.0-dev",
+      "version": "0.2.0-dev.1",
       "description": "Kanban workflow for Claude Code — task lifecycle through kanban.json",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.0-dev.2",
+      "version": "0.2.0-dev.3",
       "description": "Kanban workflow for Claude Code — task lifecycle through kanban.json",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.0-dev.3",
-      "description": "Kanban workflow for Claude Code — task lifecycle through kanban.json",
+      "version": "0.2.0",
+      "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]
     },
@@ -39,7 +39,7 @@
     {
       "name": "workbench",
       "source": "./plugins/workbench",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "description": "★ Core bundle — kanban + notify + memory (meta, stub)",
       "category": "productivity",
       "keywords": ["bundle", "meta"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.1.1",
+      "version": "0.2.0-dev",
       "description": "Kanban workflow for Claude Code — task lifecycle through kanban.json",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-04-29
+
+### Added
+- **kanban 0.2.0** — Jira Cloud as a second backend driver. The plugin
+  keeps the same `/kanban:*` command surface (status, next, done, block);
+  the storage layer is the only thing that changes when a project opts in.
+  Highlights:
+  - **Driver abstraction** — `plugins/kanban/drivers/{base,local,jira}.py`
+    behind a single `Driver` Protocol. `kanban.json` writers always emit
+    the new `version: "0.2"` shape; readers still accept legacy
+    `schema_version: 1` files transparently.
+  - **`/kanban:initjira`** — five-step setup (credentials → board →
+    workflow check → AP custom field → first AP registration), plus an
+    optional migration step that imports existing local tasks into Jira
+    and a final MCP-conflict scan.
+  - **Agent Property (AP)** — single-select Jira custom field that
+    distinguishes which AI agent owns a card. Slash commands
+    `/kanban:register-ap`, `/kanban:assign-ap`, `/kanban:whoami`. Registry
+    lives in Jira (source of truth) with a cached mirror in
+    `kanban.json#backend.jira.ap.registered` and per-repo identity in
+    `.claude/kanban-agent.json`.
+  - **Anti-self-approve (SPEC §8)** — `JiraDriver.transition` refuses
+    DONE when `task.ap == current_repo_ap`. Raises `SelfApproveRefused`;
+    surfaced to slash commands as exit code 2 + `kind: self-approve`.
+  - **Auto-detection** — `UserPromptSubmit` and `SessionStart` hooks scan
+    for Jira card keys / URLs filtered by `projectKey`, run a precheck
+    (cached 30s under `.claude/.kanban-cache/`), and inject context above
+    the agent's prompt. Cache is invalidated on every plugin write.
+  - **`/kanban:sync`** and **`/kanban:question`** — explicit refresh,
+    Q-prefix comment + transition to BLOCKED.
+  - **Comment prefix grammar (§9)** — agent comments include
+    `**[<ap>] [Q|A|C|S]**` round-trip parsable; reader resolves AP
+    attribution from the prefix when present.
+  - **Bundled skills** — `kanban-jira-agent` (agent-facing rules) and
+    `kanban-jira-setup` (owner-facing walkthrough). The existing
+    `kanban-workflow` skill scopes itself to `backend.driver = "local"`.
+  - **MCP conflict scan** — surfaces `atlassian|jira|rovo|mcp-atlassian`
+    MCP servers configured at user / project / `.mcp.json` scope. Warning
+    only — agent-side compliance is via the `kanban-jira-agent` skill.
+  - **Graceful degradation** — `--partial` opts into label substitutes
+    (`kanban:blocked` / `kanban:review` / `kanban:cancelled`) when the
+    Jira workflow lacks canonical statuses. Round-trip safe.
+  - **48 mocked regression tests** across five phase suites, runnable via
+    `plugins/kanban/scripts/test_all.sh`.
+  - Backwards-compatible: existing v0.1.x `kanban.json` files (no
+    `backend` block, `schema_version: 1`) continue to work as local mode
+    with no migration. The first write upgrades the file in place.
+
 ## 2026-04-28
 
 ### Added

--- a/kanban_quickstart.md
+++ b/kanban_quickstart.md
@@ -159,6 +159,43 @@ git log --oneline | head -3      # should see "kanban: task-XXX TODO→DOING"
 
 ---
 
+## 8a. Jira mode (kanban v0.2+)
+
+The default driver writes to `kanban.json`. For multi-machine teams or
+non-developer owners, switch to **Jira mode** instead. Same slash command
+surface, different storage layer.
+
+```
+> /kanban:initjira
+```
+
+Five interactive steps: credentials → board URL → workflow check → AP
+custom field → first AP registration. Tokens are stored in
+`~/.claude-workbench/.env` (the same file `notify` uses). The flow is
+idempotent and resumable — re-running picks up where the last one stopped.
+
+After init:
+
+```
+> /kanban:status     # live state from Jira
+> /kanban:next       # claim the top TODO for this AP
+> /kanban:done       # transition DOING → In Review (a human approves to Done)
+> /kanban:question AGENT-42 "should v1 stay backward-compatible?"
+> /kanban:whoami     # show driver, AP, token validity, MCP scan
+```
+
+Per-repo agent identity lives in `.claude/kanban-agent.json` (commit it —
+the team should see which agent owns the repo). Anti-self-approve refuses
+DONE transitions on a card whose AP equals this repo's AP.
+
+If the workflow lacks canonical statuses (`BLOCKED`, `REVIEW`, `CANCELLED`),
+re-run with `--partial` to accept label substitutes (`kanban:blocked`, etc.).
+
+See [`epic/kanban_plugin_ Jira_backend_driver_UPDATE.md`](./epic/) for the
+full v0.2 design.
+
+---
+
 ## 9. Uninstall
 
 Inside Claude:

--- a/kanban_quickstart_zhtw.md
+++ b/kanban_quickstart_zhtw.md
@@ -159,6 +159,34 @@ git log --oneline | head -3      # 應該看到 "kanban: task-XXX TODO→DOING"
 
 ---
 
+## 8a. Jira 模式（kanban v0.2+）
+
+預設 driver 寫進 `kanban.json`。如果是多機器團隊、或非工程的 owner 要用手機審核，切到 **Jira 模式**：slash command 介面不變，只換儲存層。
+
+```
+> /kanban:initjira
+```
+
+五步互動式：憑證 → board URL → workflow 檢查 → AP custom field → 第一個 AP 註冊。Token 存到 `~/.claude-workbench/.env`（和 notify 共用同一個檔）。整個 flow 冪等可續跑——上次中斷點接著走。
+
+init 完之後：
+
+```
+> /kanban:status     # 從 Jira 拉即時狀態
+> /kanban:next       # 認領這個 AP 最高優先 TODO
+> /kanban:done       # DOING → In Review（由人類批准成 Done）
+> /kanban:question AGENT-42 "v1 是否保留向下相容？"
+> /kanban:whoami     # 顯示 driver、AP、token 有效性、MCP 衝突
+```
+
+每個 repo 的 agent 身份存在 `.claude/kanban-agent.json`（建議 commit——讓團隊看到哪個 agent 管哪個 repo）。Anti-self-approve 會拒絕「自己 AP 的卡片」轉 DONE。
+
+如果 workflow 沒有完整 6 個 canonical status（缺 `BLOCKED` / `REVIEW` / `CANCELLED`），加 `--partial` 重跑——缺的欄位會用 label 替代（`kanban:blocked` 等）。
+
+完整 v0.2 設計見 [`epic/kanban_plugin_ Jira_backend_driver_UPDATE.md`](./epic/)。
+
+---
+
 ## 9. 解除安裝
 
 在 Claude 裡：

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kanban",
-  "version": "0.2.0-dev.3",
-  "description": "Kanban-driven workflow for Claude Code. Manages task lifecycle through kanban.json.",
+  "version": "0.2.0",
+  "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",
   "license": "MIT"

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.2.0-dev",
+  "version": "0.2.0-dev.1",
   "description": "Kanban-driven workflow for Claude Code. Manages task lifecycle through kanban.json.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "description": "Kanban-driven workflow for Claude Code. Manages task lifecycle through kanban.json.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.1.1",
+  "version": "0.2.0-dev",
   "description": "Kanban-driven workflow for Claude Code. Manages task lifecycle through kanban.json.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.2.0-dev.1",
+  "version": "0.2.0-dev.2",
   "description": "Kanban-driven workflow for Claude Code. Manages task lifecycle through kanban.json.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/assign-ap.md
+++ b/plugins/kanban/commands/assign-ap.md
@@ -1,0 +1,51 @@
+---
+description: Set the current repo's Agent Property (AP) — written to .claude/kanban-agent.json.
+argument-hint: <ap-name>
+allowed-tools: Read, Bash(python3:*), AskUserQuestion
+---
+
+# /kanban:assign-ap
+
+Arguments: `$ARGUMENTS`
+
+Persist this repo's AP identity to `.claude/kanban-agent.json`. Subsequent
+slash commands and hooks read from there to know which AP this repo's agent
+operates as. The AP must already be in `kanban.json#backend.jira.ap.registered`
+— if not, run `/kanban:register-ap <name>` first.
+
+## 0. Pre-flight
+
+- Confirm `kanban.json#backend.driver == "jira"`. If `local`, tell the user
+  AP is meaningful only in Jira mode.
+- Parse `$ARGUMENTS` for the AP name. If absent, ask via `AskUserQuestion`.
+
+## 1. Persist
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  assign-ap --kanban-path '<kanban.json path>' --name '<ap-name>'
+```
+
+On `{ok: true, ap, path}`: print:
+
+```
+✓ this repo is now operating as AP "<name>".
+  Written to: <path>
+```
+
+On `{ok: false, error: ..., registered: [...]}`: surface the error and the
+list of registered APs verbatim. Suggest `/kanban:register-ap <name>` if the
+user wants to add the AP.
+
+## 2. Git-policy reminder
+
+If the user has not already committed `.claude/kanban-agent.json`, tell them
+this file is intended to be committed (per SPEC §3.4 / §16.2 default — team
+sees per-repo agent identity). They can override by adding it to `.gitignore`
+manually if multiple humans run different agents in the same repo.
+
+## Absolute rules
+
+- Refuse if the AP is not registered — never silently create both registry
+  entry and assignment in one call. Registration must be deliberate.
+- Never edit `kanban.json` from this command — only `.claude/kanban-agent.json`.

--- a/plugins/kanban/commands/block.md
+++ b/plugins/kanban/commands/block.md
@@ -12,7 +12,7 @@ Move a task out of the active flow into `BLOCKED` with a mandatory reason. The S
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:block` requires AP routing, which lands in Phase 3."
 
 ## 1. Parse arguments
 

--- a/plugins/kanban/commands/block.md
+++ b/plugins/kanban/commands/block.md
@@ -10,6 +10,10 @@ Arguments: `$ARGUMENTS`
 
 Move a task out of the active flow into `BLOCKED` with a mandatory reason. The Skill `kanban-workflow` governs the rules.
 
+## 0. Driver check
+
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+
 ## 1. Parse arguments
 
 Required:

--- a/plugins/kanban/commands/block.md
+++ b/plugins/kanban/commands/block.md
@@ -12,9 +12,9 @@ Move a task out of the active flow into `BLOCKED` with a mandatory reason. The S
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:block` requires AP routing, which lands in Phase 3."
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
 
-## 1. Parse arguments
+## 1. Parse arguments (local driver)
 
 Required:
 - `<task-id>` — a bare `task-NNN` token.
@@ -46,9 +46,22 @@ Read `kanban.json` fresh. Confirm:
 
 If any other task's `depends` references the blocked task, list them (downstream impact).
 
+## Jira flow
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
+  --kanban-path '<kanban.json path>' --key '<KEY>' --to BLOCKED \
+  --reason '<reason text>'
+```
+
+The driver posts a `[<ap>] [S] Blocked: <reason>` system comment alongside
+the transition. In `partial` mode (workflow lacks a Blocked status), the
+plugin substitutes the `kanban:blocked` label and posts the same audit
+comment.
+
 ## Absolute rules
 
 - Never move a task to BLOCKED without a reason.
 - Never move from DONE to BLOCKED — DONE is terminal.
-- Never silently drop the old `started` timestamp.
+- Never silently drop the old `started` timestamp (local mode).
 - To return a task to active work, use an edit through `/kanban:*` commands that clear `custom.blocked_reason` and move back to TODO (today: manual fix via a future `/kanban:unblock` command; v0.2.0).

--- a/plugins/kanban/commands/done.md
+++ b/plugins/kanban/commands/done.md
@@ -12,9 +12,9 @@ Close out a task. The Skill `kanban-workflow` governs the rules.
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:done` requires AP routing and anti-self-approve enforcement, both of which land in Phase 3."
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
 
-## 1. Resolve target task
+## 1. Resolve target task (local driver)
 
 Parse `$ARGUMENTS`:
 - If an explicit `task-NNN` is present: target is that task.
@@ -44,8 +44,34 @@ Re-read `kanban.json` fresh. Confirm:
 
 Compute "unblocked" by finding any task in TODO whose `depends` included the closed task and are now fully satisfied. List their ids.
 
+## Jira flow
+
+In Jira mode, `/kanban:done` transitions DOING → REVIEW. The actual DONE
+transition is reserved for a human reviewer (or another agent) — anti-self-
+approve will refuse if the same AP tries to push to DONE.
+
+Identify the target key from `$ARGUMENTS`. If absent, find the single DOING
+card with this repo's AP set (use `/kanban:status` to enumerate; if there is
+not exactly one, ask the user to specify).
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
+  --kanban-path '<kanban.json path>' --key '<KEY>' --to REVIEW
+```
+
+On success print `✓ <KEY> → In Review (awaiting reviewer)`.
+
+If the user explicitly asks to mark DONE — for example a one-person team
+where the human owner uses Jira UI normally — they should approve via the
+Jira UI from a different account, not via this slash command. The plugin
+deliberately refuses self-approval; do not search for workarounds.
+
+If the helper exits with `kind: self-approve`, surface the error verbatim
+and explain that another reviewer is required.
+
 ## Absolute rules
 
-- Never close a task that isn't DOING.
+- Never close a task that isn't DOING (local mode).
 - Never retroactively edit `created` or `started`.
 - Never close multiple tasks in one invocation — one at a time keeps the commit log clean.
+- Jira mode: never push REVIEW → DONE for a card whose AP equals this repo's AP. The plugin refuses; do not retry with `--force` or hand-rolled API calls.

--- a/plugins/kanban/commands/done.md
+++ b/plugins/kanban/commands/done.md
@@ -10,6 +10,10 @@ Arguments: `$ARGUMENTS`
 
 Close out a task. The Skill `kanban-workflow` governs the rules.
 
+## 0. Driver check
+
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+
 ## 1. Resolve target task
 
 Parse `$ARGUMENTS`:

--- a/plugins/kanban/commands/done.md
+++ b/plugins/kanban/commands/done.md
@@ -12,7 +12,7 @@ Close out a task. The Skill `kanban-workflow` governs the rules.
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:done` requires AP routing and anti-self-approve enforcement, both of which land in Phase 3."
 
 ## 1. Resolve target task
 

--- a/plugins/kanban/commands/init.md
+++ b/plugins/kanban/commands/init.md
@@ -38,8 +38,11 @@ Copy `${CLAUDE_PLUGIN_ROOT}/templates/kanban.schema.json` to `<project-root>/kan
 - Read back `kanban.json` and confirm no `__CREATED_AT__` / `__UPDATED_AT__` placeholders remain.
 - Report what was created, e.g.:
 
-> ✓ Created kanban.json (empty / with 4 example tasks) and kanban.schema.json.
+> ✓ Created kanban.json v0.2 (local driver, empty / with 4 example tasks) and kanban.schema.json.
 > Next: try `/kanban:status` or `/kanban:next`.
+
+The template ships with `backend: { driver: "local" }`. To switch to the
+Jira backend later, run `/kanban:initjira` (added in plugin v0.2.0+).
 
 ## Absolute rules
 

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -1,5 +1,5 @@
 ---
-description: Switch the current project from local kanban.json to Jira-backed kanban (steps 1–3 of setup).
+description: Switch the current project from local kanban.json to Jira-backed kanban.
 argument-hint: [--partial]
 allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*), AskUserQuestion
 ---
@@ -8,11 +8,10 @@ allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*), AskUserQuestion
 
 Arguments: `$ARGUMENTS`
 
-This command switches a project to **Jira mode**. v0.2.0-dev / Phase 2 covers
-steps 1–3 (credentials, board, workflow check). Steps 4–5 (Agent Property
-custom field, AP registration) land in Phase 3 — until then, the project is
-usable for read-only Jira list/get and human-only assignments, but agent-AP
-routing is NOT yet active.
+This command switches a project to **Jira mode** end-to-end: credentials,
+board, workflow check, Agent Property (AP) custom field, and the first AP
+registration. After it completes, `/kanban:next`, `/kanban:done`, and
+`/kanban:block` operate against Jira with anti-self-approve enforcement.
 
 The helper `${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py` does the network +
 file work; this command orchestrates the prompts and surfaces results.
@@ -165,23 +164,98 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
   --jira-config-json '<json>'
 ```
 
+## Step 4/5 — Agent Property (AP) custom field
+
+Decide whether to use an existing custom field or create a new one. Ask the
+user via `AskUserQuestion`:
+
+> The AP field is what distinguishes which AI agent owns a card.
+>   [a] Use an existing custom field   (browse candidates)
+>   [b] Create a new field "Claude Agent" (recommended; requires Jira admin)
+> Choice:
+
+### Option [a] — use existing field
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py find-ap-field
+```
+
+Returns `{candidates: [{id, name}, ...]}`. If the list is empty, tell the
+user "no fields look like an AP candidate — switch to [b] or have a Jira
+admin create one and rerun". Otherwise, print the candidates and ask the
+user to pick one by `id`.
+
+Persist the choice:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py set-ap-field \
+  --kanban-path '<kanban.json path>' \
+  --field-id '<customfield_X>' --field-name '<name>'
+```
+
+### Option [b] — create new field
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py create-ap-field \
+  --name 'Claude Agent'
+```
+
+On `ok=true`, persist the new field:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py set-ap-field \
+  --kanban-path '<kanban.json path>' \
+  --field-id '<returned fieldId>' --field-name 'Claude Agent'
+```
+
+On `403` (admin permission missing), surface the helper's error verbatim
+and tell the user to either ask their Jira admin to create a single-select
+custom field once, then re-run `/kanban:initjira` and choose `[a]`. Stop —
+do NOT silently fall back to `[a]`; the choice is the user's.
+
+## Step 5/5 — First AP registration
+
+Ask for the AP name for *this* repo (regex `^[a-z][a-z0-9-]{2,40}$`).
+Examples: `agent-fin-exchange`, `agent-quant-bot`. The user can register
+more APs later via `/kanban:register-ap` and switch the active one via
+`/kanban:assign-ap`.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py register-ap \
+  --kanban-path '<kanban.json path>' --name '<ap-name>'
+```
+
+If `{ok: false, fuzzyMatch: true, similar: [...]}`, this is the first AP
+and the registry should be empty — surface the response anyway and ask the
+user to confirm proceeding with `--force`. (Realistically this only fires
+on idempotent re-run of init.)
+
+After successful registration, set this repo's AP:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py assign-ap \
+  --kanban-path '<kanban.json path>' --name '<ap-name>'
+```
+
 ## Done
 
 Print:
 
 ```
-✓ /kanban:initjira complete (Phase 2 partial: AP setup pending).
+✓ /kanban:initjira complete.
 
 Project:    <projectName> (<projectKey>)
 Board:      <boardName> (#<boardId>)
 Driver:     jira
 Workflow:   full | partial (label fallback: <list>)
+AP field:   <fieldName> (<fieldId>)
+This repo:  <ap-name>
+Roster:     <comma-list of registered APs>
 
-Next:
-  • /kanban:whoami         — check current state
-  • /kanban:reset-credentials — rotate the API token
-  • Steps 4–5 (AP custom field + first registration) land in v0.2 Phase 3.
-    Until then, agent-AP routing is not active.
+Try:
+  • /kanban:whoami       — confirm current state
+  • /kanban:status       — read live Jira state for this AP
+  • /kanban:next         — claim the next TODO for this AP
 ```
 
 ## Absolute rules

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -1,0 +1,195 @@
+---
+description: Switch the current project from local kanban.json to Jira-backed kanban (steps 1–3 of setup).
+argument-hint: [--partial]
+allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*), AskUserQuestion
+---
+
+# /kanban:initjira
+
+Arguments: `$ARGUMENTS`
+
+This command switches a project to **Jira mode**. v0.2.0-dev / Phase 2 covers
+steps 1–3 (credentials, board, workflow check). Steps 4–5 (Agent Property
+custom field, AP registration) land in Phase 3 — until then, the project is
+usable for read-only Jira list/get and human-only assignments, but agent-AP
+routing is NOT yet active.
+
+The helper `${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py` does the network +
+file work; this command orchestrates the prompts and surfaces results.
+
+**Token handling rule**: when calling helper subcommands that need the token,
+ALWAYS pipe the token via stdin (`echo "$TOKEN" | python3 .../jira_setup.py …`)
+— never pass it in `--token=` argv. Never echo the token back to the user.
+
+## 0. Pre-flight
+
+1. Confirm `kanban.json` exists at the project root (`$CLAUDE_PROJECT_DIR` or
+   `git rev-parse --show-toplevel`). If missing, stop and tell the user to run
+   `/kanban:init` first.
+2. Read `kanban.json#backend.driver`. If already `"jira"`, ask whether to
+   re-run init (overwriting the backend block) or abort.
+3. Parse `--partial` flag from `$ARGUMENTS`. Default off.
+
+## Step 1/3 — Credentials
+
+If credentials already exist (call `python3 jira_setup.py read-credentials` and
+check `tokenPresent`), validate them silently:
+
+```bash
+echo "$TOKEN_FROM_ENV" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  validate-credentials --base-url <baseUrl> --email <email>
+```
+
+But you don't have access to the stored token from this session — instead,
+*delegate the validation to a helper that reads from .env itself*. Use:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py health --kanban-path <kanban.json>
+```
+
+If health returns `ok=true`, print "Detected valid Jira credentials from a
+previous run. Skipping Step 1." and continue to Step 2.
+
+Otherwise, capture inputs via three separate `AskUserQuestion` calls:
+
+1. **Base URL** — example: `https://yourteam.atlassian.net`. Validate the
+   pattern `https?://[^/ ]+` before continuing.
+2. **Shared agent account email** — the Atlassian account agents will operate
+   under. Pattern: standard email.
+3. **API token** — generated at https://id.atlassian.com/manage-profile/security/api-tokens.
+   30+ alnum characters. Treat as secret — do not display or echo.
+
+Then validate (token via stdin):
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  validate-credentials --base-url '<URL>' --email '<EMAIL>'
+```
+
+Parse the JSON. On `ok=false`, print the error verbatim (it does NOT contain
+the token) and ask the user to re-enter the token. Repeat at most twice. On
+final failure, abort.
+
+On `ok=true`, store the credentials:
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  store-credentials --base-url '<URL>' --email '<EMAIL>'
+```
+
+Confirm to user: `✓ authenticated as <displayName>; credentials saved.`
+
+## Step 2/3 — Board URL
+
+Ask for the board URL (e.g. `https://yourteam.atlassian.net/jira/software/projects/AGENT/boards/1`).
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  parse-board-url --url '<URL>'
+```
+
+Result is `{"projectKey": "...", "boardId": ...}`. If parse fails, ask once
+more, then abort.
+
+Validate that the project + board are reachable with our credentials. The
+helper auto-loads token via `read-credentials`, but for explicit re-validation
+re-prompt is overkill — instead use a single combined check:
+
+```bash
+python3 - <<'PY'
+import json, subprocess, sys
+from pathlib import Path
+CHECKER = "${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py"
+BASE = "<URL>"; EMAIL = "<EMAIL>"; PROJECT = "<KEY>"; BOARD = <ID>
+# read token from .env via helper
+out = subprocess.check_output(["python3", CHECKER, "read-credentials"])
+token_present = json.loads(out)["tokenPresent"]
+if not token_present: print("missing token"); sys.exit(1)
+PY
+```
+
+In practice — for Phase 2 ergonomics — call validate-project by re-asking the
+user for the token. Acceptable simplification: the user just typed it; the
+session can hold it briefly in memory.
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  validate-project --base-url '<URL>' --email '<EMAIL>' \
+  --project '<KEY>' --board <ID>
+```
+
+Print `✓ project=<projectName> (<projectKey>); board=<boardName> (<boardType>)`.
+
+## Step 3/3 — Workflow check
+
+Pull the project's statuses and build the canonical → Jira-status map:
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  build-status-map --base-url '<URL>' --email '<EMAIL>' --project '<KEY>'
+```
+
+Result includes `map`, `missing`, `partial`, `labelFallback`.
+
+- If `missing` is empty: print `✓ workflow has all 6 canonical statuses`.
+- If non-empty AND `--partial` is NOT set: print the missing list and stop.
+  Tell the user to either (a) add the missing statuses in Jira project
+  settings and re-run `/kanban:initjira`, or (b) re-run with `--partial` to
+  accept label-fallback substitutions for the missing columns.
+- If non-empty AND `--partial` IS set: warn loudly, list which columns will
+  be substituted via labels (`kanban:blocked`, `kanban:review`,
+  `kanban:cancelled`), proceed.
+
+## Step 4 — Persist `backend.jira`
+
+Compose the JSON payload and write it:
+
+```json
+{
+  "boardUrl": "<URL>",
+  "boardId": <ID>,
+  "projectKey": "<KEY>",
+  "agentAccountId": "<accountId from validate-credentials>",
+  "statusMap": { ... from build-status-map },
+  "partial": <true|false>,
+  "labelFallback": { ... when partial }
+}
+```
+
+Use Bash to call `write-backend` (single-quote the JSON; do NOT pass via Edit/Write
+since `kanban-guard.sh` blocks those):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  write-backend --kanban-path '<KANBAN_PATH>' \
+  --jira-config-json '<json>'
+```
+
+## Done
+
+Print:
+
+```
+✓ /kanban:initjira complete (Phase 2 partial: AP setup pending).
+
+Project:    <projectName> (<projectKey>)
+Board:      <boardName> (#<boardId>)
+Driver:     jira
+Workflow:   full | partial (label fallback: <list>)
+
+Next:
+  • /kanban:whoami         — check current state
+  • /kanban:reset-credentials — rotate the API token
+  • Steps 4–5 (AP custom field + first registration) land in v0.2 Phase 3.
+    Until then, agent-AP routing is not active.
+```
+
+## Absolute rules
+
+- Never echo the API token back to the user.
+- Never pass the token via argv (`--token=…`) — always pipe via stdin.
+- Never write `kanban.json` via Edit/Write tools — always go through
+  `jira_setup.py write-backend`.
+- If any helper call returns `ok=false`, surface its `error` field verbatim
+  and stop; do not invent retry logic beyond what is specified above.
+- Never proceed past a failed `validate-credentials` even with `--partial`.

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -237,6 +237,54 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py assign-ap \
   --kanban-path '<kanban.json path>' --name '<ap-name>'
 ```
 
+## Step 6/6 — Migration of existing local tasks (optional)
+
+Before printing the Done block, check whether `kanban.json#tasks` has any
+entries from a prior local-mode life. If `len(tasks) > 0`, ask:
+
+> Found N existing local tasks. Import them as Jira issues? (y/N)
+>   • Imported tasks get the `migrated-from-local` label.
+>   • DONE / CANCELLED tasks are skipped by default (use --include-done to override).
+>   • The original `tasks[]` stays in kanban.json for rollback.
+
+On `y`:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py import-tasks \
+  --kanban-path '<kanban.json path>'
+```
+
+Surface the response: `imported`, `skipped`, mapping path. If any task
+errored individually (`skippedDetail[i].reason` starts with `error:`),
+print those lines so the user can investigate.
+
+On `n` or absent: skip silently. The user can run `import-tasks` later via
+the helper if they change their mind.
+
+## Final check — Jira MCP conflict scan
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py mcp-conflict-scan \
+  --kanban-path '<kanban.json path>'
+```
+
+If `conflicts` is non-empty, print a warning per SPEC §18.2:
+
+```
+⚠ Detected conflicting Jira MCP server(s):
+  • <server> (in <source>) — matched on <matchedOn>
+
+This plugin enforces AP routing, anti-self-approve, and comment attribution.
+A separate Jira MCP can bypass these silently. Recommended:
+  - scope the conflicting MCP to user-level only (not project-level), OR
+  - disable it for repos that use kanban Jira mode.
+
+The kanban-jira-agent skill instructs agents not to call other Jira MCPs,
+but defense in depth is preferred.
+```
+
+This is informational. Do not block the init flow.
+
 ## Done
 
 Print:
@@ -251,6 +299,8 @@ Workflow:   full | partial (label fallback: <list>)
 AP field:   <fieldName> (<fieldId>)
 This repo:  <ap-name>
 Roster:     <comma-list of registered APs>
+Migration:  N imported, M skipped     (omit if not run)
+MCP scan:   ✓ no conflicts | ⚠ <count> conflict(s)
 
 Try:
   • /kanban:whoami       — confirm current state

--- a/plugins/kanban/commands/next.md
+++ b/plugins/kanban/commands/next.md
@@ -10,6 +10,10 @@ Arguments: `$ARGUMENTS`
 
 Pick the next eligible TODO task, move it to DOING, then begin executing it. The Skill `kanban-workflow` (loaded automatically) governs the rules.
 
+## 0. Driver check
+
+Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+
 ## 1. Load state
 
 Read `kanban.json` fresh. Do not rely on earlier reads from this session.

--- a/plugins/kanban/commands/next.md
+++ b/plugins/kanban/commands/next.md
@@ -12,9 +12,9 @@ Pick the next eligible TODO task, move it to DOING, then begin executing it. The
 
 ## 0. Driver check
 
-Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:next` requires AP routing and anti-self-approve enforcement, both of which land in Phase 3. For now use `/kanban:status` to see live Jira state."
+Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
 
-## 1. Load state
+## 1. Load state (local driver)
 
 Read `kanban.json` fresh. Do not rely on earlier reads from this session.
 
@@ -64,8 +64,32 @@ Briefly report:
 
 Then begin executing the task described in `description`. Treat `description` as the brief — ask the user for clarification if anything is ambiguous rather than guessing.
 
+## Jira flow
+
+Pick the highest-priority TODO card scoped to this repo's AP, transition it
+to `In Progress`, and post a `[<ap>] [S] claimed` system comment. The driver
+honours the `statusMap` configured at init time.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py claim-next \
+  --kanban-path '<kanban.json path>'
+```
+
+Parse the response:
+
+| Shape | Action |
+|---|---|
+| `{ok: true, claimed: {id, title, priority, ap}}` | print `Claiming <id> "<title>" (P<n>, ap=<ap>)`, then begin executing the card |
+| `{ok: true, claimed: null, reason}` | print `No TODO cards for AP <ap>` and stop |
+| `{ok: false, error}` | surface verbatim and stop. If error mentions `kanban-agent.json`, suggest `/kanban:assign-ap`. |
+
+Then read the card details if you need them (`get_task` via the helper or by
+asking Jira directly through `/kanban:status`) — the description there is
+your brief.
+
 ## Absolute rules
 
-- Never start a task whose deps are not all DONE.
+- Never start a task whose deps are not all DONE (local mode).
 - Never start a task in DONE or BLOCKED.
 - Never start more than one task at a time in the same session. If a DOING task already exists with assignee `claude-code`, confirm with the user before starting a new one.
+- Jira mode: never bypass `claim-next` — it enforces AP routing.

--- a/plugins/kanban/commands/next.md
+++ b/plugins/kanban/commands/next.md
@@ -12,7 +12,7 @@ Pick the next eligible TODO task, move it to DOING, then begin executing it. The
 
 ## 0. Driver check
 
-Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If the value is anything other than `"local"`, stop and tell the user that the Jira-driver branch of this command is not yet implemented in this build.
+Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If the value is `"jira"`, stop and tell the user: "Jira-mode `/kanban:next` requires AP routing and anti-self-approve enforcement, both of which land in Phase 3. For now use `/kanban:status` to see live Jira state."
 
 ## 1. Load state
 

--- a/plugins/kanban/commands/question.md
+++ b/plugins/kanban/commands/question.md
@@ -1,0 +1,67 @@
+---
+description: Post a question to a Jira card and transition it to BLOCKED.
+argument-hint: <KEY> "<question text>"
+allowed-tools: Read, Bash(python3:*)
+---
+
+# /kanban:question
+
+Arguments: `$ARGUMENTS`
+
+Post a Q-kind comment (per SPEC §9 prefix grammar) to a Jira card and move
+the card to `BLOCKED`. The agent stops working on the card until a human
+answers; once answered, the card returns to TODO via human action in Jira UI.
+
+Local mode does not have an equivalent — for local mode use `/kanban:block`
+with a `--reason=<question>` instead.
+
+## 0. Pre-flight
+
+- Confirm `kanban.json#backend.driver == "jira"`. If not, tell the user this
+  command is jira-only and suggest `/kanban:block` for local mode.
+- Parse `$ARGUMENTS`:
+  - First token must be a Jira KEY matching `^[A-Z][A-Z0-9_]+-\\d+$`. Reject
+    if missing.
+  - The remainder (quoted or not) is the question text. Strip surrounding
+    quotes. Reject if empty.
+
+## 1. Post the question
+
+The driver writes a Q-kind comment with the SPEC §9 AP prefix
+(`**[<ap>] [Q]**\\n\\n<text>`):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
+  --kanban-path '<kanban.json path>' \
+  --key '<KEY>' --to BLOCKED --reason '<question text>'
+```
+
+The driver's `transition(BLOCKED, reason=...)` posts a system comment with
+the reason. We piggy-back on that for the question — it gets the same
+audit trail with the AP attribution. (Future v0.3 may upgrade to a
+distinct `--kind=Q` flag if the system-vs-question distinction matters in
+practice.)
+
+Parse the JSON response:
+
+| Shape | Action |
+|---|---|
+| `{ok: true, key, column, raw_status}` | print `✓ <KEY> → Blocked. Question posted.` |
+| `{ok: false, error}` | surface verbatim and stop |
+
+## 2. Inform the user
+
+```
+✓ <KEY> "<title if known>" → Blocked.
+  Question: "<question text>"
+
+The card is paused until a human (or another agent) replies. You can keep
+working on other tasks via /kanban:next.
+```
+
+## Absolute rules
+
+- Do not bypass the helper to call Jira directly — the AP prefix and BLOCKED
+  transition must be coupled.
+- Do not silently invent the question text — it must come from the user.
+- Do not mark the question as resolved yourself — the answer is human-side.

--- a/plugins/kanban/commands/register-ap.md
+++ b/plugins/kanban/commands/register-ap.md
@@ -1,0 +1,67 @@
+---
+description: Register a new Agent Property (AP) value to the Jira AP custom field.
+argument-hint: <ap-name>
+allowed-tools: Read, Bash(python3:*), AskUserQuestion
+---
+
+# /kanban:register-ap
+
+Arguments: `$ARGUMENTS`
+
+Add a new AP option to `backend.jira.ap.fieldId`. The AP is the single-select
+custom-field value that distinguishes which AI agent owns a card. The
+operation:
+
+1. Validates the AP name (`^[a-z][a-z0-9-]{2,40}$`).
+2. Refuses exact duplicates (case-insensitive). Already-registered names exit ok.
+3. Warns on fuzzy collisions (Levenshtein ≤ 2). The user decides whether to
+   proceed via `--force`.
+4. Adds the option to Jira's custom-field context.
+5. Caches the name in `kanban.json#backend.jira.ap.registered`.
+
+## 0. Pre-flight
+
+- Confirm `kanban.json#backend.driver == "jira"` and `backend.jira.ap.fieldId`
+  is set. If not, instruct the user to run `/kanban:initjira` first.
+- Parse `$ARGUMENTS`: first token is the AP name. If absent, ask once via
+  `AskUserQuestion`.
+
+## 1. Try registration
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  register-ap --kanban-path '<kanban.json path>' --name '<ap-name>'
+```
+
+Parse the JSON response:
+
+| Response shape | Meaning | Action |
+|---|---|---|
+| `{ok: true, alreadyRegistered: true, ...}` | already in the registry | print `✓ already registered` and stop |
+| `{ok: true, name, registered}` | added | print `✓ registered <name>; current AP roster: <list>` |
+| `{ok: false, fuzzyMatch: true, similar: [...]}` | near-duplicate | proceed to step 2 |
+| `{ok: false, error: ...}` | hard error | surface the error verbatim and stop |
+
+## 2. Fuzzy-collision confirmation
+
+If step 1 returned `fuzzyMatch`, list the similar names and their Levenshtein
+distance, then ask once via `AskUserQuestion`:
+
+> The following existing APs are similar to `<name>`:
+>   • <existing> (distance N)
+> Continue with registration? (y/N)
+
+On `y`:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  register-ap --kanban-path '<kanban.json path>' --name '<ap-name>' --force
+```
+
+On `n` or any other answer: stop. Do not retry.
+
+## Absolute rules
+
+- Never bypass the fuzzy-collision warning silently — the user must choose `--force`.
+- Never edit `kanban.json` directly via Edit/Write — always go through the helper.
+- Never invent an AP name — it must come from the user.

--- a/plugins/kanban/commands/reset-credentials.md
+++ b/plugins/kanban/commands/reset-credentials.md
@@ -1,0 +1,69 @@
+---
+description: Rotate Jira API credentials for the current machine.
+allowed-tools: Bash(python3:*), AskUserQuestion
+---
+
+# /kanban:reset-credentials
+
+Re-prompt and overwrite the Jira credentials in `~/.claude-workbench/.env`.
+Use when the API token has been rotated, expired, or exposed.
+
+This command does NOT touch `kanban.json`, AP registry, or any other
+plugin's configuration. Only the `JIRA_*` lines in `.env` are replaced.
+
+## 0. Show current state
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
+```
+
+Print:
+```
+Current Base URL: <baseUrl> (or "(not set)")
+Current Email:    <email>   (or "(not set)")
+Current Token:    <"present" if tokenPresent else "missing">
+```
+
+## 1. Capture new values
+
+Three `AskUserQuestion` calls. For Base URL / Email, default to current value
+on empty input — tell the user "press Enter to keep current".
+
+1. **Base URL** — same validation as `/kanban:initjira`.
+2. **Email** — Atlassian account email.
+3. **API token** — secret. Do not echo.
+
+## 2. Validate
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  validate-credentials --base-url '<URL>' --email '<EMAIL>'
+```
+
+If `ok=false`, surface the error and ask once more for the token. On second
+failure, abort without writing.
+
+## 3. Store
+
+```bash
+echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+  store-credentials --base-url '<URL>' --email '<EMAIL>'
+```
+
+This atomically rewrites only the `JIRA_*` lines, leaving any `PUSHOVER_*`
+or other plugin lines untouched.
+
+## 4. Confirm
+
+```
+✓ credentials updated; authenticated as <displayName>.
+```
+
+Do NOT print the token, the email/URL is fine.
+
+## Absolute rules
+
+- Never echo the API token.
+- Never pass the token via argv — always stdin pipe.
+- Never modify `kanban.json` here — that is the job of `/kanban:initjira`.
+- If validation fails twice, abort. Do not store an unvalidated token.

--- a/plugins/kanban/commands/status.md
+++ b/plugins/kanban/commands/status.md
@@ -7,6 +7,10 @@ allowed-tools: Read
 
 Print a concise snapshot of `kanban.json`. Read-only — do not write anything.
 
+## 0. Driver check
+
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"` (v0.1 backwards-compat). If the value is anything other than `"local"`, stop and tell the user this slash command does not yet support that driver in this build — Jira-mode commands land in a later phase.
+
 ## 1. Load
 
 Read `kanban.json` at the project root. If missing, tell the user to run `/kanban:init`.
@@ -24,7 +28,7 @@ Read `kanban.json` at the project root. If missing, tell the user to run `/kanba
 Format (keep it tight — monospace-friendly):
 
 ```
-Kanban status (kanban.json · schema v1)
+Kanban status (kanban.json · v0.2 · local)
 
 Columns: TODO 7 · DOING 1 · DONE 12 · BLOCKED 2
 

--- a/plugins/kanban/commands/status.md
+++ b/plugins/kanban/commands/status.md
@@ -9,9 +9,11 @@ Print a concise snapshot of `kanban.json`. Read-only — do not write anything.
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"` (v0.1 backwards-compat). If the value is anything other than `"local"`, stop and tell the user this slash command does not yet support that driver in this build — Jira-mode commands land in a later phase.
+Read `kanban.json`. Look at `backend.driver`.
+- Absent or `"local"`: continue with the local flow below (steps 1–3).
+- `"jira"`: skip steps 1–3 and use the Jira flow (step 4).
 
-## 1. Load
+## 1. Load (local driver)
 
 Read `kanban.json` at the project root. If missing, tell the user to run `/kanban:init`.
 
@@ -49,6 +51,42 @@ BLOCKED:
 ```
 
 If counts are zero or a section is empty, omit it rather than printing `(empty)`.
+
+## 4. Jira flow (when backend.driver == "jira")
+
+Use the helper to read live state without going through Edit/Write:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py health \
+  --kanban-path '<kanban.json path>'
+```
+
+If health is not `ok` (especially `unauthenticated`), surface the detail and
+suggest `/kanban:reset-credentials`. Stop.
+
+Otherwise pull two lists for the snapshot:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py list-tasks \
+  --kanban-path '<kanban.json path>' --column DOING --limit 20
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py list-tasks \
+  --kanban-path '<kanban.json path>' --column BLOCKED --limit 20
+```
+
+Render in the same compact format as the local flow:
+
+```
+Kanban status (Jira · project=<KEY> · board #<id>)
+
+DOING:
+  <KEY>-12  [P1]  <summary>  (assignee=<displayName>, ap=<ap or "—">)
+
+BLOCKED:
+  <KEY>-9   [P2]  <summary>  (raw status: <jira status>)
+```
+
+If `partial` mode is in effect (read from `backend.jira.partial`), append a
+one-line note: `Workflow: partial — REVIEW/BLOCKED/CANCELLED collapse via labels`.
 
 ## Absolute rules
 

--- a/plugins/kanban/commands/sync.md
+++ b/plugins/kanban/commands/sync.md
@@ -1,0 +1,61 @@
+---
+description: Pull the open-card summary for the current AP. Driver-aware.
+allowed-tools: Read, Bash(python3:*), Bash(git:*)
+---
+
+# /kanban:sync
+
+Refresh the agent's view of the kanban state.
+
+- **Local mode**: re-read `kanban.json` and surface DOING + BLOCKED tasks
+  (same content the SessionStart hook would print).
+- **Jira mode**: pull open cards (TODO / DOING / BLOCKED / REVIEW) for the
+  current repo's AP and render the summary block.
+
+This command is also invoked automatically on `SessionStart` (jira mode)
+via `kanban-jira-sync.sh`. Run it explicitly when you suspect the cached
+state is stale or you just resumed the session after a break.
+
+## 0. Resolve repo
+
+`$CLAUDE_PROJECT_DIR` if set, else `git rev-parse --show-toplevel`, else cwd.
+Kanban file at `<repo>/kanban.json` — if missing, suggest `/kanban:init`.
+
+## 1. Driver branch
+
+Read `kanban.json#backend.driver` (default `local`).
+
+### Local
+
+Read `kanban.json`. Render:
+
+```
+Kanban sync (local · v0.2)
+
+DOING:
+  task-042  [P1 trading]  重寫 grid pricing dynamic classifier  (since 2026-04-20)
+
+BLOCKED:
+  task-004  [P1 bug]      Investigate flaky test on macOS — Need access to macOS runner logs.
+
+(No DOING/BLOCKED → "All clear.")
+```
+
+### Jira
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py sync-summary \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{summary, counts, ap, projectKey}`. Print the `summary` field
+verbatim. If `summary` is empty, print `(no open cards for ap=<ap>)`.
+
+If the helper exits non-zero, surface its `error` field. Common causes:
+- `Jira credentials missing` → suggest `/kanban:reset-credentials`
+- `kanban-agent.json` missing → suggest `/kanban:assign-ap <name>`
+
+## Absolute rules
+
+- Read-only. Never write to `kanban.json`, the cache, or Jira.
+- Never invent data — if the helper says no cards, say no cards.

--- a/plugins/kanban/commands/whoami.md
+++ b/plugins/kanban/commands/whoami.md
@@ -1,0 +1,78 @@
+---
+description: Show current kanban driver state — project, board, AP, token validity.
+allowed-tools: Read, Bash(python3:*), Bash(git:*)
+---
+
+# /kanban:whoami
+
+Read-only summary of the kanban configuration in this repo. Never displays
+the API token value — only `present` / `missing` / `valid` / `invalid`.
+
+## 1. Resolve repo
+
+`$CLAUDE_PROJECT_DIR` if set, else `git rev-parse --show-toplevel`, else
+current working directory.
+
+## 2. Inspect kanban.json
+
+Read `kanban.json`. If missing: print `Repo: <path>\nDriver: (no kanban.json — run /kanban:init)` and stop.
+
+Pull `version` (default `0.1`), `backend.driver` (default `local`).
+
+## 3. Branch on driver
+
+### Local driver
+
+```
+Repo:     <path>
+Driver:   local
+Schema:   <version>
+Tasks:    <count of tasks[]>  (DOING <n> · BLOCKED <n>)
+```
+
+Stop here.
+
+### Jira driver
+
+Pull `backend.jira.{boardUrl, boardId, projectKey}`. Then:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
+```
+
+For token validity, run health (will hit /myself):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py health \
+  --kanban-path '<kanban.json path>'
+```
+
+Token row maps from health.status:
+- `ok` → `✓ valid`
+- `unauthenticated` → `✗ invalid (re-run /kanban:reset-credentials)`
+- `unreachable` → `? unknown (network)`
+- `degraded` → `? degraded — <detail>`
+
+If `.claude/kanban-agent.json` exists, read its `ap` value. Also pull
+`backend.jira.ap.registered` if present (Phase 3+ writes it).
+
+Render:
+
+```
+Repo:             <path>
+Driver:           jira
+Base URL:         <baseUrl>
+Email:            <email>
+Project:          <projectKey>
+Board:            #<boardId>
+AP (this repo):   <ap or "(unset — run /kanban:assign-ap when Phase 3 lands)">
+AP (registered):  <comma-list or "(none — Phase 3 will populate this)">
+Token:            <validity row>
+Workflow:         full | partial (fallback: BLOCKED, REVIEW, CANCELLED)
+```
+
+## Absolute rules
+
+- Never display the token value, only its validity.
+- Never write to `kanban.json` or `.env` from this command.
+- If health returns a network error, print the row and continue — do not abort.

--- a/plugins/kanban/commands/whoami.md
+++ b/plugins/kanban/commands/whoami.md
@@ -53,8 +53,14 @@ Token row maps from health.status:
 - `unreachable` → `? unknown (network)`
 - `degraded` → `? degraded — <detail>`
 
-If `.claude/kanban-agent.json` exists, read its `ap` value. Also pull
-`backend.jira.ap.registered` if present (Phase 3+ writes it).
+Read this repo's AP via the helper (it parses `.claude/kanban-agent.json`):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-agent-ap \
+  --kanban-path '<kanban.json path>'
+```
+
+Also pull `backend.jira.ap.registered` from `kanban.json` for the AP roster.
 
 Render:
 
@@ -65,8 +71,9 @@ Base URL:         <baseUrl>
 Email:            <email>
 Project:          <projectKey>
 Board:            #<boardId>
-AP (this repo):   <ap or "(unset — run /kanban:assign-ap when Phase 3 lands)">
-AP (registered):  <comma-list or "(none — Phase 3 will populate this)">
+AP field:         <fieldName> (<fieldId> — or "(unconfigured — run /kanban:initjira)")
+AP (this repo):   <ap or "(unset — run /kanban:assign-ap <name>)">
+AP (registered):  <comma-list or "(empty — run /kanban:register-ap <name>)">
 Token:            <validity row>
 Workflow:         full | partial (fallback: BLOCKED, REVIEW, CANCELLED)
 ```

--- a/plugins/kanban/commands/whoami.md
+++ b/plugins/kanban/commands/whoami.md
@@ -62,6 +62,16 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-agent-ap \
 
 Also pull `backend.jira.ap.registered` from `kanban.json` for the AP roster.
 
+Run the MCP conflict scan:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py mcp-conflict-scan \
+  --kanban-path '<kanban.json path>'
+```
+
+The `Jira MCP` row reports `✓ none` (empty conflicts) or
+`⚠ N detected: <comma-list>` (so the user knows what to scope away).
+
 Render:
 
 ```
@@ -76,6 +86,7 @@ AP (this repo):   <ap or "(unset — run /kanban:assign-ap <name>)">
 AP (registered):  <comma-list or "(empty — run /kanban:register-ap <name>)">
 Token:            <validity row>
 Workflow:         full | partial (fallback: BLOCKED, REVIEW, CANCELLED)
+Jira MCP:         <conflict row>
 ```
 
 ## Absolute rules

--- a/plugins/kanban/drivers/__init__.py
+++ b/plugins/kanban/drivers/__init__.py
@@ -16,8 +16,7 @@ def get_driver(data: dict[str, Any], project_root: str | Path) -> Driver:
         from .local import LocalDriver
         return LocalDriver(Path(project_root))
     if name == "jira":
-        # Phase 2 lands this. Importing lazily so Phase 1 has no jira deps.
-        from .jira import JiraDriver  # type: ignore[import-not-found]
+        from .jira import JiraDriver
         return JiraDriver(data, Path(project_root))
     raise ValueError(f"unknown driver: {name!r}")
 

--- a/plugins/kanban/drivers/__init__.py
+++ b/plugins/kanban/drivers/__init__.py
@@ -1,0 +1,25 @@
+"""Driver registry. `get_driver(data, project_root)` returns the right impl
+based on `data['backend']['driver']`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .base import Driver
+
+
+def get_driver(data: dict[str, Any], project_root: str | Path) -> Driver:
+    backend = data.get("backend") or {"driver": "local"}
+    name = backend.get("driver", "local")
+    if name == "local":
+        from .local import LocalDriver
+        return LocalDriver(Path(project_root))
+    if name == "jira":
+        # Phase 2 lands this. Importing lazily so Phase 1 has no jira deps.
+        from .jira import JiraDriver  # type: ignore[import-not-found]
+        return JiraDriver(data, Path(project_root))
+    raise ValueError(f"unknown driver: {name!r}")
+
+
+__all__ = ["get_driver", "Driver"]

--- a/plugins/kanban/drivers/base.py
+++ b/plugins/kanban/drivers/base.py
@@ -1,0 +1,130 @@
+"""Driver Protocol — defines the contract every storage backend must satisfy.
+
+Phase 1 lands the Protocol and dataclasses; only `local` is implemented.
+Phase 2 adds `jira`. Optional capabilities (list_aps, register_ap) raise
+NotSupported on drivers that don't implement them.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal, Protocol, Union
+
+
+class CommentKind(str, Enum):
+    """Maps to the SPEC §9 comment-prefix grammar (Q/A/C/S)."""
+    QUESTION = "Q"
+    ANSWER = "A"
+    COMMENT = "C"
+    SYSTEM = "S"
+
+
+class HealthStatus(str, Enum):
+    OK = "ok"
+    DEGRADED = "degraded"
+    UNREACHABLE = "unreachable"
+    UNAUTHENTICATED = "unauthenticated"
+
+
+@dataclass
+class HealthResult:
+    status: HealthStatus
+    detail: str = ""
+
+
+@dataclass
+class HumanRef:
+    accountId: str
+    kind: Literal["human"] = "human"
+
+
+@dataclass
+class AgentRef:
+    ap: str
+    kind: Literal["agent"] = "agent"
+
+
+MemberRef = Union[HumanRef, AgentRef]
+
+
+@dataclass
+class Member:
+    """Returned from list_members. Drivers may leave fields empty if unknown."""
+    ref: MemberRef
+    displayName: str = ""
+    email: str = ""
+
+
+@dataclass
+class TaskFilter:
+    """Common query knobs. Drivers translate to JQL / dict filtering."""
+    column: str | None = None          # e.g. "TODO" or Jira-mapped status
+    ap: str | None = None              # restrict to one agent property
+    assignee: str | None = None        # human accountId or local string
+    priority: str | None = None        # at-or-above (driver-specific ordering)
+    category: str | None = None
+    limit: int | None = None
+
+
+@dataclass
+class TaskInput:
+    """For create_task. Required fields per driver may differ."""
+    title: str
+    description: str = ""
+    priority: str | None = None
+    category: str | None = None
+    tags: list[str] = field(default_factory=list)
+    depends: list[str] = field(default_factory=list)
+    assignee: MemberRef | None = None
+    custom: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Comment:
+    author: str          # for jira: human displayName or AP if agent
+    ts: str              # ISO 8601
+    text: str
+    kind: CommentKind = CommentKind.COMMENT
+
+
+@dataclass
+class Task:
+    """Driver-neutral task record. id is `task-NNN` (local) or `KEY-N` (jira)."""
+    id: str
+    title: str
+    column: str
+    priority: str
+    created: str
+    updated: str
+    description: str = ""
+    category: str | None = None
+    tags: list[str] = field(default_factory=list)
+    depends: list[str] = field(default_factory=list)
+    started: str | None = None
+    completed: str | None = None
+    assignee: MemberRef | None = None
+    ap: str | None = None              # jira: AP custom-field value
+    comments: list[Comment] = field(default_factory=list)
+    custom: dict[str, Any] = field(default_factory=dict)
+
+
+class NotSupported(Exception):
+    """Raised when a driver does not implement an optional capability."""
+
+
+class Driver(Protocol):
+    name: str
+
+    def health(self) -> HealthResult: ...
+    def list_tasks(self, filter: TaskFilter | None = None) -> list[Task]: ...
+    def get_task(self, key: str) -> Task: ...
+    def create_task(self, task: TaskInput) -> Task: ...
+    def transition(self, key: str, to_column: str, **kwargs: Any) -> Task: ...
+    def post_comment(self, key: str, body: str, kind: CommentKind = CommentKind.COMMENT) -> Comment: ...
+    def list_comments(self, key: str) -> list[Comment]: ...
+    def assign(self, key: str, member: MemberRef) -> Task: ...
+    def list_members(self) -> list[Member]: ...
+
+    # Optional — jira-only in v0.2.
+    def list_aps(self) -> list[str]: ...
+    def register_ap(self, name: str) -> None: ...

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -36,6 +36,14 @@ from .base import (
 
 CANONICAL_COLUMNS = ("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED")
 
+
+class SelfApproveRefused(RuntimeError):
+    """Raised when an agent tries to transition its own card to DONE.
+
+    SPEC §8 invariant — the plugin enforces this client-side as well as
+    delegating to Jira workflow conditions when admin can configure them.
+    """
+
 # SPEC §9 prefix grammar.
 _PREFIX_RE = re.compile(
     r"^\*\*\[(?P<ap>[a-z][a-z0-9-]+)\]\s+\[(?P<kind>Q|A|C|S)\]\*\*\s*\n*(?P<rest>.*)$",
@@ -244,6 +252,18 @@ class JiraDriver:
                 f"unknown canonical column {to_column!r}; expected one of "
                 f"{CANONICAL_COLUMNS}"
             )
+        # Anti-self-approve (SPEC §8). Refuse client-side when the current
+        # repo's AP would approve a card it owns.
+        if to_column == "DONE":
+            current_ap = self._current_repo_ap()
+            if current_ap:
+                existing = self.get_task(key)
+                if existing.ap and existing.ap == current_ap:
+                    raise SelfApproveRefused(
+                        f"anti-self-approve: agent {current_ap!r} cannot "
+                        f"transition its own card {key} to DONE — ask another "
+                        "agent or a human reviewer to approve"
+                    )
         client = self._client_or_raise()
         target_status = self._canonical_to_status(to_column)
 
@@ -311,28 +331,55 @@ class JiraDriver:
         return [self._parse_comment(c) for c in (raw.get("comments") or [])]
 
     def assign(self, key: str, member: MemberRef) -> Task:
-        if member.kind != "human":
-            raise NotSupported(
-                "Jira agent assignment by AP is a Phase 3 feature — "
-                "use a human accountId here"
-            )
         client = self._client_or_raise()
-        client._request(
-            "PUT",
-            f"/rest/api/3/issue/{key}/assignee",
-            body={"accountId": member.accountId},  # type: ignore[union-attr]
-        )
+        if member.kind == "human":
+            client._request(
+                "PUT",
+                f"/rest/api/3/issue/{key}/assignee",
+                body={"accountId": member.accountId},  # type: ignore[union-attr]
+            )
+        else:  # AgentRef — write the AP custom field, leave assignee alone.
+            if not self.ap_field_id:
+                raise NotSupported(
+                    "AP field is not configured — run /kanban:initjira step 4"
+                )
+            ap_value = member.ap  # type: ignore[union-attr]
+            client.update_issue(
+                key,
+                {self.ap_field_id: {"value": ap_value}},
+            )
+            # Also set assignee to the shared agent account so notifications
+            # land somewhere visible. No-op if agentAccountId is unset.
+            if self.agent_account_id:
+                client._request(
+                    "PUT",
+                    f"/rest/api/3/issue/{key}/assignee",
+                    body={"accountId": self.agent_account_id},
+                )
         return self.get_task(key)
 
     def list_members(self) -> list[Member]:
-        # Phase 3 surfaces /user/assignable + AP registry. Phase 2 returns [].
-        return []
+        # Returns the registered AP roster as agent members. Human members
+        # come from Jira directly via UI; we don't shadow that here.
+        out: list[Member] = []
+        for ap in self.list_aps():
+            out.append(Member(ref=AgentRef(ap=ap), displayName=ap))
+        return out
 
     def list_aps(self) -> list[str]:
-        raise NotSupported("AP operations land in Phase 3")
+        return list((self.cfg.get("ap") or {}).get("registered") or [])
 
     def register_ap(self, name: str) -> None:
-        raise NotSupported("AP operations land in Phase 3")
+        """Append `name` to backend.jira.ap.registered. Caller is expected to
+        have already added the option in Jira and validated uniqueness — this
+        only persists the cached registry. The full flow lives in
+        scripts/jira_setup.py to keep network ops out of the driver fast path.
+        """
+        ap_block = self.cfg.setdefault("ap", {})
+        registered = list(ap_block.get("registered") or [])
+        if name not in registered:
+            registered.append(name)
+        ap_block["registered"] = registered
 
     # --- repo identity ------------------------------------------------
 

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ..lib import credentials
+from ..lib import card_cache, credentials
 from ..lib.jira_client import JiraClient, JiraError, adf_to_text, text_to_adf
 from .base import (
     AgentRef,
@@ -303,6 +303,8 @@ class JiraDriver:
             reason = kwargs.get("reason")
             if reason:
                 self.post_comment(key, f"Blocked: {reason}", CommentKind.SYSTEM)
+        # Any successful transition invalidates the cache for that key.
+        card_cache.invalidate(self.project_root, key)
         return self.get_task(key)
 
     def post_comment(
@@ -312,6 +314,8 @@ class JiraDriver:
         ap = self._current_repo_ap()
         adf = self._agent_comment_body(body, kind, ap)
         raw = client.add_comment(key, adf)
+        # Comment write changes the card's "last update" — drop the cache.
+        card_cache.invalidate(self.project_root, key)
         return Comment(
             author=ap or self.email,
             ts=raw.get("created") or _now_iso(),
@@ -356,6 +360,7 @@ class JiraDriver:
                     f"/rest/api/3/issue/{key}/assignee",
                     body={"accountId": self.agent_account_id},
                 )
+        card_cache.invalidate(self.project_root, key)
         return self.get_task(key)
 
     def list_members(self) -> list[Member]:

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -1,0 +1,350 @@
+"""JiraDriver — Jira Cloud-backed implementation of the Driver Protocol.
+
+Phase 2 scope:
+- health, list_tasks, get_task, transition (canonical → Jira via statusMap),
+  post_comment, list_comments, assign (human only).
+- AP-related ops (list_aps, register_ap) raise NotSupported. Phase 3 lands them.
+- Anti-self-approve client-side enforcement requires AP wiring (Phase 3).
+- Comment prefix grammar (SPEC §9) is wired so Phase 3 can light up AP-aware
+  attribution — for now agent comments use kind=COMMENT with no AP prefix.
+"""
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..lib import credentials
+from ..lib.jira_client import JiraClient, JiraError, adf_to_text, text_to_adf
+from .base import (
+    AgentRef,
+    Comment,
+    CommentKind,
+    HealthResult,
+    HealthStatus,
+    HumanRef,
+    Member,
+    MemberRef,
+    NotSupported,
+    Task,
+    TaskFilter,
+    TaskInput,
+)
+
+
+CANONICAL_COLUMNS = ("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED")
+
+# SPEC §9 prefix grammar.
+_PREFIX_RE = re.compile(
+    r"^\*\*\[(?P<ap>[a-z][a-z0-9-]+)\]\s+\[(?P<kind>Q|A|C|S)\]\*\*\s*\n*(?P<rest>.*)$",
+    re.DOTALL,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+class JiraDriver:
+    name = "jira"
+
+    def __init__(self, kanban_data: dict[str, Any], project_root: Path):
+        self.project_root = Path(project_root)
+        backend = kanban_data.get("backend") or {}
+        if backend.get("driver") != "jira":
+            raise ValueError("JiraDriver requires backend.driver == 'jira'")
+        self.cfg: dict[str, Any] = backend.get("jira") or {}
+        self.project_key: str = self.cfg.get("projectKey") or ""
+        self.board_id: int | None = self.cfg.get("boardId")
+        self.status_map: dict[str, str] = self.cfg.get("statusMap") or {}
+        self.partial: bool = bool(self.cfg.get("partial"))
+        self.label_fallback: dict[str, str] = self.cfg.get("labelFallback") or {}
+        self.agent_account_id: str | None = self.cfg.get("agentAccountId")
+        self.ap_field_id: str | None = (self.cfg.get("ap") or {}).get("fieldId")
+
+        env = credentials.read("JIRA_")
+        self.base_url = env.get("JIRA_BASE_URL", "")
+        self.email = env.get("JIRA_AGENT_EMAIL", "")
+        self._token = env.get("JIRA_API_TOKEN", "")
+        self._client: JiraClient | None = None
+
+    # --- helpers -------------------------------------------------------
+
+    def _client_or_raise(self) -> JiraClient:
+        if not (self.base_url and self.email and self._token):
+            raise RuntimeError(
+                "Jira credentials missing — run /kanban:initjira or "
+                "/kanban:reset-credentials"
+            )
+        if self._client is None:
+            self._client = JiraClient(self.base_url, self.email, self._token)
+        return self._client
+
+    def _canonical_to_status(self, column: str) -> str | None:
+        return self.status_map.get(column)
+
+    def _status_to_canonical(self, status_name: str) -> str:
+        for canonical, display in self.status_map.items():
+            if display == status_name:
+                return canonical
+        # Unknown — return the raw status as-is so callers see it untranslated.
+        return status_name
+
+    def _issue_to_task(self, issue: dict[str, Any]) -> Task:
+        f = issue.get("fields") or {}
+        status_name = ((f.get("status") or {}).get("name")) or ""
+        column = self._status_to_canonical(status_name)
+        # Apply label fallback in partial mode.
+        if self.partial and self.label_fallback:
+            for canonical, label in self.label_fallback.items():
+                if label in (f.get("labels") or []):
+                    column = canonical
+                    break
+
+        ap_value: str | None = None
+        if self.ap_field_id:
+            raw = f.get(self.ap_field_id)
+            if isinstance(raw, dict):
+                ap_value = raw.get("value")
+            elif isinstance(raw, str):
+                ap_value = raw
+
+        priority = ((f.get("priority") or {}).get("name")) or ""
+        assignee_obj = f.get("assignee") or {}
+        member: MemberRef | None = None
+        if assignee_obj.get("accountId"):
+            member = HumanRef(accountId=assignee_obj["accountId"])
+
+        return Task(
+            id=issue.get("key", ""),
+            title=f.get("summary", ""),
+            column=column,
+            priority=priority,
+            created=f.get("created", ""),
+            updated=f.get("updated", ""),
+            description=adf_to_text(f.get("description")) if f.get("description") else "",
+            tags=list(f.get("labels") or []),
+            depends=[],  # epic/issuelink resolution deferred (out of scope v0.2)
+            assignee=member,
+            ap=ap_value,
+            comments=[],
+            custom={"raw_status": status_name},
+        )
+
+    @staticmethod
+    def _agent_prefix(ap: str | None, kind: CommentKind) -> str:
+        ap_str = ap or "agent"
+        return f"**[{ap_str}] [{kind.value}]**\n\n"
+
+    def _agent_comment_body(
+        self, body: str, kind: CommentKind, ap: str | None
+    ) -> dict[str, Any]:
+        return text_to_adf(self._agent_prefix(ap, kind) + body)
+
+    def _parse_comment(self, raw: dict[str, Any]) -> Comment:
+        author = ((raw.get("author") or {}).get("displayName")) or ""
+        ts = raw.get("created") or ""
+        text = adf_to_text(raw.get("body"))
+        kind = CommentKind.COMMENT
+        m = _PREFIX_RE.match(text or "")
+        if m:
+            try:
+                kind = CommentKind(m.group("kind"))
+            except ValueError:
+                pass
+            author = m.group("ap")
+            text = m.group("rest").strip()
+        return Comment(author=author, ts=ts, text=text, kind=kind)
+
+    # --- Driver Protocol ----------------------------------------------
+
+    def health(self) -> HealthResult:
+        if not (self.base_url and self.email and self._token):
+            return HealthResult(HealthStatus.UNAUTHENTICATED, "credentials missing")
+        try:
+            client = self._client_or_raise()
+            client.get_myself()
+        except JiraError as e:
+            if e.status_code == 401:
+                return HealthResult(HealthStatus.UNAUTHENTICATED, e.detail)
+            return HealthResult(HealthStatus.UNREACHABLE, e.detail)
+        if not self.project_key:
+            return HealthResult(HealthStatus.DEGRADED, "projectKey unconfigured")
+        return HealthResult(HealthStatus.OK)
+
+    def list_tasks(self, filter: TaskFilter | None = None) -> list[Task]:
+        if not self.project_key:
+            raise RuntimeError("backend.jira.projectKey unconfigured")
+        client = self._client_or_raise()
+
+        clauses = [f'project = "{self.project_key}"']
+        if filter:
+            if filter.column:
+                status = self._canonical_to_status(filter.column)
+                if status:
+                    clauses.append(f'status = "{status}"')
+                elif self.partial and filter.column in self.label_fallback:
+                    clauses.append(f'labels = "{self.label_fallback[filter.column]}"')
+            if filter.assignee:
+                clauses.append(f'assignee = "{filter.assignee}"')
+            if filter.priority:
+                clauses.append(f'priority = "{filter.priority}"')
+            if filter.ap and self.ap_field_id:
+                # Phase 3 feature: jql-by-AP. Field id is safe to inject; AP
+                # values are validated [a-z0-9-] so quote-escaping is moot.
+                clauses.append(f'cf[{self.ap_field_id[12:]}] = "{filter.ap}"')
+
+        jql = " AND ".join(clauses) + " ORDER BY priority DESC, created ASC"
+        fields = ["summary", "status", "priority", "assignee", "labels",
+                  "created", "updated", "description"]
+        if self.ap_field_id:
+            fields.append(self.ap_field_id)
+        max_results = filter.limit if filter and filter.limit else 50
+
+        resp = client.search_jql(jql, fields=fields, max_results=max_results)
+        return [self._issue_to_task(i) for i in resp.get("issues", [])]
+
+    def get_task(self, key: str) -> Task:
+        client = self._client_or_raise()
+        fields = ["summary", "status", "priority", "assignee", "labels",
+                  "created", "updated", "description"]
+        if self.ap_field_id:
+            fields.append(self.ap_field_id)
+        issue = client.get_issue(key, fields=fields)
+        return self._issue_to_task(issue)
+
+    def create_task(self, task: TaskInput) -> Task:
+        # Used by §11 migration. Phase 2 ships a minimal create that maps to
+        # /rest/api/3/issue. Idempotency (don't double-create on retry) is
+        # the importer's responsibility, not the driver's.
+        if not self.project_key:
+            raise RuntimeError("backend.jira.projectKey unconfigured")
+        client = self._client_or_raise()
+        body: dict[str, Any] = {
+            "fields": {
+                "project": {"key": self.project_key},
+                "summary": task.title,
+                "issuetype": {"name": "Task"},
+            }
+        }
+        if task.description:
+            body["fields"]["description"] = text_to_adf(task.description)
+        if task.priority:
+            body["fields"]["priority"] = {"name": task.priority}
+        if task.tags:
+            body["fields"]["labels"] = list(task.tags)
+        resp = client._request("POST", "/rest/api/3/issue", body=body)
+        return self.get_task(resp["key"])
+
+    def transition(self, key: str, to_column: str, **kwargs: Any) -> Task:
+        if to_column not in CANONICAL_COLUMNS:
+            raise ValueError(
+                f"unknown canonical column {to_column!r}; expected one of "
+                f"{CANONICAL_COLUMNS}"
+            )
+        client = self._client_or_raise()
+        target_status = self._canonical_to_status(to_column)
+
+        if target_status:
+            transitions = (client.get_transitions(key) or {}).get("transitions", [])
+            tid = next(
+                (
+                    t["id"]
+                    for t in transitions
+                    if (t.get("to") or {}).get("name") == target_status
+                ),
+                None,
+            )
+            if not tid:
+                raise RuntimeError(
+                    f"no transition to status {target_status!r} on issue {key} — "
+                    f"check Jira workflow conditions"
+                )
+            client.transition_issue(key, tid)
+        elif self.partial and to_column in self.label_fallback:
+            # Apply label substitute via PUT issue.
+            label = self.label_fallback[to_column]
+            client._request(
+                "PUT",
+                f"/rest/api/3/issue/{key}",
+                body={"update": {"labels": [{"add": label}]}},
+            )
+            self._post_system_comment(
+                key, f"label substitute applied: {label} (canonical={to_column})"
+            )
+        else:
+            raise RuntimeError(
+                f"no Jira status or label fallback configured for {to_column!r}"
+            )
+
+        if to_column == "BLOCKED":
+            reason = kwargs.get("reason")
+            if reason:
+                self.post_comment(key, f"Blocked: {reason}", CommentKind.SYSTEM)
+        return self.get_task(key)
+
+    def post_comment(
+        self, key: str, body: str, kind: CommentKind = CommentKind.COMMENT
+    ) -> Comment:
+        client = self._client_or_raise()
+        ap = self._current_repo_ap()
+        adf = self._agent_comment_body(body, kind, ap)
+        raw = client.add_comment(key, adf)
+        return Comment(
+            author=ap or self.email,
+            ts=raw.get("created") or _now_iso(),
+            text=body,
+            kind=kind,
+        )
+
+    def _post_system_comment(self, key: str, body: str) -> None:
+        try:
+            self.post_comment(key, body, CommentKind.SYSTEM)
+        except JiraError:
+            pass  # do not block the transition if commenting fails
+
+    def list_comments(self, key: str) -> list[Comment]:
+        client = self._client_or_raise()
+        raw = client.list_comments(key)
+        return [self._parse_comment(c) for c in (raw.get("comments") or [])]
+
+    def assign(self, key: str, member: MemberRef) -> Task:
+        if member.kind != "human":
+            raise NotSupported(
+                "Jira agent assignment by AP is a Phase 3 feature — "
+                "use a human accountId here"
+            )
+        client = self._client_or_raise()
+        client._request(
+            "PUT",
+            f"/rest/api/3/issue/{key}/assignee",
+            body={"accountId": member.accountId},  # type: ignore[union-attr]
+        )
+        return self.get_task(key)
+
+    def list_members(self) -> list[Member]:
+        # Phase 3 surfaces /user/assignable + AP registry. Phase 2 returns [].
+        return []
+
+    def list_aps(self) -> list[str]:
+        raise NotSupported("AP operations land in Phase 3")
+
+    def register_ap(self, name: str) -> None:
+        raise NotSupported("AP operations land in Phase 3")
+
+    # --- repo identity ------------------------------------------------
+
+    def _current_repo_ap(self) -> str | None:
+        """Read .claude/kanban-agent.json. Phase 3 wires this fully — Phase 2
+        treats it as best-effort for outgoing comment attribution.
+        """
+        path = self.project_root / ".claude" / "kanban-agent.json"
+        if not path.exists():
+            return None
+        try:
+            import json
+            return json.loads(path.read_text()).get("ap")
+        except Exception:
+            return None

--- a/plugins/kanban/drivers/local.py
+++ b/plugins/kanban/drivers/local.py
@@ -1,0 +1,232 @@
+"""LocalDriver — kanban.json-backed implementation of the Driver Protocol.
+
+Behaviour mirrors v0.1.x exactly. AP capabilities are not supported.
+The slash commands continue to use Read/Write tools directly for state
+mutation; this driver exists so future code (hooks, /kanban:status, jira
+parity) can read kanban.json through one canonical path.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..lib import kanban_io
+from .base import (
+    AgentRef,
+    Comment,
+    CommentKind,
+    Driver,
+    HealthResult,
+    HealthStatus,
+    HumanRef,
+    Member,
+    MemberRef,
+    NotSupported,
+    Task,
+    TaskFilter,
+    TaskInput,
+)
+
+
+LOCAL_COLUMNS = ("TODO", "DOING", "DONE", "BLOCKED")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def _next_task_id(tasks: list[dict[str, Any]]) -> str:
+    nums = []
+    for t in tasks:
+        tid = t.get("id", "")
+        if tid.startswith("task-"):
+            try:
+                nums.append(int(tid[5:]))
+            except ValueError:
+                pass
+    n = (max(nums) + 1) if nums else 1
+    return f"task-{n:03d}"
+
+
+def _to_task(raw: dict[str, Any]) -> Task:
+    assignee = raw.get("assignee")
+    member: MemberRef | None
+    if assignee:
+        # Local mode does not distinguish human vs agent; treat as human by default.
+        member = HumanRef(accountId=assignee)
+    else:
+        member = None
+    return Task(
+        id=raw["id"],
+        title=raw["title"],
+        column=raw["column"],
+        priority=raw.get("priority", ""),
+        created=raw["created"],
+        updated=raw["updated"],
+        description=raw.get("description", ""),
+        category=raw.get("category"),
+        tags=list(raw.get("tags") or []),
+        depends=list(raw.get("depends") or []),
+        started=raw.get("started"),
+        completed=raw.get("completed"),
+        assignee=member,
+        comments=[
+            Comment(author=c["author"], ts=c["ts"], text=c["text"])
+            for c in (raw.get("comments") or [])
+        ],
+        custom=dict(raw.get("custom") or {}),
+    )
+
+
+class LocalDriver:
+    name = "local"
+
+    def __init__(self, project_root: Path):
+        self.project_root = Path(project_root)
+        self.path = self.project_root / "kanban.json"
+
+    # --- helpers -------------------------------------------------------
+
+    def _load(self) -> dict[str, Any]:
+        return kanban_io.load(self.path)
+
+    def _save(self, data: dict[str, Any]) -> None:
+        data.setdefault("meta", {})["updated_at"] = _now()
+        kanban_io.save(self.path, data)
+
+    def _find(self, data: dict[str, Any], key: str) -> dict[str, Any]:
+        for t in data.get("tasks", []):
+            if t.get("id") == key:
+                return t
+        raise KeyError(f"task {key!r} not found")
+
+    # --- Driver Protocol ----------------------------------------------
+
+    def health(self) -> HealthResult:
+        if not self.path.exists():
+            return HealthResult(HealthStatus.UNREACHABLE, "kanban.json missing")
+        try:
+            self._load()
+        except Exception as e:
+            return HealthResult(HealthStatus.DEGRADED, f"parse error: {e}")
+        return HealthResult(HealthStatus.OK)
+
+    def list_tasks(self, filter: TaskFilter | None = None) -> list[Task]:
+        data = self._load()
+        out = [_to_task(t) for t in data.get("tasks", [])]
+        if filter is None:
+            return out
+        if filter.column:
+            out = [t for t in out if t.column == filter.column]
+        if filter.assignee:
+            out = [
+                t
+                for t in out
+                if t.assignee
+                and getattr(t.assignee, "accountId", None) == filter.assignee
+            ]
+        if filter.priority:
+            out = [t for t in out if t.priority == filter.priority]
+        if filter.category:
+            out = [t for t in out if t.category == filter.category]
+        if filter.limit:
+            out = out[: filter.limit]
+        return out
+
+    def get_task(self, key: str) -> Task:
+        data = self._load()
+        return _to_task(self._find(data, key))
+
+    def create_task(self, task: TaskInput) -> Task:
+        data = self._load()
+        tasks = data.setdefault("tasks", [])
+        ts = _now()
+        new_id = _next_task_id(tasks)
+        raw: dict[str, Any] = {
+            "id": new_id,
+            "title": task.title,
+            "column": "TODO",
+            "priority": task.priority or "P2",
+            "created": ts,
+            "updated": ts,
+            "description": task.description,
+            "category": task.category,
+            "tags": list(task.tags),
+            "depends": list(task.depends),
+            "started": None,
+            "completed": None,
+            "assignee": (
+                getattr(task.assignee, "accountId", None)
+                if task.assignee and task.assignee.kind == "human"
+                else None
+            ),
+            "comments": [],
+            "custom": dict(task.custom),
+        }
+        tasks.append(raw)
+        self._save(data)
+        return _to_task(raw)
+
+    def transition(self, key: str, to_column: str, **kwargs: Any) -> Task:
+        if to_column not in LOCAL_COLUMNS:
+            raise ValueError(
+                f"local driver only supports {LOCAL_COLUMNS}; got {to_column!r}"
+            )
+        data = self._load()
+        raw = self._find(data, key)
+        if raw["column"] == "DONE":
+            raise ValueError("DONE is terminal — cannot transition")
+        ts = _now()
+        raw["column"] = to_column
+        raw["updated"] = ts
+        if to_column == "DOING" and not raw.get("started"):
+            raw["started"] = ts
+        if to_column == "DONE":
+            raw["completed"] = ts
+            if not raw.get("started"):
+                raw["started"] = ts
+        if to_column == "BLOCKED":
+            reason = kwargs.get("reason")
+            if not reason:
+                raise ValueError("transition to BLOCKED requires reason=...")
+            raw.setdefault("custom", {})["blocked_reason"] = reason
+        self._save(data)
+        return _to_task(raw)
+
+    def post_comment(
+        self, key: str, body: str, kind: CommentKind = CommentKind.COMMENT
+    ) -> Comment:
+        data = self._load()
+        raw = self._find(data, key)
+        ts = _now()
+        author = "claude-code"
+        comment = {"author": author, "ts": ts, "text": body}
+        raw.setdefault("comments", []).append(comment)
+        raw["updated"] = ts
+        self._save(data)
+        return Comment(author=author, ts=ts, text=body, kind=kind)
+
+    def list_comments(self, key: str) -> list[Comment]:
+        return self.get_task(key).comments
+
+    def assign(self, key: str, member: MemberRef) -> Task:
+        data = self._load()
+        raw = self._find(data, key)
+        if member.kind == "human":
+            raw["assignee"] = member.accountId  # type: ignore[union-attr]
+        else:
+            raw["assignee"] = member.ap  # type: ignore[union-attr]
+        raw["updated"] = _now()
+        self._save(data)
+        return _to_task(raw)
+
+    def list_members(self) -> list[Member]:
+        # Local mode has no member directory; return empty.
+        return []
+
+    def list_aps(self) -> list[str]:
+        raise NotSupported("local driver does not support agent properties")
+
+    def register_ap(self, name: str) -> None:
+        raise NotSupported("local driver does not support agent properties")

--- a/plugins/kanban/hooks/hooks.json
+++ b/plugins/kanban/hooks/hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/kanban-session-check.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/kanban-jira-sync.sh"
           }
         ]
       }
@@ -16,6 +20,10 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/kanban-session-check.sh --lightweight"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/kanban-card-detect.sh"
           }
         ]
       }

--- a/plugins/kanban/lib/ap_registry.py
+++ b/plugins/kanban/lib/ap_registry.py
@@ -1,0 +1,95 @@
+"""Agent Property (AP) registry helpers.
+
+AP is the value of a single-select Jira custom field that distinguishes
+which AI agent owns a card (humans use the native `assignee`; agents share
+one Atlassian account and disambiguate via this property).
+
+This module is pure stdlib so it is trivially unit-testable. It does NOT
+talk to Jira — that lives in jira_client + jira_setup.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# SPEC §3.4: AP names are lowercase alnum + hyphens, must start with a letter,
+# 3–41 chars total (^[a-z][a-z0-9-]{2,40}$).
+AP_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{2,40}$")
+
+# Default fuzzy-collision threshold (Levenshtein distance). SPEC §16.1
+# acknowledges this is noisy for very short names; we ship 2 and revisit.
+DEFAULT_FUZZY_THRESHOLD = 2
+
+
+class APValidationError(ValueError):
+    """Raised when an AP name does not match the spec regex."""
+
+
+def validate_ap_name(name: str) -> None:
+    """Raise APValidationError if `name` is not a valid AP."""
+    if not isinstance(name, str) or not AP_NAME_RE.match(name):
+        raise APValidationError(
+            f"invalid AP name {name!r}: must match {AP_NAME_RE.pattern} "
+            "(start with a-z, then [a-z0-9-], length 3–41)"
+        )
+
+
+def levenshtein(a: str, b: str) -> int:
+    """Classic dynamic-programming Levenshtein distance.
+
+    O(len(a)*len(b)) time, O(len(b)) space. Stable, deterministic.
+    """
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    if len(a) < len(b):
+        a, b = b, a
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            curr[j] = min(
+                curr[j - 1] + 1,        # insertion
+                prev[j] + 1,            # deletion
+                prev[j - 1] + cost,     # substitution
+            )
+        prev = curr
+    return prev[-1]
+
+
+@dataclass
+class FuzzyHit:
+    name: str
+    distance: int
+
+
+def fuzzy_collisions(
+    candidate: str,
+    existing: list[str] | tuple[str, ...],
+    threshold: int = DEFAULT_FUZZY_THRESHOLD,
+) -> list[FuzzyHit]:
+    """Return existing names within Levenshtein distance `threshold` of
+    `candidate`, sorted by distance ascending then name ascending.
+
+    Exact matches (distance 0) are returned — the caller decides whether to
+    treat them as a hard duplicate (refuse) or a near-duplicate (warn).
+    """
+    hits: list[FuzzyHit] = []
+    cand = candidate.lower()
+    for ex in existing:
+        d = levenshtein(cand, ex.lower())
+        if d <= threshold:
+            hits.append(FuzzyHit(name=ex, distance=d))
+    hits.sort(key=lambda h: (h.distance, h.name))
+    return hits
+
+
+def is_exact_collision(candidate: str, existing: list[str] | tuple[str, ...]) -> bool:
+    """Case-insensitive exact match against `existing`."""
+    cand = candidate.lower()
+    return any(cand == ex.lower() for ex in existing)

--- a/plugins/kanban/lib/card_cache.py
+++ b/plugins/kanban/lib/card_cache.py
@@ -1,0 +1,93 @@
+"""Per-project, time-bounded cache for Jira card lookups.
+
+SPEC §5.4: scope = Claude Code session, TTL = 30 s, invalidated on any
+plugin-issued write (transition / post_comment / assign).
+
+Implementation: a `.kanban-cache/` directory under the project's `.claude/`,
+with one JSON file per cached key (e.g. `AGENT-42.json`). Hooks and slash
+commands run in separate Python processes, so a file-backed store is the
+only practical choice. The TTL is enforced per-entry by parsing the embedded
+`fetched_at` timestamp.
+
+Public surface:
+    cache_dir(project_root) -> Path
+    get(project_root, key, ttl=30) -> dict | None
+    put(project_root, key, data) -> None
+    invalidate(project_root, key) -> None
+    clear(project_root) -> None
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TTL_SECONDS = 30
+
+
+def cache_dir(project_root: str | os.PathLike[str]) -> Path:
+    return Path(project_root) / ".claude" / ".kanban-cache"
+
+
+def _entry_path(project_root: str | os.PathLike[str], key: str) -> Path:
+    safe = key.replace("/", "_").replace("..", "_")
+    return cache_dir(project_root) / f"{safe}.json"
+
+
+def get(
+    project_root: str | os.PathLike[str],
+    key: str,
+    ttl: int = DEFAULT_TTL_SECONDS,
+) -> dict[str, Any] | None:
+    """Return cached data for `key` if fresh, else None."""
+    p = _entry_path(project_root, key)
+    if not p.exists():
+        return None
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        # Corrupt entry — drop it.
+        try:
+            p.unlink()
+        except OSError:
+            pass
+        return None
+    fetched_at = raw.get("fetched_at_unix")
+    if not isinstance(fetched_at, (int, float)):
+        return None
+    if (time.time() - fetched_at) > ttl:
+        return None
+    return raw.get("data")
+
+
+def put(
+    project_root: str | os.PathLike[str], key: str, data: dict[str, Any]
+) -> None:
+    p = _entry_path(project_root, key)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"fetched_at_unix": time.time(), "key": key, "data": data}
+    tmp = p.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def invalidate(project_root: str | os.PathLike[str], key: str) -> None:
+    p = _entry_path(project_root, key)
+    try:
+        p.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def clear(project_root: str | os.PathLike[str]) -> None:
+    d = cache_dir(project_root)
+    if not d.exists():
+        return
+    for entry in d.iterdir():
+        try:
+            entry.unlink()
+        except OSError:
+            pass

--- a/plugins/kanban/lib/card_parser.py
+++ b/plugins/kanban/lib/card_parser.py
@@ -1,0 +1,65 @@
+"""Detect Jira card references (keys + URLs) in arbitrary text.
+
+SPEC §5.1 patterns:
+    KEY:    \\b[A-Z][A-Z0-9_]+-[0-9]+\\b           e.g. AGENT-42, FIN-103
+    URL:    https?://.../browse/<KEY>
+    URL:    https?://.../?selectedIssue=<KEY>
+
+Project key prefix must match `backend.jira.projectKey` to avoid false
+positives from past chats and unrelated repos. We dedupe results, preserve
+first-occurrence order, and do not normalise case (keys are uppercase by
+construction).
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+
+# A Jira issue key. Allows underscore in the project portion (e.g. AGENT_BOT-12).
+_KEY_RE = re.compile(r"\b([A-Z][A-Z0-9_]+)-(\d+)\b")
+_URL_KEY_RE = re.compile(
+    r"https?://[^/\s]+/(?:browse/|.*?[?&]selectedIssue=)([A-Z][A-Z0-9_]+-\d+)"
+)
+
+
+def extract_keys(text: str) -> list[str]:
+    """Return all KEY-N references in `text`, deduped, in document order."""
+    if not text:
+        return []
+    matches: list[tuple[int, str]] = []
+    consumed_ranges: list[tuple[int, int]] = []
+    for m in _URL_KEY_RE.finditer(text):
+        matches.append((m.start(), m.group(1)))
+        consumed_ranges.append(m.span())
+
+    def _within_url(pos: int) -> bool:
+        return any(start <= pos < end for start, end in consumed_ranges)
+
+    for m in _KEY_RE.finditer(text):
+        if _within_url(m.start()):
+            continue  # the URL pass already captured this
+        matches.append((m.start(), f"{m.group(1)}-{m.group(2)}"))
+
+    matches.sort(key=lambda pair: pair[0])
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, key in matches:
+        if key not in seen:
+            seen.add(key)
+            out.append(key)
+    return out
+
+
+def filter_by_project(keys: Iterable[str], project_key: str) -> list[str]:
+    """Keep only KEYs whose project portion equals `project_key`."""
+    if not project_key:
+        return list(keys)
+    prefix = f"{project_key}-"
+    return [k for k in keys if k.startswith(prefix)]
+
+
+def extract_for_project(text: str, project_key: str) -> list[str]:
+    """Convenience: extract + filter in one call."""
+    return filter_by_project(extract_keys(text), project_key)

--- a/plugins/kanban/lib/credentials.py
+++ b/plugins/kanban/lib/credentials.py
@@ -1,0 +1,168 @@
+"""Atomic ~/.claude-workbench/.env reader/writer.
+
+Shared with notify plugin's storage convention. Each plugin owns its prefix
+(e.g. JIRA_*, PUSHOVER_*) and must never modify another plugin's lines.
+
+Public surface:
+    env_path() -> Path
+    read(prefix=None) -> dict[str, str]
+    write(updates: dict[str, str], prefix: str) -> None
+    delete(keys: list[str]) -> None
+    ensure_mode() -> bool   # True if file exists with 0600
+
+Write strategy: read all lines, replace lines whose key starts with `prefix`,
+preserve everything else byte-for-byte, write to tempfile, fsync, rename.
+"""
+from __future__ import annotations
+
+import os
+import re
+import stat
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+
+ENV_DIR = Path.home() / ".claude-workbench"
+ENV_FILE = ENV_DIR / ".env"
+
+# Match KEY=VALUE lines (no inline comments — keeps the format simple).
+_LINE_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+
+
+def env_path() -> Path:
+    return ENV_FILE
+
+
+def _read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as f:
+        return f.read().splitlines()
+
+
+def _parse(lines: Iterable[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in lines:
+        m = _LINE_RE.match(line.strip())
+        if not m:
+            continue
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def read(prefix: str | None = None) -> dict[str, str]:
+    """Return all KEY=VALUE pairs in .env, optionally filtered by prefix."""
+    if not ENV_FILE.exists():
+        return {}
+    pairs = _parse(_read_lines(ENV_FILE))
+    if prefix is None:
+        return pairs
+    return {k: v for k, v in pairs.items() if k.startswith(prefix)}
+
+
+def ensure_mode() -> bool:
+    """If .env exists with mode broader than 0600, tighten and return False.
+    Returns True if file is already 0600 (or absent).
+    """
+    if not ENV_FILE.exists():
+        return True
+    mode = ENV_FILE.stat().st_mode & 0o777
+    if mode != 0o600:
+        os.chmod(ENV_FILE, 0o600)
+        return False
+    return True
+
+
+def write(updates: dict[str, str], prefix: str) -> None:
+    """Replace all lines whose key starts with `prefix` with the given updates.
+
+    Other plugins' lines are preserved byte-for-byte (including blanks/comments).
+    File mode is forced to 0600. Write is atomic via tempfile + rename.
+
+    Raises ValueError if any update key does not start with `prefix` (guards
+    against accidentally clobbering another plugin's namespace).
+    """
+    for k in updates:
+        if not k.startswith(prefix):
+            raise ValueError(
+                f"key {k!r} does not start with prefix {prefix!r} — refusing to write"
+            )
+
+    ENV_DIR.mkdir(parents=True, exist_ok=True)
+    old_umask = os.umask(0o077)
+    try:
+        existing = _read_lines(ENV_FILE)
+
+        kept: list[str] = []
+        seen: set[str] = set()
+        for line in existing:
+            stripped = line.strip()
+            m = _LINE_RE.match(stripped)
+            if m and m.group(1).startswith(prefix):
+                key = m.group(1)
+                if key in updates:
+                    kept.append(f"{key}={updates[key]}")
+                    seen.add(key)
+                # else: drop (key removed in this update set)
+                continue
+            kept.append(line)
+
+        # Append any new keys not present before.
+        for key, val in updates.items():
+            if key not in seen:
+                kept.append(f"{key}={val}")
+
+        body = "\n".join(kept)
+        if body and not body.endswith("\n"):
+            body += "\n"
+
+        fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=ENV_DIR)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(body)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, ENV_FILE)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    finally:
+        os.umask(old_umask)
+
+
+def delete(keys: list[str]) -> None:
+    """Remove the named keys. No-op if .env or keys absent."""
+    if not ENV_FILE.exists() or not keys:
+        return
+    existing = _read_lines(ENV_FILE)
+    targets = set(keys)
+    kept = [
+        line
+        for line in existing
+        if not (
+            (m := _LINE_RE.match(line.strip())) is not None
+            and m.group(1) in targets
+        )
+    ]
+    body = "\n".join(kept)
+    if body and not body.endswith("\n"):
+        body += "\n"
+    fd, tmp_path = tempfile.mkstemp(prefix=".env.", suffix=".tmp", dir=ENV_DIR)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(body)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, ENV_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -1,0 +1,287 @@
+"""Jira Cloud REST client used by drivers/jira.py.
+
+Design constraints:
+- stdlib only (urllib) — no `requests`/`httpx` dependency
+- Basic Auth with shared agent email + API token
+- Retry: 429 (Retry-After), 5xx (exponential backoff), network errors
+- Injectable transport for tests (no live HTTP in CI)
+- Never log/echo the token; redact on errors
+
+Public surface (each maps to a Jira REST endpoint, mostly v3):
+    JiraClient(base_url, email, api_token, *, transport=None)
+        get_myself()
+        get_project(project_key)
+        get_board(board_id)
+        get_board_configuration(board_id)
+        get_project_statuses(project_key)
+        search_jql(jql, fields=..., max_results=50)
+        get_issue(key, fields=...)
+        get_transitions(key)
+        transition_issue(key, transition_id)
+        add_comment(key, body_adf)         # body_adf is a dict per Jira ADF
+        list_comments(key)
+
+Errors raise JiraError with .status_code (or 0 for network) and .detail.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+JsonAny = Any  # Jira responses are dicts/lists with mixed types
+
+
+class JiraError(Exception):
+    def __init__(self, status_code: int, detail: str = "", url: str = ""):
+        super().__init__(f"[{status_code}] {detail or url}")
+        self.status_code = status_code
+        self.detail = detail
+        self.url = url
+
+
+@dataclass
+class _Response:
+    status: int
+    body: bytes
+    headers: dict[str, str]
+
+
+# A transport is `(method, url, headers, body) -> _Response`. The default
+# implementation uses urllib; tests inject a fake.
+Transport = Callable[[str, str, dict[str, str], Optional[bytes]], _Response]
+
+
+def _default_transport(
+    method: str, url: str, headers: dict[str, str], body: Optional[bytes]
+) -> _Response:
+    req = urllib.request.Request(url=url, method=method, headers=headers, data=body)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return _Response(
+                status=resp.status,
+                body=resp.read(),
+                headers={k.lower(): v for k, v in resp.headers.items()},
+            )
+    except urllib.error.HTTPError as e:
+        return _Response(
+            status=e.code,
+            body=e.read() if hasattr(e, "read") else b"",
+            headers={k.lower(): v for k, v in (e.headers.items() if e.headers else [])},
+        )
+    except urllib.error.URLError as e:
+        # Treat as transport error; let retry loop decide.
+        raise JiraError(0, f"network: {e.reason}", url) from e
+
+
+# -------- retry policy --------------------------------------------------------
+
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+_MAX_RETRIES = 3
+_BASE_BACKOFF_SEC = 0.5
+
+
+def _retry_sleep(attempt: int, retry_after: Optional[str]) -> float:
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return _BASE_BACKOFF_SEC * (2**attempt)
+
+
+# -------- client --------------------------------------------------------------
+
+
+class JiraClient:
+    def __init__(
+        self,
+        base_url: str,
+        email: str,
+        api_token: str,
+        *,
+        transport: Transport | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        if not base_url:
+            raise ValueError("base_url required")
+        self.base_url = base_url.rstrip("/")
+        self.email = email
+        self._token = api_token  # never logged
+        self._transport = transport or _default_transport
+        self._sleep = sleep
+
+    # --- low-level ----------------------------------------------------
+
+    def _auth_header(self) -> str:
+        raw = f"{self.email}:{self._token}".encode()
+        return "Basic " + base64.b64encode(raw).decode()
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, Any] | None = None,
+        body: dict[str, Any] | None = None,
+    ) -> JsonAny:
+        url = f"{self.base_url}{path}"
+        if query:
+            url = f"{url}?{urllib.parse.urlencode(query, doseq=True)}"
+        headers = {
+            "Authorization": self._auth_header(),
+            "Accept": "application/json",
+        }
+        body_bytes: Optional[bytes] = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            body_bytes = json.dumps(body).encode("utf-8")
+
+        last_exc: JiraError | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = self._transport(method, url, headers, body_bytes)
+            except JiraError as e:
+                last_exc = e
+                if attempt < _MAX_RETRIES:
+                    self._sleep(_retry_sleep(attempt, None))
+                    continue
+                raise
+
+            if resp.status in _RETRYABLE_STATUS and attempt < _MAX_RETRIES:
+                self._sleep(_retry_sleep(attempt, resp.headers.get("retry-after")))
+                continue
+
+            if 200 <= resp.status < 300:
+                if not resp.body:
+                    return None
+                try:
+                    return json.loads(resp.body.decode("utf-8"))
+                except json.JSONDecodeError:
+                    return resp.body
+
+            detail = ""
+            try:
+                payload = json.loads(resp.body.decode("utf-8"))
+                msgs = payload.get("errorMessages") or []
+                errs = payload.get("errors") or {}
+                detail = "; ".join(
+                    list(msgs) + [f"{k}: {v}" for k, v in errs.items()]
+                ) or json.dumps(payload)
+            except (ValueError, AttributeError):
+                detail = resp.body.decode("utf-8", errors="replace")[:500]
+            raise JiraError(resp.status, detail, url)
+
+        # Exhausted retries on transport-level errors.
+        if last_exc:
+            raise last_exc
+        raise JiraError(0, "retries exhausted", url)
+
+    # --- high-level endpoints ----------------------------------------
+
+    def get_myself(self) -> dict[str, Any]:
+        return self._request("GET", "/rest/api/3/myself")
+
+    def get_project(self, project_key: str) -> dict[str, Any]:
+        return self._request("GET", f"/rest/api/3/project/{project_key}")
+
+    def get_board(self, board_id: int) -> dict[str, Any]:
+        return self._request("GET", f"/rest/agile/1.0/board/{board_id}")
+
+    def get_board_configuration(self, board_id: int) -> dict[str, Any]:
+        return self._request(
+            "GET", f"/rest/agile/1.0/board/{board_id}/configuration"
+        )
+
+    def get_project_statuses(self, project_key: str) -> list[dict[str, Any]]:
+        """Returns a list of issue-types each with their `statuses` array."""
+        return self._request("GET", f"/rest/api/3/project/{project_key}/statuses")
+
+    def search_jql(
+        self,
+        jql: str,
+        *,
+        fields: list[str] | None = None,
+        max_results: int = 50,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"jql": jql, "maxResults": max_results}
+        if fields:
+            body["fields"] = fields
+        return self._request("POST", "/rest/api/3/search/jql", body=body)
+
+    def get_issue(self, key: str, *, fields: list[str] | None = None) -> dict[str, Any]:
+        query = {"fields": ",".join(fields)} if fields else None
+        return self._request("GET", f"/rest/api/3/issue/{key}", query=query)
+
+    def get_transitions(self, key: str) -> dict[str, Any]:
+        return self._request("GET", f"/rest/api/3/issue/{key}/transitions")
+
+    def transition_issue(self, key: str, transition_id: str) -> None:
+        self._request(
+            "POST",
+            f"/rest/api/3/issue/{key}/transitions",
+            body={"transition": {"id": transition_id}},
+        )
+
+    def add_comment(self, key: str, body_adf: dict[str, Any]) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/rest/api/3/issue/{key}/comment",
+            body={"body": body_adf},
+        )
+
+    def list_comments(self, key: str) -> dict[str, Any]:
+        return self._request("GET", f"/rest/api/3/issue/{key}/comment")
+
+
+# -------- helpers ----------------------------------------------------------
+
+
+def text_to_adf(text: str) -> dict[str, Any]:
+    """Wrap a plain-text body in Atlassian Document Format.
+
+    Used for comments. Does not attempt rich formatting; SPEC §9 prefix is
+    added at the driver layer.
+    """
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    }
+
+
+def adf_to_text(adf: dict[str, Any] | None) -> str:
+    """Best-effort flatten of an ADF body back to plain text. Concatenates
+    every text node in document order. Lossy by design.
+    """
+    if not adf:
+        return ""
+    out: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "text":
+                t = node.get("text")
+                if isinstance(t, str):
+                    out.append(t)
+            for child in node.get("content", []) or []:
+                walk(child)
+            if node.get("type") in {"paragraph", "heading"}:
+                out.append("\n")
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+
+    walk(adf)
+    return "".join(out).strip()

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -239,6 +239,69 @@ class JiraClient:
     def list_comments(self, key: str) -> dict[str, Any]:
         return self._request("GET", f"/rest/api/3/issue/{key}/comment")
 
+    # --- custom-field endpoints (Phase 3) -----------------------------
+
+    def list_fields(self) -> list[dict[str, Any]]:
+        """All fields visible to this account, including custom fields.
+
+        Used by /kanban:initjira step 4 [a] (browse existing fields).
+        """
+        return self._request("GET", "/rest/api/3/field")
+
+    def create_custom_field(
+        self,
+        name: str,
+        description: str = "",
+        type_key: str = "com.atlassian.jira.plugin.system.customfieldtypes:select",
+        searcher_key: str = "com.atlassian.jira.plugin.system.customfieldtypes:multiselectsearcher",
+    ) -> dict[str, Any]:
+        """Create a single-select custom field. Requires Jira admin privileges.
+
+        Returns the new field object including `id` (e.g. `customfield_10042`).
+        """
+        return self._request(
+            "POST",
+            "/rest/api/3/field",
+            body={
+                "name": name,
+                "description": description,
+                "type": type_key,
+                "searcherKey": searcher_key,
+            },
+        )
+
+    def list_field_contexts(self, field_id: str) -> dict[str, Any]:
+        """List contexts for a custom field. The default context is the
+        scope where adding an option makes that option available everywhere.
+        """
+        return self._request("GET", f"/rest/api/3/field/{field_id}/context")
+
+    def list_field_options(self, field_id: str, context_id: int) -> dict[str, Any]:
+        return self._request(
+            "GET",
+            f"/rest/api/3/field/{field_id}/context/{context_id}/option",
+        )
+
+    def add_field_option(
+        self, field_id: str, context_id: int, value: str
+    ) -> dict[str, Any]:
+        """Add a single-select option to a custom field's context."""
+        return self._request(
+            "POST",
+            f"/rest/api/3/field/{field_id}/context/{context_id}/option",
+            body={"options": [{"value": value}]},
+        )
+
+    def update_issue(self, key: str, fields: dict[str, Any]) -> None:
+        """PUT /issue/{key} with `fields` payload. Used by AgentRef assign
+        to write the AP custom field directly.
+        """
+        self._request(
+            "PUT",
+            f"/rest/api/3/issue/{key}",
+            body={"fields": fields},
+        )
+
 
 # -------- helpers ----------------------------------------------------------
 

--- a/plugins/kanban/lib/kanban_io.py
+++ b/plugins/kanban/lib/kanban_io.py
@@ -1,0 +1,115 @@
+"""kanban.json reader/writer with v0.1↔v0.2 compatibility.
+
+Reader policy: accept v0.1 (`schema_version: 1`) and v0.2 (`version: "0.2"`).
+Writer policy: always emit v0.2 form.
+
+Public surface:
+    load(path) -> dict       # normalized v0.2 shape, with default `backend`
+    save(path, data) -> None # atomic write, v0.2 form
+    detect_version(data) -> "0.1" | "0.2"
+    default_backend() -> dict
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+CURRENT_VERSION = "0.2"
+LEGACY_SCHEMA_VERSION = 1
+
+
+def default_backend() -> dict[str, Any]:
+    return {"driver": "local"}
+
+
+def detect_version(data: dict[str, Any]) -> str:
+    """Return '0.2' if v0.2 form, '0.1' for legacy. Heuristic, not strict."""
+    if isinstance(data.get("version"), str):
+        return data["version"]
+    if data.get("schema_version") == LEGACY_SCHEMA_VERSION:
+        return "0.1"
+    # No marker — treat as legacy and let downstream decide.
+    return "0.1"
+
+
+def normalize(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `data` in canonical v0.2 shape.
+
+    - Adds `version: "0.2"` if absent.
+    - Drops legacy `schema_version` (writer policy is single-source).
+    - Adds `backend: {driver: local}` if absent (v0.1 implicit local).
+    - Leaves `meta`, `tasks` untouched.
+    """
+    out = dict(data)
+    out["version"] = CURRENT_VERSION
+    out.pop("schema_version", None)
+    if "backend" not in out or not isinstance(out["backend"], dict):
+        out["backend"] = default_backend()
+    elif "driver" not in out["backend"]:
+        out["backend"]["driver"] = "local"
+    return out
+
+
+def load(path: str | os.PathLike[str]) -> dict[str, Any]:
+    """Read kanban.json and return normalized v0.2 dict.
+
+    Raises FileNotFoundError if missing, json.JSONDecodeError if malformed.
+    """
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: top-level must be an object")
+    return normalize(data)
+
+
+def save(path: str | os.PathLike[str], data: dict[str, Any]) -> None:
+    """Atomically write kanban.json in v0.2 form.
+
+    Strategy: write to tempfile in same directory, fsync, rename. Survives
+    partial writes and concurrent reads.
+    """
+    p = Path(path)
+    out = normalize(data)
+    parent = p.parent if p.parent != Path("") else Path(".")
+    parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_path = tempfile.mkstemp(prefix=".kanban.", suffix=".tmp", dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, p)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI for hooks/scripts. Usage: python -m lib.kanban_io <path>"""
+    import sys
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print("usage: kanban_io <path>", file=sys.stderr)
+        return 2
+    try:
+        data = load(args[0])
+    except FileNotFoundError:
+        return 1
+    json.dump(data, __import__("sys").stdout, indent=2, ensure_ascii=False)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/plugins/kanban/lib/mcp_conflict_scan.py
+++ b/plugins/kanban/lib/mcp_conflict_scan.py
@@ -1,0 +1,84 @@
+"""Detect Jira-related MCP servers configured at user / project / .mcp.json scope.
+
+SPEC §18.2 rationale: when the kanban plugin is the sanctioned path for an
+agent to touch Jira, a separate Jira MCP server (Atlassian Rovo,
+mcp-atlassian, ...) bypasses AP routing, anti-self-approve, and the comment
+prefix grammar. This module surfaces such servers as a warning so the user
+can decide whether to scope them to user-only or remove them.
+
+Public surface:
+    scan(project_root) -> list[Conflict]
+
+Conflict.source is the absolute path of the settings file the entry came from.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_KEYWORD_RE = re.compile(r"(?i)atlassian|jira|rovo|mcp-atlassian")
+
+
+@dataclass
+class Conflict:
+    server_name: str
+    source: str       # absolute path to the settings file
+    matched_on: str   # short reason ("name", "command", "args", "url")
+
+
+def _candidate_paths(project_root: str | os.PathLike[str]) -> list[Path]:
+    project_root = Path(project_root)
+    return [
+        Path.home() / ".claude" / "settings.json",
+        project_root / ".claude" / "settings.json",
+        project_root / ".mcp.json",
+    ]
+
+
+def _scan_servers(blob: dict, source: Path) -> list[Conflict]:
+    servers = blob.get("mcpServers")
+    if not isinstance(servers, dict):
+        return []
+    out: list[Conflict] = []
+    for name, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if _KEYWORD_RE.search(name or ""):
+            out.append(Conflict(name, str(source), "name"))
+            continue
+        for field in ("command", "url"):
+            v = cfg.get(field)
+            if isinstance(v, str) and _KEYWORD_RE.search(v):
+                out.append(Conflict(name, str(source), field))
+                break
+        else:
+            args = cfg.get("args")
+            if isinstance(args, list):
+                joined = " ".join(str(a) for a in args)
+                if _KEYWORD_RE.search(joined):
+                    out.append(Conflict(name, str(source), "args"))
+    return out
+
+
+def scan(project_root: str | os.PathLike[str]) -> list[Conflict]:
+    """Walk all candidate settings files; return any matches.
+
+    Missing files / parse errors are silently skipped — this is best-effort
+    surfacing, not a validator.
+    """
+    out: list[Conflict] = []
+    for path in _candidate_paths(project_root):
+        if not path.exists():
+            continue
+        try:
+            blob = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(blob, dict):
+            continue
+        out.extend(_scan_servers(blob, path))
+    return out

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Jira-mode setup helper invoked by /kanban:initjira and friends.
+
+Subcommands print JSON to stdout (one object per call). Errors print to
+stderr and return non-zero. Tokens are read from --token-stdin (FD 0) so
+they never appear in argv.
+
+Subcommands:
+  validate-credentials --base-url URL --email E
+       (token on stdin)
+       -> {"ok": true, "displayName": "...", "accountId": "..."}
+
+  parse-board-url --url URL
+       -> {"projectKey": "AGENT", "boardId": 1}
+
+  validate-project --base-url URL --email E --project K --board ID
+       (token on stdin)
+       -> {"projectName": "...", "boardName": "...", "boardType": "scrum"}
+
+  build-status-map --base-url URL --email E --project K
+       (token on stdin)
+       -> {"found": [{"name": "To Do"}, ...],
+           "map": {"TODO": "To Do", "DOING": "In Progress", "DONE": "Done"},
+           "missing": ["BLOCKED", "REVIEW", "CANCELLED"],
+           "partial": true}
+
+  write-backend --kanban-path P --jira-config-json '{...}'
+       -> {"ok": true, "version": "0.2"}
+
+  store-credentials --base-url URL --email E
+       (token on stdin)
+       -> {"ok": true}
+
+  read-credentials
+       -> {"baseUrl": "...", "email": "...", "tokenPresent": true}
+
+  health
+       -> driver-health JSON for current project
+
+  list-tasks --kanban-path P [--column COL] [--limit N]
+       -> {"tasks": [{...}, ...]}   # driver-dispatched, no token argv
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Import package modules with relative path. Plugin layout: scripts/ is a
+# sibling of lib/ and drivers/. Python doesn't auto-import "kanban" in this
+# layout, so we resolve plugins/ as the path root and import as
+# `kanban.lib.*` etc.
+HERE = Path(__file__).resolve()
+PLUGINS_ROOT = HERE.parents[2]   # .../plugins
+sys.path.insert(0, str(PLUGINS_ROOT))
+
+from kanban.lib import credentials, kanban_io  # noqa: E402
+from kanban.lib.jira_client import JiraClient, JiraError  # noqa: E402
+
+
+# --- helpers --------------------------------------------------------------
+
+
+CANONICAL_COLUMNS = ("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED")
+
+# Liberal name → canonical match, case-insensitive, ignoring whitespace and
+# punctuation. Keys are compared as the lowercase normalised form.
+_NAME_RULES: dict[str, str] = {
+    "todo": "TODO",
+    "to do": "TODO",
+    "to-do": "TODO",
+    "open": "TODO",
+    "doing": "DOING",
+    "in progress": "DOING",
+    "inprogress": "DOING",
+    "wip": "DOING",
+    "blocked": "BLOCKED",
+    "on hold": "BLOCKED",
+    "review": "REVIEW",
+    "in review": "REVIEW",
+    "code review": "REVIEW",
+    "done": "DONE",
+    "closed": "DONE",
+    "resolved": "DONE",
+    "cancelled": "CANCELLED",
+    "canceled": "CANCELLED",
+    "wontfix": "CANCELLED",
+    "won't fix": "CANCELLED",
+}
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9 ]", "", s.lower()).strip()
+
+
+def _read_token() -> str:
+    if sys.stdin.isatty():
+        sys.stderr.write("error: token expected on stdin\n")
+        sys.exit(2)
+    return sys.stdin.read().strip()
+
+
+def _client(base_url: str, email: str, token: str) -> JiraClient:
+    return JiraClient(base_url, email, token)
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    json.dump(obj, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def _fail(msg: str, code: int = 1, **extra: Any) -> None:
+    payload = {"ok": False, "error": msg, **extra}
+    _emit(payload)
+    sys.exit(code)
+
+
+# --- subcommands ----------------------------------------------------------
+
+
+def cmd_validate_credentials(args: argparse.Namespace) -> int:
+    token = _read_token()
+    try:
+        me = _client(args.base_url, args.email, token).get_myself()
+    except JiraError as e:
+        _fail(f"jira: {e.detail or e}", code=1, statusCode=e.status_code)
+        return 1
+    except Exception as e:  # noqa: BLE001 — surface network errors clearly
+        _fail(f"network: {e}", code=1)
+        return 1
+    _emit(
+        {
+            "ok": True,
+            "displayName": me.get("displayName", ""),
+            "accountId": me.get("accountId", ""),
+            "emailAddress": me.get("emailAddress", ""),
+        }
+    )
+    return 0
+
+
+def cmd_store_credentials(args: argparse.Namespace) -> int:
+    token = _read_token()
+    if not token:
+        _fail("empty token")
+    credentials.write(
+        {
+            "JIRA_BASE_URL": args.base_url,
+            "JIRA_AGENT_EMAIL": args.email,
+            "JIRA_API_TOKEN": token,
+        },
+        prefix="JIRA_",
+    )
+    _emit({"ok": True})
+    return 0
+
+
+def cmd_read_credentials(_args: argparse.Namespace) -> int:
+    env = credentials.read("JIRA_")
+    _emit(
+        {
+            "baseUrl": env.get("JIRA_BASE_URL", ""),
+            "email": env.get("JIRA_AGENT_EMAIL", ""),
+            "tokenPresent": bool(env.get("JIRA_API_TOKEN")),
+        }
+    )
+    return 0
+
+
+_BOARD_URL_RE = re.compile(
+    r"https?://[^/]+/jira/(?:software/(?:c/)?)?projects/(?P<key>[A-Z][A-Z0-9_]+)/boards/(?P<id>\d+)"
+)
+
+
+def cmd_parse_board_url(args: argparse.Namespace) -> int:
+    m = _BOARD_URL_RE.search(args.url)
+    if not m:
+        _fail("could not parse board URL — expected /jira/.../projects/<KEY>/boards/<ID>")
+        return 1
+    _emit({"projectKey": m.group("key"), "boardId": int(m.group("id"))})
+    return 0
+
+
+def cmd_validate_project(args: argparse.Namespace) -> int:
+    token = _read_token()
+    client = _client(args.base_url, args.email, token)
+    try:
+        proj = client.get_project(args.project)
+        board = client.get_board(args.board)
+    except JiraError as e:
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+    _emit(
+        {
+            "ok": True,
+            "projectName": proj.get("name", ""),
+            "projectKey": proj.get("key", ""),
+            "boardName": board.get("name", ""),
+            "boardType": board.get("type", ""),
+        }
+    )
+    return 0
+
+
+def cmd_build_status_map(args: argparse.Namespace) -> int:
+    token = _read_token()
+    client = _client(args.base_url, args.email, token)
+    try:
+        types = client.get_project_statuses(args.project)
+    except JiraError as e:
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+
+    found: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for issue_type in types or []:
+        for status in issue_type.get("statuses", []) or []:
+            n = status.get("name") or ""
+            if n and n not in seen:
+                seen.add(n)
+                found.append({"name": n, "category": (status.get("statusCategory") or {}).get("key")})
+
+    canonical_map: dict[str, str] = {}
+    for s in found:
+        canonical = _NAME_RULES.get(_norm(s["name"]))
+        if canonical and canonical not in canonical_map:
+            canonical_map[canonical] = s["name"]
+
+    missing = [c for c in CANONICAL_COLUMNS if c not in canonical_map]
+    label_fallback = {c: f"kanban:{c.lower()}" for c in missing}
+    _emit(
+        {
+            "found": found,
+            "map": canonical_map,
+            "missing": missing,
+            "partial": bool(missing),
+            "labelFallback": label_fallback,
+        }
+    )
+    return 0
+
+
+def cmd_write_backend(args: argparse.Namespace) -> int:
+    cfg = json.loads(args.jira_config_json)
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    data["backend"] = {"driver": "jira", "jira": cfg}
+    # Adjust columns metadata to match SPEC: jira mode permits all 6.
+    meta = data.setdefault("meta", {})
+    meta["columns"] = list(CANONICAL_COLUMNS)
+    kanban_io.save(p, data)
+    _emit({"ok": True, "version": data.get("version", "0.2")})
+    return 0
+
+
+def cmd_list_tasks(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import TaskFilter
+
+    driver = get_driver(data, p.parent)
+    flt = TaskFilter(column=args.column, limit=args.limit)
+    try:
+        tasks = driver.list_tasks(flt)
+    except Exception as e:  # noqa: BLE001
+        _fail(f"{type(e).__name__}: {e}")
+        return 1
+    out: list[dict[str, Any]] = []
+    for t in tasks:
+        out.append(
+            {
+                "id": t.id,
+                "title": t.title,
+                "column": t.column,
+                "priority": t.priority,
+                "assignee": (
+                    getattr(t.assignee, "accountId", None) or getattr(t.assignee, "ap", None)
+                    if t.assignee
+                    else None
+                ),
+                "ap": t.ap,
+                "started": t.started,
+                "completed": t.completed,
+            }
+        )
+    _emit({"tasks": out})
+    return 0
+
+
+def cmd_health(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    from kanban.drivers import get_driver
+
+    driver = get_driver(data, p.parent)
+    h = driver.health()
+    _emit({"ok": h.status.value == "ok", "status": h.status.value, "detail": h.detail})
+    return 0
+
+
+# --- entry point ----------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="jira_setup", add_help=True)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("validate-credentials")
+    s.add_argument("--base-url", required=True)
+    s.add_argument("--email", required=True)
+    s.set_defaults(func=cmd_validate_credentials)
+
+    s = sub.add_parser("store-credentials")
+    s.add_argument("--base-url", required=True)
+    s.add_argument("--email", required=True)
+    s.set_defaults(func=cmd_store_credentials)
+
+    s = sub.add_parser("read-credentials")
+    s.set_defaults(func=cmd_read_credentials)
+
+    s = sub.add_parser("parse-board-url")
+    s.add_argument("--url", required=True)
+    s.set_defaults(func=cmd_parse_board_url)
+
+    s = sub.add_parser("validate-project")
+    s.add_argument("--base-url", required=True)
+    s.add_argument("--email", required=True)
+    s.add_argument("--project", required=True)
+    s.add_argument("--board", required=True, type=int)
+    s.set_defaults(func=cmd_validate_project)
+
+    s = sub.add_parser("build-status-map")
+    s.add_argument("--base-url", required=True)
+    s.add_argument("--email", required=True)
+    s.add_argument("--project", required=True)
+    s.set_defaults(func=cmd_build_status_map)
+
+    s = sub.add_parser("write-backend")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--jira-config-json", required=True)
+    s.set_defaults(func=cmd_write_backend)
+
+    s = sub.add_parser("health")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_health)
+
+    s = sub.add_parser("list-tasks")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--column")
+    s.add_argument("--limit", type=int)
+    s.set_defaults(func=cmd_list_tasks)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -86,7 +86,7 @@ HERE = Path(__file__).resolve()
 PLUGINS_ROOT = HERE.parents[2]   # .../plugins
 sys.path.insert(0, str(PLUGINS_ROOT))
 
-from kanban.lib import ap_registry, credentials, kanban_io  # noqa: E402
+from kanban.lib import ap_registry, card_cache, credentials, kanban_io  # noqa: E402
 from kanban.lib.jira_client import JiraClient, JiraError  # noqa: E402
 
 
@@ -593,6 +593,227 @@ def cmd_transition(args: argparse.Namespace) -> int:
     return 0
 
 
+def _read_repo_ap(p: Path) -> str | None:
+    """Return AP value from .claude/kanban-agent.json next to `p`, else None."""
+    target = p.parent / ".claude" / "kanban-agent.json"
+    if not target.exists():
+        return None
+    try:
+        return json.loads(target.read_text()).get("ap")
+    except Exception:
+        return None
+
+
+def _build_precheck_block(
+    key: str,
+    task_data: dict[str, Any] | None,
+    repo_ap: str | None,
+) -> tuple[list[str], str]:
+    """Return (warnings, context_block_text) per SPEC §5.3."""
+    warnings: list[str] = []
+    if task_data is None:
+        return (
+            ["card not found in this project"],
+            f"[kanban context for {key}]\n  Status: not found in this project — ignore",
+        )
+
+    column = task_data.get("column") or "?"
+    raw_status = (task_data.get("custom") or {}).get("raw_status") or column
+    ap = task_data.get("ap")
+    title = task_data.get("title") or ""
+
+    rows: list[str] = []
+    rows.append(f"[kanban context for {key}]")
+    rows.append(f'  Title:        {title}')
+    rows.append(f"  Status:       {raw_status}")
+
+    if not ap:
+        rows.append("  AP:           (unassigned)")
+    elif repo_ap and ap == repo_ap:
+        rows.append(f"  AP:           {ap}  (you)")
+    else:
+        rows.append(f"  AP:           {ap}   ⚠ NOT YOU (you are {repo_ap or 'unassigned'})")
+        warnings.append("ap-mismatch")
+
+    if column in {"DONE", "CANCELLED"}:
+        rows.append(f"  ⚠ This card is closed ({column}). Do not modify it.")
+        warnings.append(f"closed-{column.lower()}")
+
+    if column == "REVIEW" and repo_ap and ap == repo_ap:
+        rows.append(
+            "  ⚠ This card is awaiting human review and is owned by you. "
+            "Do not push it to DONE — anti-self-approve will refuse."
+        )
+        warnings.append("awaiting-review-self")
+
+    last_q = task_data.get("last_open_question")
+    if last_q:
+        rows.append(f'  Open question: "{last_q}"')
+        rows.append("  Consider answering before continuing.")
+        warnings.append("open-question")
+
+    if "ap-mismatch" in warnings:
+        rows.append(
+            "  Suggested action: do NOT modify this card. To take it over, "
+            f"reassign in Jira UI or run /kanban:assign-ap to switch your AP."
+        )
+
+    return warnings, "\n".join(rows)
+
+
+def _detect_open_question(comments: list) -> str | None:
+    """Latest unanswered Q-kind comment text, or None.
+
+    Walks backwards: a Q is "open" if the last comment after it (if any) is
+    not an A.
+    """
+    last_q_text: str | None = None
+    last_q_index = -1
+    for i, c in enumerate(comments):
+        if getattr(c.kind, "value", None) == "Q":
+            last_q_text = c.text
+            last_q_index = i
+    if last_q_index == -1:
+        return None
+    # Scan after last_q for an A.
+    for c in comments[last_q_index + 1 :]:
+        if getattr(c.kind, "value", None) == "A":
+            return None
+    return last_q_text
+
+
+def cmd_precheck_card(args: argparse.Namespace) -> int:
+    """Fetch (with cache) + render context block per SPEC §5.3."""
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _emit({"key": args.key, "found": False, "context_block": ""})
+        return 0
+
+    project_key = (backend.get("jira") or {}).get("projectKey") or ""
+    if project_key and not args.key.startswith(f"{project_key}-"):
+        # Not in this project — silently ignore.
+        _emit({"key": args.key, "found": False, "context_block": "", "ignored": True})
+        return 0
+
+    repo_ap = _read_repo_ap(p)
+    cached = card_cache.get(p.parent, args.key)
+    if cached is not None:
+        warnings, block = _build_precheck_block(args.key, cached, repo_ap)
+        _emit(
+            {
+                "key": args.key,
+                "found": True,
+                "warnings": warnings,
+                "context_block": block,
+                "from_cache": True,
+            }
+        )
+        return 0
+
+    from kanban.drivers import get_driver
+
+    driver = get_driver(data, p.parent)
+    try:
+        task = driver.get_task(args.key)
+    except JiraError as e:
+        if e.status_code == 404:
+            warnings, block = _build_precheck_block(args.key, None, repo_ap)
+            _emit({"key": args.key, "found": False, "warnings": warnings, "context_block": block})
+            return 0
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+    except Exception as e:  # noqa: BLE001
+        _fail(f"{type(e).__name__}: {e}")
+        return 1
+
+    open_q: str | None = None
+    if not args.skip_comments:
+        try:
+            comments = driver.list_comments(args.key)
+            open_q = _detect_open_question(comments)
+        except Exception:
+            open_q = None
+
+    task_data = {
+        "id": task.id,
+        "title": task.title,
+        "column": task.column,
+        "ap": task.ap,
+        "priority": task.priority,
+        "custom": task.custom,
+        "last_open_question": open_q,
+    }
+    card_cache.put(p.parent, args.key, task_data)
+    warnings, block = _build_precheck_block(args.key, task_data, repo_ap)
+    _emit(
+        {
+            "key": args.key,
+            "found": True,
+            "warnings": warnings,
+            "context_block": block,
+            "from_cache": False,
+        }
+    )
+    return 0
+
+
+def cmd_sync_summary(args: argparse.Namespace) -> int:
+    """Render an open-cards summary for the current repo's AP."""
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _emit({"summary": "", "skip": "not in jira mode"})
+        return 0
+
+    repo_ap = _read_repo_ap(p)
+    project_key = (backend.get("jira") or {}).get("projectKey") or ""
+
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import TaskFilter
+
+    driver = get_driver(data, p.parent)
+    open_columns = ("TODO", "DOING", "BLOCKED", "REVIEW")
+    rows: list[str] = []
+    counts: dict[str, int] = {c: 0 for c in open_columns}
+    try:
+        for col in open_columns:
+            tasks = driver.list_tasks(
+                TaskFilter(column=col, ap=repo_ap, limit=20) if repo_ap else TaskFilter(column=col, limit=20)
+            )
+            counts[col] = len(tasks)
+            for t in tasks:
+                raw = (t.custom or {}).get("raw_status") or t.column
+                rows.append(f"  {t.id:<14}{raw:<14}{t.title}")
+    except Exception as e:  # noqa: BLE001
+        _fail(f"{type(e).__name__}: {e}")
+        return 1
+
+    if not rows:
+        summary = (
+            f"[kanban Jira sync — {project_key} · ap={repo_ap or '(unset)'}]\n"
+            f"  No open cards."
+        )
+    else:
+        header = (
+            f"[kanban Jira sync — {project_key} · ap={repo_ap or '(unset)'}]\n"
+            f"  TODO {counts['TODO']} · DOING {counts['DOING']} · "
+            f"BLOCKED {counts['BLOCKED']} · REVIEW {counts['REVIEW']}\n"
+        )
+        summary = header + "\n".join(rows)
+
+    _emit({"summary": summary, "counts": counts, "ap": repo_ap, "projectKey": project_key})
+    return 0
+
+
 def cmd_health(args: argparse.Namespace) -> int:
     p = Path(args.kanban_path)
     if not p.exists():
@@ -701,6 +922,17 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--to", required=True, choices=("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"))
     s.add_argument("--reason")
     s.set_defaults(func=cmd_transition)
+
+    s = sub.add_parser("precheck-card")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--key", required=True)
+    s.add_argument("--skip-comments", action="store_true",
+                   help="skip the open-question scan (saves an API call)")
+    s.set_defaults(func=cmd_precheck_card)
+
+    s = sub.add_parser("sync-summary")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_sync_summary)
 
     return p
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -87,6 +88,7 @@ PLUGINS_ROOT = HERE.parents[2]   # .../plugins
 sys.path.insert(0, str(PLUGINS_ROOT))
 
 from kanban.lib import ap_registry, card_cache, credentials, kanban_io  # noqa: E402
+from kanban.lib import mcp_conflict_scan  # noqa: E402
 from kanban.lib.jira_client import JiraClient, JiraError  # noqa: E402
 
 
@@ -814,6 +816,109 @@ def cmd_sync_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_mcp_conflict_scan(args: argparse.Namespace) -> int:
+    """SPEC §18.2: surface any Jira-flavoured MCP servers in scope."""
+    p = Path(args.kanban_path) if args.kanban_path else Path.cwd()
+    project_root = p.parent if p.name == "kanban.json" else p
+    hits = mcp_conflict_scan.scan(project_root)
+    _emit(
+        {
+            "ok": True,
+            "conflicts": [
+                {"server": h.server_name, "source": h.source, "matchedOn": h.matched_on}
+                for h in hits
+            ],
+        }
+    )
+    return 0
+
+
+def cmd_import_tasks(args: argparse.Namespace) -> int:
+    """Migrate local kanban.json#tasks into Jira issues. Idempotent.
+
+    Skip strategy:
+      - tasks already in `.claude/.migration-map.json` → skip (mapped)
+      - column in {DONE, CANCELLED} and not --include-done → skip
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    if (data.get("backend") or {}).get("driver") != "jira":
+        _fail("backend.driver must be 'jira' to import — run /kanban:initjira first")
+        return 1
+    legacy_tasks = data.get("tasks") or []
+    if not legacy_tasks:
+        _emit({"ok": True, "imported": 0, "skipped": 0, "tasks": []})
+        return 0
+
+    map_path = p.parent / ".claude" / ".migration-map.json"
+    map_path.parent.mkdir(parents=True, exist_ok=True)
+    if map_path.exists():
+        try:
+            mapping = json.loads(map_path.read_text())
+        except Exception:
+            mapping = {}
+    else:
+        mapping = {}
+
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import TaskInput
+
+    driver = get_driver(data, p.parent)
+
+    imported: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for t in legacy_tasks:
+        local_id = t.get("id")
+        if not local_id:
+            continue
+        if local_id in mapping:
+            skipped.append({"id": local_id, "reason": "already-mapped", "key": mapping[local_id]})
+            continue
+        col = t.get("column")
+        if col in {"DONE", "CANCELLED"} and not args.include_done:
+            skipped.append({"id": local_id, "reason": f"closed-{col.lower()}"})
+            continue
+        if args.dry_run:
+            imported.append({"id": local_id, "would_create": True})
+            continue
+        try:
+            new_task = driver.create_task(
+                TaskInput(
+                    title=t.get("title") or local_id,
+                    description=t.get("description") or "",
+                    priority=t.get("priority"),
+                    tags=list(t.get("tags") or []) + ["migrated-from-local"],
+                    category=t.get("category"),
+                )
+            )
+        except Exception as e:  # noqa: BLE001
+            skipped.append({"id": local_id, "reason": f"error: {type(e).__name__}: {e}"})
+            continue
+        mapping[local_id] = new_task.id
+        imported.append({"id": local_id, "key": new_task.id, "title": new_task.title})
+
+    if not args.dry_run:
+        tmp = map_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(mapping, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, map_path)
+
+    _emit(
+        {
+            "ok": True,
+            "dryRun": bool(args.dry_run),
+            "imported": len(imported),
+            "skipped": len(skipped),
+            "tasks": imported,
+            "skippedDetail": skipped,
+            "mapPath": str(map_path),
+        }
+    )
+    return 0
+
+
 def cmd_health(args: argparse.Namespace) -> int:
     p = Path(args.kanban_path)
     if not p.exists():
@@ -933,6 +1038,19 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("sync-summary")
     s.add_argument("--kanban-path", required=True)
     s.set_defaults(func=cmd_sync_summary)
+
+    s = sub.add_parser("mcp-conflict-scan")
+    s.add_argument("--kanban-path", default=None,
+                   help="optional; defaults to current working directory")
+    s.set_defaults(func=cmd_mcp_conflict_scan)
+
+    s = sub.add_parser("import-tasks")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--dry-run", action="store_true",
+                   help="report what would be imported without creating Jira issues")
+    s.add_argument("--include-done", action="store_true",
+                   help="also import DONE / CANCELLED tasks (default: skip)")
+    s.set_defaults(func=cmd_import_tasks)
 
     return p
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -39,6 +39,35 @@ Subcommands:
 
   list-tasks --kanban-path P [--column COL] [--limit N]
        -> {"tasks": [{...}, ...]}   # driver-dispatched, no token argv
+
+  Phase 3 — AP routing:
+
+  find-ap-field
+       -> {"candidates": [{"id": "customfield_10042", "name": "Claude Agent"}, ...]}
+
+  create-ap-field [--name "Claude Agent"]
+       -> {"ok": true, "fieldId": "customfield_10042", "fieldName": "Claude Agent"}
+       (requires Jira admin; surfaces 403 with a clear hint)
+
+  set-ap-field --kanban-path P --field-id customfield_X --field-name N
+       -> {"ok": true, ...}   # writes backend.jira.ap to kanban.json
+
+  register-ap --kanban-path P --name N [--force]
+       -> {"ok": true, "registered": [...]}                # success
+       -> {"ok": false, "fuzzyMatch": true, "similar": [...]}   # caller must --force
+
+  assign-ap --kanban-path P --name N
+       -> {"ok": true, "ap": N, "path": ".../.claude/kanban-agent.json"}
+
+  read-agent-ap --kanban-path P
+       -> {"ap": N | null, "path": "..."}
+
+  claim-next --kanban-path P
+       -> {"ok": true, "claimed": {"id":..., "title":..., "priority":..., "ap":...}}
+
+  transition --kanban-path P --key K --to COLUMN [--reason R]
+       -> {"ok": true, "key": K, "column": COLUMN, "raw_status": "..."}
+       -> exit 2 with kind=self-approve when SPEC §8 anti-self-approve fires
 """
 from __future__ import annotations
 
@@ -57,7 +86,7 @@ HERE = Path(__file__).resolve()
 PLUGINS_ROOT = HERE.parents[2]   # .../plugins
 sys.path.insert(0, str(PLUGINS_ROOT))
 
-from kanban.lib import credentials, kanban_io  # noqa: E402
+from kanban.lib import ap_registry, credentials, kanban_io  # noqa: E402
 from kanban.lib.jira_client import JiraClient, JiraError  # noqa: E402
 
 
@@ -105,6 +134,16 @@ def _read_token() -> str:
 
 def _client(base_url: str, email: str, token: str) -> JiraClient:
     return JiraClient(base_url, email, token)
+
+
+def _client_from_env() -> JiraClient:
+    env = credentials.read("JIRA_")
+    base = env.get("JIRA_BASE_URL")
+    email = env.get("JIRA_AGENT_EMAIL")
+    tok = env.get("JIRA_API_TOKEN")
+    if not (base and email and tok):
+        _fail("Jira credentials missing — run /kanban:initjira or /kanban:reset-credentials")
+    return JiraClient(base, email, tok)
 
 
 def _emit(obj: dict[str, Any]) -> None:
@@ -297,6 +336,263 @@ def cmd_list_tasks(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_find_ap_field(_args: argparse.Namespace) -> int:
+    """List custom fields whose name suggests an agent property."""
+    client = _client_from_env()
+    try:
+        fields = client.list_fields() or []
+    except JiraError as e:
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+    candidates = []
+    for f in fields:
+        if not f.get("custom"):
+            continue
+        name = (f.get("name") or "").lower()
+        if "agent" in name or "claude" in name or "ap" == name:
+            candidates.append({"id": f.get("id"), "name": f.get("name")})
+    _emit({"candidates": candidates})
+    return 0
+
+
+def cmd_create_ap_field(args: argparse.Namespace) -> int:
+    client = _client_from_env()
+    try:
+        result = client.create_custom_field(
+            name=args.name,
+            description="Distinguishes which AI agent owns this card. Managed by claude-workbench kanban plugin.",
+        )
+    except JiraError as e:
+        if e.status_code == 403:
+            _fail(
+                "permission denied — creating a custom field requires Jira admin. "
+                "Ask an admin to create a single-select field once, then re-run "
+                "/kanban:initjira and pick [a] use existing field.",
+                statusCode=e.status_code,
+            )
+            return 1
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+    _emit({"ok": True, "fieldId": result.get("id"), "fieldName": result.get("name")})
+    return 0
+
+
+def cmd_set_ap_field(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.setdefault("backend", {"driver": "jira"})
+    if backend.get("driver") != "jira":
+        _fail("backend.driver must be 'jira' before configuring AP")
+        return 1
+    jira_cfg = backend.setdefault("jira", {})
+    ap_block = jira_cfg.setdefault("ap", {})
+    ap_block["fieldId"] = args.field_id
+    ap_block["fieldName"] = args.field_name
+    ap_block.setdefault("registered", [])
+    kanban_io.save(p, data)
+    _emit({"ok": True, "fieldId": args.field_id, "fieldName": args.field_name})
+    return 0
+
+
+def _resolve_default_context(client: JiraClient, field_id: str) -> int:
+    ctxs = client.list_field_contexts(field_id) or {}
+    values = ctxs.get("values") or []
+    for v in values:
+        if v.get("isGlobalContext") or v.get("default") or len(values) == 1:
+            return int(v["id"])
+    if values:
+        return int(values[0]["id"])
+    raise RuntimeError("no contexts found for AP field — Jira config is unusual")
+
+
+def cmd_register_ap(args: argparse.Namespace) -> int:
+    """Add `--name` to the AP field's options + cache in kanban.json#registered."""
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    try:
+        ap_registry.validate_ap_name(args.name)
+    except ap_registry.APValidationError as e:
+        _fail(str(e))
+        return 1
+
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _fail("backend.driver must be 'jira'")
+        return 1
+    jira_cfg = backend.get("jira") or {}
+    ap_block = jira_cfg.get("ap") or {}
+    field_id = ap_block.get("fieldId")
+    if not field_id:
+        _fail("AP field unconfigured — run /kanban:initjira step 4")
+        return 1
+    registered = list(ap_block.get("registered") or [])
+
+    if ap_registry.is_exact_collision(args.name, registered):
+        _emit({"ok": True, "alreadyRegistered": True, "name": args.name})
+        return 0
+
+    hits = ap_registry.fuzzy_collisions(args.name, registered)
+    if hits and not args.force:
+        _emit(
+            {
+                "ok": False,
+                "fuzzyMatch": True,
+                "name": args.name,
+                "similar": [{"name": h.name, "distance": h.distance} for h in hits],
+            }
+        )
+        return 0  # caller decides; not an error
+
+    client = _client_from_env()
+    try:
+        ctx_id = _resolve_default_context(client, field_id)
+        client.add_field_option(field_id, ctx_id, args.name)
+    except JiraError as e:
+        _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
+        return 1
+
+    registered.append(args.name)
+    ap_block["registered"] = registered
+    jira_cfg["ap"] = ap_block
+    backend["jira"] = jira_cfg
+    data["backend"] = backend
+    kanban_io.save(p, data)
+    _emit({"ok": True, "name": args.name, "registered": registered})
+    return 0
+
+
+def cmd_assign_ap(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _fail("backend.driver must be 'jira'")
+        return 1
+    registered = ((backend.get("jira") or {}).get("ap") or {}).get("registered") or []
+    if args.name not in registered:
+        _fail(
+            f"AP {args.name!r} is not registered. Register it first via "
+            f"/kanban:register-ap {args.name}",
+            registered=list(registered),
+        )
+        return 1
+
+    repo_root = p.parent
+    claude_dir = repo_root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    target = claude_dir / "kanban-agent.json"
+    target.write_text(
+        json.dumps({"ap": args.name}, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _emit({"ok": True, "ap": args.name, "path": str(target)})
+    return 0
+
+
+def cmd_read_agent_ap(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    repo_root = p.parent
+    target = repo_root / ".claude" / "kanban-agent.json"
+    if not target.exists():
+        _emit({"ap": None})
+        return 0
+    try:
+        ap = json.loads(target.read_text()).get("ap")
+    except Exception as e:  # noqa: BLE001
+        _fail(f"corrupt kanban-agent.json: {e}")
+        return 1
+    _emit({"ap": ap, "path": str(target)})
+    return 0
+
+
+def cmd_claim_next(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _fail("backend.driver must be 'jira'")
+        return 1
+    target = repo_root_ap = ((p.parent / ".claude" / "kanban-agent.json"))
+    if not target.exists():
+        _fail("this repo has no AP set — run /kanban:assign-ap <name> first")
+        return 1
+    try:
+        ap = json.loads(target.read_text()).get("ap")
+    except Exception as e:  # noqa: BLE001
+        _fail(f"corrupt kanban-agent.json: {e}")
+        return 1
+    if not ap:
+        _fail("kanban-agent.json present but `ap` is empty")
+        return 1
+
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import CommentKind, TaskFilter
+
+    driver = get_driver(data, p.parent)
+    todos = driver.list_tasks(TaskFilter(column="TODO", ap=ap, limit=1))
+    if not todos:
+        _emit({"ok": True, "claimed": None, "reason": "no TODO cards for this AP"})
+        return 0
+    pick = todos[0]
+    try:
+        driver.transition(pick.id, "DOING")
+    except Exception as e:  # noqa: BLE001
+        _fail(f"transition: {type(e).__name__}: {e}")
+        return 1
+    driver.post_comment(pick.id, "claimed", kind=CommentKind.SYSTEM)
+    refreshed = driver.get_task(pick.id)
+    _emit(
+        {
+            "ok": True,
+            "claimed": {
+                "id": refreshed.id,
+                "title": refreshed.title,
+                "priority": refreshed.priority,
+                "ap": refreshed.ap,
+            },
+        }
+    )
+    return 0
+
+
+def cmd_transition(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import CommentKind
+    from kanban.drivers.jira import SelfApproveRefused
+
+    driver = get_driver(data, p.parent)
+    kwargs: dict[str, Any] = {}
+    if args.reason:
+        kwargs["reason"] = args.reason
+    try:
+        t = driver.transition(args.key, args.to, **kwargs)
+    except SelfApproveRefused as e:
+        _fail(str(e), code=2, kind="self-approve")
+        return 2
+    except Exception as e:  # noqa: BLE001
+        _fail(f"{type(e).__name__}: {e}")
+        return 1
+    _emit({"ok": True, "key": t.id, "column": t.column, "raw_status": t.custom.get("raw_status")})
+    return 0
+
+
 def cmd_health(args: argparse.Namespace) -> int:
     p = Path(args.kanban_path)
     if not p.exists():
@@ -362,6 +658,49 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--column")
     s.add_argument("--limit", type=int)
     s.set_defaults(func=cmd_list_tasks)
+
+    s = sub.add_parser("find-ap-field")
+    s.set_defaults(func=cmd_find_ap_field)
+
+    s = sub.add_parser("create-ap-field")
+    s.add_argument("--name", default="Claude Agent")
+    s.set_defaults(func=cmd_create_ap_field)
+
+    s = sub.add_parser("set-ap-field")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--field-id", required=True)
+    s.add_argument("--field-name", required=True)
+    s.set_defaults(func=cmd_set_ap_field)
+
+    s = sub.add_parser("register-ap")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--name", required=True)
+    s.add_argument(
+        "--force",
+        action="store_true",
+        help="acknowledge fuzzy-similar names and proceed with registration",
+    )
+    s.set_defaults(func=cmd_register_ap)
+
+    s = sub.add_parser("assign-ap")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--name", required=True)
+    s.set_defaults(func=cmd_assign_ap)
+
+    s = sub.add_parser("read-agent-ap")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_read_agent_ap)
+
+    s = sub.add_parser("claim-next")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_claim_next)
+
+    s = sub.add_parser("transition")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--key", required=True)
+    s.add_argument("--to", required=True, choices=("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"))
+    s.add_argument("--reason")
+    s.set_defaults(func=cmd_transition)
 
     return p
 

--- a/plugins/kanban/scripts/kanban-card-detect.sh
+++ b/plugins/kanban/scripts/kanban-card-detect.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# kanban-card-detect.sh — UserPromptSubmit hook for Jira mode.
+#
+# Reads the prompt event JSON from stdin, scans the prompt text for Jira
+# card keys filtered by backend.jira.projectKey, runs precheck-card per
+# detected key (cached 30s), and emits an additionalContext block with one
+# section per card. Silent on:
+#   - no kanban.json
+#   - backend.driver != "jira"
+#   - no detected keys / no matches in this project
+#
+# Exits 0 always (additive context, never blocks).
+set -euo pipefail
+
+PLUGIN_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+proj="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$proj" ]; then
+  proj="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+KANBAN="$proj/kanban.json"
+[ -f "$KANBAN" ] || exit 0
+
+# Stash stdin so the python block can re-read it.
+payload="$(cat)"
+[ -z "$payload" ] && exit 0
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+KANBAN_PATH="$KANBAN" PLUGIN_LIB="$PLUGIN_LIB" PAYLOAD="$payload" \
+  python3 - <<'PY' 2>/dev/null || true
+import json, os, sys, subprocess
+sys.path.insert(0, os.environ["PLUGIN_LIB"])
+
+try:
+    from lib import card_parser, kanban_io
+except Exception:
+    raise SystemExit(0)
+
+kanban_path = os.environ["KANBAN_PATH"]
+try:
+    data = kanban_io.load(kanban_path)
+except Exception:
+    raise SystemExit(0)
+
+backend = data.get("backend") or {}
+if backend.get("driver") != "jira":
+    raise SystemExit(0)
+
+project_key = (backend.get("jira") or {}).get("projectKey") or ""
+if not project_key:
+    raise SystemExit(0)
+
+# Extract prompt text from the hook payload.
+try:
+    payload = json.loads(os.environ["PAYLOAD"])
+except Exception:
+    raise SystemExit(0)
+prompt = (payload.get("prompt") or payload.get("user_prompt") or "")
+if not isinstance(prompt, str):
+    raise SystemExit(0)
+
+keys = card_parser.extract_for_project(prompt, project_key)
+if not keys:
+    raise SystemExit(0)
+
+# Cap at 5 to keep context block bounded.
+keys = keys[:5]
+
+setup = os.path.join(os.environ["PLUGIN_LIB"], "scripts", "jira_setup.py")
+blocks = []
+for key in keys:
+    res = subprocess.run(
+        ["python3", setup, "precheck-card",
+         "--kanban-path", kanban_path,
+         "--key", key,
+         "--skip-comments"],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        continue
+    try:
+        j = json.loads(res.stdout)
+    except Exception:
+        continue
+    block = j.get("context_block")
+    if block:
+        blocks.append(block)
+
+if not blocks:
+    raise SystemExit(0)
+
+context = "\n\n".join(blocks)
+out = {
+    "hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": context,
+    }
+}
+print(json.dumps(out))
+PY
+
+exit 0

--- a/plugins/kanban/scripts/kanban-jira-sync.sh
+++ b/plugins/kanban/scripts/kanban-jira-sync.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# kanban-jira-sync.sh — SessionStart hook for Jira mode.
+#
+# When the project's kanban.json has backend.driver == "jira" AND a current
+# AP is set in .claude/kanban-agent.json, fetches the open-card summary and
+# emits it as additionalContext so the agent picks up where it left off.
+# Silent for local mode (kanban-session-check.sh covers that).
+#
+# Exits 0 always (additive context, never blocks).
+set -euo pipefail
+
+PLUGIN_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+proj="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$proj" ]; then
+  proj="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+KANBAN="$proj/kanban.json"
+[ -f "$KANBAN" ] || exit 0
+
+if ! command -v python3 >/dev/null 2>&1; then
+  exit 0
+fi
+
+KANBAN_PATH="$KANBAN" PLUGIN_LIB="$PLUGIN_LIB" python3 - <<'PY' 2>/dev/null || true
+import json, os, subprocess, sys
+sys.path.insert(0, os.environ["PLUGIN_LIB"])
+
+try:
+    from lib import kanban_io
+except Exception:
+    raise SystemExit(0)
+
+kanban_path = os.environ["KANBAN_PATH"]
+try:
+    data = kanban_io.load(kanban_path)
+except Exception:
+    raise SystemExit(0)
+
+if (data.get("backend") or {}).get("driver") != "jira":
+    raise SystemExit(0)
+
+setup = os.path.join(os.environ["PLUGIN_LIB"], "scripts", "jira_setup.py")
+res = subprocess.run(
+    ["python3", setup, "sync-summary", "--kanban-path", kanban_path],
+    capture_output=True, text=True,
+)
+if res.returncode != 0:
+    raise SystemExit(0)
+
+try:
+    j = json.loads(res.stdout)
+except Exception:
+    raise SystemExit(0)
+
+summary = j.get("summary") or ""
+if not summary.strip():
+    raise SystemExit(0)
+
+out = {
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": summary,
+    }
+}
+print(json.dumps(out))
+PY
+
+exit 0

--- a/plugins/kanban/scripts/kanban-session-check.sh
+++ b/plugins/kanban/scripts/kanban-session-check.sh
@@ -45,17 +45,36 @@ KANBAN="$proj/kanban.json"
 
 # --- Extract DOING / BLOCKED summary -----------------------------------------
 # Prefer python3 (always present on Linux/macOS). Falls back to jq.
+# In v0.2 kanban_io normalizes the file shape and surfaces backend.driver;
+# this hook only emits a summary for the local driver (jira mode lives in
+# Jira, not in this file). The PLUGIN_LIB var is passed so the python block
+# can `import` lib/kanban_io.py.
+PLUGIN_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 summary=""
 if command -v python3 >/dev/null 2>&1; then
-  summary="$(KANBAN_PATH="$KANBAN" LIGHTWEIGHT="$LIGHTWEIGHT" python3 - <<'PY' 2>/dev/null || true
-import json, os
+  summary="$(KANBAN_PATH="$KANBAN" LIGHTWEIGHT="$LIGHTWEIGHT" PLUGIN_LIB="$PLUGIN_LIB" python3 - <<'PY' 2>/dev/null || true
+import json, os, sys
+sys.path.insert(0, os.environ["PLUGIN_LIB"])
 path = os.environ["KANBAN_PATH"]
 lightweight = os.environ["LIGHTWEIGHT"] == "1"
 try:
-    with open(path) as f:
-        data = json.load(f)
+    from lib import kanban_io
+    data = kanban_io.load(path)
 except Exception:
+    # Fall back to raw json read (e.g. lib unavailable on this checkout).
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        data.setdefault("backend", {"driver": "local"})
+    except Exception:
+        raise SystemExit(0)
+
+driver = (data.get("backend") or {}).get("driver", "local")
+if driver != "local":
+    # Jira mode: live state lives in Jira, not in this file. The jira-mode
+    # hook (added in a later phase) will surface its own summary.
     raise SystemExit(0)
+
 tasks = data.get("tasks", [])
 doing = [t for t in tasks if t.get("column") == "DOING"]
 blocked = [] if lightweight else [t for t in tasks if t.get("column") == "BLOCKED"]

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run all kanban v0.2 regression suites in order. Stops on first failure.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for n in 1 2 3 4 5; do
+  echo "----- phase $n -----"
+  python3 "$DIR/test_phase$n.py"
+done
+echo "all phases passed"

--- a/plugins/kanban/scripts/test_phase1.py
+++ b/plugins/kanban/scripts/test_phase1.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Phase 1 regression checks for the kanban v0.2 driver-abstraction milestone.
+
+Run from anywhere:
+    python3 plugins/kanban/scripts/test_phase1.py
+
+Covers:
+  (a) v0.1 (`schema_version: 1`) → reader produces normalized v0.2 dict
+  (b) v0.2 → writer round-trip stable, no `schema_version` leak
+  (c) missing `backend` → defaults to {driver: local}
+  (d) credentials atomic write preserves unrelated prefixes byte-for-byte
+  (e) LocalDriver smoke test: create / transition / block / done lifecycle
+  (f) session-check.sh: surfaces local-mode tasks; emits nothing in jira mode
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins"))
+
+
+def _seed_meta() -> dict:
+    return {
+        "priorities": ["P0", "P1", "P2"],
+        "categories": [],
+        "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+        "created_at": "2026-04-29T00:00:00+08:00",
+        "updated_at": "2026-04-29T00:00:00+08:00",
+    }
+
+
+def test_kanban_io():
+    from kanban.lib import kanban_io
+
+    # (a) v0.1 normalize
+    v01 = {
+        "$schema": "./kanban.schema.json",
+        "schema_version": 1,
+        "meta": _seed_meta(),
+        "tasks": [],
+    }
+    norm = kanban_io.normalize(v01)
+    assert norm["version"] == "0.2"
+    assert norm["backend"] == {"driver": "local"}
+    assert "schema_version" not in norm
+
+    # (b) v0.2 round-trip
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        p.write_text(json.dumps(v01))
+        loaded = kanban_io.load(p)
+        kanban_io.save(p, loaded)
+        written = json.loads(p.read_text())
+        assert written["version"] == "0.2"
+        assert "schema_version" not in written
+        assert written["backend"] == {"driver": "local"}
+
+    # (c) missing backend defaults
+    bare = {"schema_version": 1, "meta": _seed_meta(), "tasks": []}
+    norm = kanban_io.normalize(bare)
+    assert norm["backend"] == {"driver": "local"}
+
+    # jira backend preserved
+    j = {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {"projectKey": "AGENT"}},
+        "meta": _seed_meta(),
+        "tasks": [],
+    }
+    norm = kanban_io.normalize(j)
+    assert norm["backend"]["driver"] == "jira"
+    assert norm["backend"]["jira"]["projectKey"] == "AGENT"
+
+
+def test_credentials_isolation():
+    from kanban.lib import credentials
+
+    with tempfile.TemporaryDirectory() as td:
+        # Override module-level paths.
+        credentials.ENV_DIR = pathlib.Path(td)
+        credentials.ENV_FILE = pathlib.Path(td) / ".env"
+
+        # Existing PUSHOVER_* lines must survive a JIRA_* write.
+        credentials.write(
+            {"PUSHOVER_USER_KEY": "uABC", "PUSHOVER_APP_TOKEN": "aXYZ"},
+            prefix="PUSHOVER_",
+        )
+        credentials.write(
+            {"JIRA_BASE_URL": "https://x.atlassian.net", "JIRA_API_TOKEN": "tok"},
+            prefix="JIRA_",
+        )
+        all_keys = credentials.read()
+        assert all_keys["PUSHOVER_USER_KEY"] == "uABC"
+        assert all_keys["PUSHOVER_APP_TOKEN"] == "aXYZ"
+        assert all_keys["JIRA_BASE_URL"] == "https://x.atlassian.net"
+
+        # Rewriting JIRA_* must not touch PUSHOVER_*.
+        credentials.write(
+            {"JIRA_BASE_URL": "https://new.atlassian.net"}, prefix="JIRA_"
+        )
+        all_keys = credentials.read()
+        assert all_keys["PUSHOVER_USER_KEY"] == "uABC"
+        assert all_keys["JIRA_BASE_URL"] == "https://new.atlassian.net"
+
+        # Wrong prefix is refused.
+        try:
+            credentials.write({"PUSHOVER_USER_KEY": "y"}, prefix="JIRA_")
+            assert False, "should have raised"
+        except ValueError:
+            pass
+
+        # Mode tightening.
+        credentials.ENV_FILE.chmod(0o644)
+        assert credentials.ensure_mode() is False
+        assert (credentials.ENV_FILE.stat().st_mode & 0o777) == 0o600
+
+
+def test_local_driver():
+    from kanban.drivers import get_driver
+    from kanban.drivers.base import HumanRef, NotSupported, TaskFilter, TaskInput
+
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        seed = {
+            "version": "0.2",
+            "backend": {"driver": "local"},
+            "meta": _seed_meta(),
+            "tasks": [],
+        }
+        (proj / "kanban.json").write_text(json.dumps(seed))
+        drv = get_driver(seed, proj)
+        assert drv.name == "local"
+
+        t = drv.create_task(TaskInput(title="hello", priority="P1"))
+        assert t.id == "task-001" and t.column == "TODO"
+        assert len(drv.list_tasks(TaskFilter(column="TODO"))) == 1
+
+        drv.transition("task-001", "DOING")
+        drv.assign("task-001", HumanRef(accountId="kirin"))
+        assert drv.get_task("task-001").assignee.accountId == "kirin"
+
+        drv.create_task(TaskInput(title="x", priority="P2"))
+        try:
+            drv.transition("task-002", "BLOCKED")
+            assert False
+        except ValueError:
+            pass
+        drv.transition("task-002", "BLOCKED", reason="waiting on infra")
+        assert drv.get_task("task-002").custom["blocked_reason"] == "waiting on infra"
+
+        drv.transition("task-001", "DONE")
+        try:
+            drv.transition("task-001", "TODO")
+            assert False
+        except ValueError:
+            pass
+
+        try:
+            drv.list_aps()
+            assert False
+        except NotSupported:
+            pass
+
+        # File still in v0.2 form after all writes.
+        on_disk = json.loads((proj / "kanban.json").read_text())
+        assert on_disk["version"] == "0.2"
+        assert on_disk["backend"] == {"driver": "local"}
+
+
+def test_session_check_hook():
+    script = PLUGIN / "scripts" / "kanban-session-check.sh"
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        data = {
+            "version": "0.2",
+            "backend": {"driver": "local"},
+            "meta": _seed_meta(),
+            "tasks": [
+                {
+                    "id": "task-001",
+                    "title": "doing thing",
+                    "column": "DOING",
+                    "priority": "P1",
+                    "created": "2026-04-29T00:00:00+08:00",
+                    "updated": "2026-04-29T00:00:00+08:00",
+                    "started": "2026-04-29T01:00:00+08:00",
+                }
+            ],
+        }
+        (proj / "kanban.json").write_text(json.dumps(data))
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(proj)
+        out = subprocess.run(
+            ["bash", str(script)], env=env, capture_output=True, text=True
+        )
+        assert out.returncode == 0, out.stderr
+        assert "task-001" in out.stdout
+
+        # jira mode → no surfacing
+        data["backend"] = {"driver": "jira"}
+        (proj / "kanban.json").write_text(json.dumps(data))
+        out = subprocess.run(
+            ["bash", str(script)], env=env, capture_output=True, text=True
+        )
+        assert out.returncode == 0
+        assert "task-001" not in out.stdout
+
+        # v0.1 legacy file
+        (proj / "kanban.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "meta": _seed_meta(),
+                    "tasks": [
+                        {
+                            "id": "task-001",
+                            "title": "legacy",
+                            "column": "DOING",
+                            "priority": "P0",
+                            "created": "2026-04-29T00:00:00+08:00",
+                            "updated": "2026-04-29T00:00:00+08:00",
+                            "started": "2026-04-29T00:00:00+08:00",
+                        }
+                    ],
+                }
+            )
+        )
+        out = subprocess.run(
+            ["bash", str(script)], env=env, capture_output=True, text=True
+        )
+        assert out.returncode == 0
+        assert "task-001" in out.stdout
+
+
+def main() -> int:
+    cases = [
+        ("kanban_io", test_kanban_io),
+        ("credentials_isolation", test_credentials_isolation),
+        ("local_driver", test_local_driver),
+        ("session_check_hook", test_session_check_hook),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase1: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase2.py
+++ b/plugins/kanban/scripts/test_phase2.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""Phase 2 regression checks for kanban v0.2.0-dev (Jira driver core).
+
+Run from anywhere:
+    python3 plugins/kanban/scripts/test_phase2.py
+
+All Jira interactions are mocked — no live network. Covers:
+  (a) jira_client retry behaviour: 429 with Retry-After, 5xx exponential
+  (b) jira_client raises immediately on 401 / non-retryable 4xx
+  (c) JiraDriver dispatch: get_driver(data with driver=jira) → JiraDriver
+  (d) JiraDriver.list_tasks builds correct JQL and parses issues
+  (e) JiraDriver.transition resolves transition_id from statusMap
+  (f) JiraDriver.post_comment prefixes per SPEC §9
+  (g) JiraDriver.list_comments parses prefix back to (ap, kind, text)
+  (h) jira_setup.parse-board-url handles both URL shapes
+  (i) jira_setup.write-backend persists backend.jira block to kanban.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins"))
+
+from kanban.lib.jira_client import (  # noqa: E402
+    JiraClient,
+    JiraError,
+    _Response,
+    text_to_adf,
+    adf_to_text,
+)
+
+
+def _mock_transport(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "headers": headers, "body": body})
+        if not queue:
+            raise AssertionError("transport queue empty")
+        return queue.pop(0)
+    return t
+
+
+# --- jira_client tests --------------------------------------------------
+
+
+def test_client_429_retry_after():
+    queue = [
+        _Response(429, b"", {"retry-after": "0.01"}),
+        _Response(200, b'{"accountId":"abc"}', {}),
+    ]
+    calls = []
+    sleeps: list[float] = []
+    c = JiraClient("https://x", "a@b", "tok", transport=_mock_transport(queue, calls), sleep=sleeps.append)
+    assert c.get_myself()["accountId"] == "abc"
+    assert sleeps == [0.01]
+    assert len(calls) == 2
+
+
+def test_client_5xx_exponential():
+    queue = [
+        _Response(503, b"", {}),
+        _Response(503, b"", {}),
+        _Response(200, b'{"id":1}', {}),
+    ]
+    calls = []
+    sleeps: list[float] = []
+    c = JiraClient("https://x", "a@b", "tok", transport=_mock_transport(queue, calls), sleep=sleeps.append)
+    assert c.get_board(1)["id"] == 1
+    assert sleeps == [0.5, 1.0]
+
+
+def test_client_401_immediate():
+    queue = [_Response(401, b'{"errorMessages":["bad token"]}', {})]
+    calls = []
+    c = JiraClient("https://x", "a@b", "tok", transport=_mock_transport(queue, calls), sleep=lambda _: None)
+    try:
+        c.get_myself()
+        assert False
+    except JiraError as e:
+        assert e.status_code == 401
+        assert "bad token" in e.detail
+    assert len(calls) == 1
+
+
+def test_client_max_retries_exhausted():
+    queue = [_Response(500, b"", {}) for _ in range(5)]
+    calls = []
+    c = JiraClient("https://x", "a@b", "tok", transport=_mock_transport(queue, calls), sleep=lambda _: None)
+    try:
+        c.get_myself()
+        assert False
+    except JiraError as e:
+        assert e.status_code == 500
+    assert len(calls) == 4
+
+
+def test_adf_round_trip():
+    adf = text_to_adf("hello")
+    assert adf_to_text(adf) == "hello"
+
+
+# --- JiraDriver tests ---------------------------------------------------
+
+
+def _mk_kanban_data(*, partial=False, label_fallback=None, ap_field=None):
+    backend = {
+        "driver": "jira",
+        "jira": {
+            "boardUrl": "https://x/boards/1",
+            "boardId": 1,
+            "projectKey": "AGENT",
+            "agentAccountId": "agent-acct",
+            "statusMap": {
+                "TODO": "To Do",
+                "DOING": "In Progress",
+                "DONE": "Done",
+            },
+            "partial": partial,
+            "labelFallback": label_fallback or {},
+        },
+    }
+    if ap_field:
+        backend["jira"]["ap"] = {"fieldId": ap_field, "fieldName": "Claude Agent", "registered": []}
+    return {
+        "version": "0.2",
+        "backend": backend,
+        "meta": {
+            "priorities": ["P0", "P1", "P2"],
+            "categories": [],
+            "columns": ["TODO", "DOING", "DONE", "BLOCKED", "REVIEW", "CANCELLED"],
+            "created_at": "2026-04-29T00:00:00+08:00",
+            "updated_at": "2026-04-29T00:00:00+08:00",
+        },
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, monkeypatch_creds=None):
+    """Build a JiraDriver with credentials mocked in via monkey-patch on
+    credentials.read."""
+    from kanban.lib import credentials
+    from kanban.drivers.jira import JiraDriver
+
+    orig_read = credentials.read
+    creds = monkeypatch_creds or {
+        "JIRA_BASE_URL": "https://x",
+        "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    credentials.read = lambda prefix=None: {k: v for k, v in creds.items() if not prefix or k.startswith(prefix)}
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            drv = JiraDriver(data, pathlib.Path(td))
+            return drv
+    finally:
+        credentials.read = orig_read
+
+
+def _attach_mock(drv, queue, calls):
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=_mock_transport(queue, calls),
+        sleep=lambda _: None,
+    )
+
+
+def test_dispatch_to_jira_driver():
+    from kanban.drivers import get_driver
+    from kanban.drivers.jira import JiraDriver
+
+    data = _mk_kanban_data()
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(data)
+        # _patched_driver builds a fresh driver with td root; here we just
+        # verify get_driver returns the right class.
+        from kanban.lib import credentials
+        orig = credentials.read
+        credentials.read = lambda prefix=None: {"JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b", "JIRA_API_TOKEN": "tok"}
+        try:
+            d2 = get_driver(data, td)
+            assert isinstance(d2, JiraDriver)
+            assert d2.name == "jira"
+        finally:
+            credentials.read = orig
+
+
+def test_list_tasks_builds_jql():
+    data = _mk_kanban_data()
+    drv = _patched_driver(data)
+    queue = [
+        _Response(
+            200,
+            json.dumps(
+                {
+                    "issues": [
+                        {
+                            "key": "AGENT-1",
+                            "fields": {
+                                "summary": "first",
+                                "status": {"name": "To Do"},
+                                "priority": {"name": "P1"},
+                                "assignee": {"accountId": "u-1"},
+                                "labels": [],
+                                "created": "2026-04-29T00:00:00+08:00",
+                                "updated": "2026-04-29T00:00:00+08:00",
+                            },
+                        }
+                    ]
+                }
+            ).encode(),
+            {},
+        )
+    ]
+    calls = []
+    _attach_mock(drv, queue, calls)
+
+    from kanban.drivers.base import TaskFilter
+
+    tasks = drv.list_tasks(TaskFilter(column="TODO", limit=10))
+    assert len(tasks) == 1
+    t = tasks[0]
+    assert t.id == "AGENT-1" and t.column == "TODO" and t.title == "first"
+    sent = json.loads(calls[0]["body"])
+    assert 'project = "AGENT"' in sent["jql"]
+    assert 'status = "To Do"' in sent["jql"]
+    assert sent["maxResults"] == 10
+
+
+def test_transition_resolves_id():
+    data = _mk_kanban_data()
+    drv = _patched_driver(data)
+    # 1) get_transitions, 2) transition_issue, 3) get_issue (after-transition refresh)
+    queue = [
+        _Response(
+            200,
+            json.dumps(
+                {
+                    "transitions": [
+                        {"id": "21", "to": {"name": "In Progress"}},
+                        {"id": "31", "to": {"name": "Done"}},
+                    ]
+                }
+            ).encode(),
+            {},
+        ),
+        _Response(204, b"", {}),
+        _Response(
+            200,
+            json.dumps(
+                {
+                    "key": "AGENT-1",
+                    "fields": {
+                        "summary": "first",
+                        "status": {"name": "In Progress"},
+                        "priority": {"name": "P1"},
+                        "assignee": None,
+                        "labels": [],
+                        "created": "x",
+                        "updated": "y",
+                    },
+                }
+            ).encode(),
+            {},
+        ),
+    ]
+    calls = []
+    _attach_mock(drv, queue, calls)
+
+    t = drv.transition("AGENT-1", "DOING")
+    assert t.column == "DOING"
+    # Second call must be the transition POST with id=21
+    assert calls[1]["method"] == "POST"
+    sent = json.loads(calls[1]["body"])
+    assert sent["transition"]["id"] == "21"
+
+
+def test_transition_unknown_column_raises():
+    data = _mk_kanban_data()
+    drv = _patched_driver(data)
+    try:
+        drv.transition("AGENT-1", "NOPE")
+        assert False
+    except ValueError:
+        pass
+
+
+def test_post_comment_prefixes():
+    data = _mk_kanban_data()
+    drv = _patched_driver(data)
+    queue = [_Response(201, b'{"created":"2026-04-29T00:00:00+08:00"}', {})]
+    calls = []
+    _attach_mock(drv, queue, calls)
+
+    from kanban.drivers.base import CommentKind
+
+    drv.post_comment("AGENT-1", "Body of question?", CommentKind.QUESTION)
+    sent = json.loads(calls[0]["body"])
+    body_text = adf_to_text(sent["body"])
+    assert body_text.startswith("**[")
+    assert "[Q]" in body_text
+    assert "Body of question?" in body_text
+
+
+def test_list_comments_parses_prefix():
+    data = _mk_kanban_data()
+    drv = _patched_driver(data)
+    # Compose a Jira response with one prefixed agent comment + one human reply
+    queue = [
+        _Response(
+            200,
+            json.dumps(
+                {
+                    "comments": [
+                        {
+                            "author": {"displayName": "Agent Bot"},
+                            "created": "2026-04-29T00:00:00+08:00",
+                            "body": text_to_adf("**[agent-fin] [Q]**\n\nIs the API stable?"),
+                        },
+                        {
+                            "author": {"displayName": "Alice"},
+                            "created": "2026-04-29T00:01:00+08:00",
+                            "body": text_to_adf("Yes, locked in."),
+                        },
+                    ]
+                }
+            ).encode(),
+            {},
+        )
+    ]
+    calls = []
+    _attach_mock(drv, queue, calls)
+
+    comments = drv.list_comments("AGENT-1")
+    assert len(comments) == 2
+    assert comments[0].author == "agent-fin"
+    assert comments[0].kind.value == "Q"
+    assert "Is the API stable?" in comments[0].text
+    assert comments[1].author == "Alice"
+
+
+# --- jira_setup CLI tests -----------------------------------------------
+
+
+def _setup_cmd(*args, stdin: bytes = b"") -> subprocess.CompletedProcess:
+    cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
+    return subprocess.run(cmd, input=stdin, capture_output=True)
+
+
+def test_parse_board_url():
+    out = _setup_cmd("parse-board-url", "--url", "https://x/jira/software/projects/AGENT/boards/1")
+    assert out.returncode == 0, out.stderr
+    j = json.loads(out.stdout)
+    assert j == {"projectKey": "AGENT", "boardId": 1}
+
+    out = _setup_cmd("parse-board-url", "--url", "https://x/jira/software/c/projects/FIN/boards/42")
+    j = json.loads(out.stdout)
+    assert j == {"projectKey": "FIN", "boardId": 42}
+
+    out = _setup_cmd("parse-board-url", "--url", "https://example.com/garbage")
+    assert out.returncode != 0
+
+
+def test_write_backend():
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        seed = {
+            "version": "0.2",
+            "backend": {"driver": "local"},
+            "meta": {
+                "priorities": ["P0", "P1"],
+                "categories": [],
+                "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+                "created_at": "x",
+                "updated_at": "x",
+            },
+            "tasks": [],
+        }
+        kp.write_text(json.dumps(seed))
+
+        cfg = {
+            "boardUrl": "https://x/boards/1",
+            "boardId": 1,
+            "projectKey": "AGENT",
+            "agentAccountId": "acct-x",
+            "statusMap": {"TODO": "To Do", "DOING": "In Progress", "DONE": "Done"},
+            "partial": True,
+            "labelFallback": {"BLOCKED": "kanban:blocked"},
+        }
+        out = _setup_cmd(
+            "write-backend",
+            "--kanban-path",
+            str(kp),
+            "--jira-config-json",
+            json.dumps(cfg),
+        )
+        assert out.returncode == 0, out.stderr
+        on_disk = json.loads(kp.read_text())
+        assert on_disk["backend"]["driver"] == "jira"
+        assert on_disk["backend"]["jira"]["projectKey"] == "AGENT"
+        # columns extended to canonical 6
+        assert set(on_disk["meta"]["columns"]) == {
+            "TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"
+        }
+
+
+# --- entry point --------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("client_429_retry_after", test_client_429_retry_after),
+        ("client_5xx_exponential", test_client_5xx_exponential),
+        ("client_401_immediate", test_client_401_immediate),
+        ("client_max_retries_exhausted", test_client_max_retries_exhausted),
+        ("adf_round_trip", test_adf_round_trip),
+        ("dispatch_to_jira_driver", test_dispatch_to_jira_driver),
+        ("list_tasks_builds_jql", test_list_tasks_builds_jql),
+        ("transition_resolves_id", test_transition_resolves_id),
+        ("transition_unknown_column_raises", test_transition_unknown_column_raises),
+        ("post_comment_prefixes", test_post_comment_prefixes),
+        ("list_comments_parses_prefix", test_list_comments_parses_prefix),
+        ("parse_board_url", test_parse_board_url),
+        ("write_backend", test_write_backend),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase2: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase3.py
+++ b/plugins/kanban/scripts/test_phase3.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Phase 3 regression checks for kanban v0.2 (AP routing + anti-self-approve).
+
+Run from anywhere:
+    python3 plugins/kanban/scripts/test_phase3.py
+
+Mocked Jira; no live network. Covers:
+  (a) ap_registry validate / levenshtein / fuzzy_collisions / is_exact_collision
+  (b) JiraDriver.list_aps reads kanban.json#backend.jira.ap.registered
+  (c) JiraDriver.assign(AgentRef) writes the AP custom field via update_issue
+  (d) JiraDriver.transition refuses DONE when task.ap == current_repo_ap
+  (e) JiraDriver.transition allows DONE when task.ap differs from repo AP
+  (f) jira_setup register-ap on fuzzy match returns ok=false + similar list
+  (g) jira_setup register-ap with --force registers via mocked Jira (option add)
+       and persists in kanban.json
+  (h) jira_setup assign-ap writes .claude/kanban-agent.json with right path
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins"))
+
+from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+def _mock_transport(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError("queue empty")
+        return queue.pop(0)
+    return t
+
+
+def _mk_data(ap_field_id="customfield_10042", registered=None, partial=False):
+    return {
+        "version": "0.2",
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "boardUrl": "https://x/boards/1",
+                "boardId": 1,
+                "projectKey": "AGENT",
+                "agentAccountId": "agent-acct",
+                "statusMap": {
+                    "TODO": "To Do",
+                    "DOING": "In Progress",
+                    "DONE": "Done",
+                    "REVIEW": "In Review",
+                    "BLOCKED": "Blocked",
+                    "CANCELLED": "Cancelled",
+                },
+                "partial": partial,
+                "ap": {
+                    "fieldId": ap_field_id,
+                    "fieldName": "Claude Agent",
+                    "registered": list(registered or []),
+                },
+            },
+        },
+        "meta": {
+            "priorities": ["P0", "P1"],
+            "categories": [],
+            "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+            "created_at": "x",
+            "updated_at": "x",
+        },
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    """Return a JiraDriver with credentials.read mocked."""
+    from kanban.drivers.jira import JiraDriver
+    from kanban.lib import credentials
+
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x",
+        "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=_mock_transport(queue, calls),
+        sleep=lambda _: None,
+    )
+
+
+# --- ap_registry tests ---------------------------------------------------
+
+
+def test_ap_registry():
+    from kanban.lib import ap_registry as ap
+
+    ap.validate_ap_name("agent-fin-exchange")
+    for bad in ("", "A", "ab", "1agent", "agent_x", "-agent", "a"*42):
+        try:
+            ap.validate_ap_name(bad)
+            assert False, f"should reject {bad!r}"
+        except ap.APValidationError:
+            pass
+
+    assert ap.levenshtein("agent-fin", "agent-fin") == 0
+    assert ap.levenshtein("agent-fin", "agent-fix") == 1
+    assert ap.levenshtein("", "abc") == 3
+
+    hits = ap.fuzzy_collisions("agent-fix", ["agent-fin"], threshold=2)
+    assert len(hits) == 1 and hits[0].distance == 1
+
+    assert ap.is_exact_collision("AGENT-FIN", ["agent-fin"])
+    assert not ap.is_exact_collision("agent-fix", ["agent-fin"])
+
+
+# --- driver tests --------------------------------------------------------
+
+
+def test_list_aps_from_kanban():
+    with tempfile.TemporaryDirectory() as td:
+        data = _mk_data(registered=["agent-fin", "agent-quant"])
+        drv = _patched_driver(data, pathlib.Path(td))
+        assert drv.list_aps() == ["agent-fin", "agent-quant"]
+
+
+def test_assign_agent_writes_custom_field():
+    with tempfile.TemporaryDirectory() as td:
+        data = _mk_data(registered=["agent-fin"])
+        drv = _patched_driver(data, pathlib.Path(td))
+        # update_issue (custom field) → assignee (shared agent acct) → get_task
+        queue = [
+            _Response(204, b"", {}),
+            _Response(204, b"", {}),
+            _Response(
+                200,
+                json.dumps(
+                    {
+                        "key": "AGENT-1",
+                        "fields": {
+                            "summary": "x",
+                            "status": {"name": "To Do"},
+                            "priority": {"name": "P1"},
+                            "assignee": None,
+                            "labels": [],
+                            "created": "x",
+                            "updated": "y",
+                            "customfield_10042": {"value": "agent-fin"},
+                        },
+                    }
+                ).encode(),
+                {},
+            ),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        from kanban.drivers.base import AgentRef
+
+        result = drv.assign("AGENT-1", AgentRef(ap="agent-fin"))
+        assert result.ap == "agent-fin"
+        # First call writes the AP custom field
+        sent = json.loads(calls[0]["body"])
+        assert calls[0]["method"] == "PUT"
+        assert sent["fields"]["customfield_10042"] == {"value": "agent-fin"}
+        # Second call sets assignee to shared agent account
+        sent2 = json.loads(calls[1]["body"])
+        assert sent2["accountId"] == "agent-acct"
+
+
+def test_transition_refuses_self_approve():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        # Pre-write .claude/kanban-agent.json so _current_repo_ap returns it.
+        (proj / ".claude").mkdir()
+        (proj / ".claude" / "kanban-agent.json").write_text(
+            json.dumps({"ap": "agent-fin"})
+        )
+        data = _mk_data(registered=["agent-fin"])
+        drv = _patched_driver(data, proj)
+
+        # _current_repo_ap → "agent-fin"; pre-flight get_task returns task.ap = agent-fin.
+        queue = [
+            _Response(
+                200,
+                json.dumps(
+                    {
+                        "key": "AGENT-1",
+                        "fields": {
+                            "summary": "x",
+                            "status": {"name": "In Review"},
+                            "priority": {"name": "P1"},
+                            "assignee": None,
+                            "labels": [],
+                            "created": "x",
+                            "updated": "y",
+                            "customfield_10042": {"value": "agent-fin"},
+                        },
+                    }
+                ).encode(),
+                {},
+            ),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        from kanban.drivers.jira import SelfApproveRefused
+
+        try:
+            drv.transition("AGENT-1", "DONE")
+            assert False, "should have refused"
+        except SelfApproveRefused as e:
+            assert "agent-fin" in str(e)
+        # No transition POST was made — only the pre-flight get_task ran.
+        assert len(calls) == 1
+
+
+def test_transition_allows_when_ap_differs():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        (proj / ".claude").mkdir()
+        (proj / ".claude" / "kanban-agent.json").write_text(
+            json.dumps({"ap": "agent-fin"})
+        )
+        data = _mk_data(registered=["agent-fin", "agent-quant"])
+        drv = _patched_driver(data, proj)
+
+        # 1) pre-flight get_task: card owned by a different AP
+        # 2) get_transitions
+        # 3) transition_issue
+        # 4) post_comment (none — no BLOCKED reason; skipped)
+        # 5) get_task post-transition
+        queue = [
+            _Response(
+                200,
+                json.dumps(
+                    {
+                        "key": "AGENT-1",
+                        "fields": {
+                            "summary": "x",
+                            "status": {"name": "In Review"},
+                            "priority": {"name": "P1"},
+                            "assignee": None,
+                            "labels": [],
+                            "created": "x",
+                            "updated": "y",
+                            "customfield_10042": {"value": "agent-quant"},
+                        },
+                    }
+                ).encode(),
+                {},
+            ),
+            _Response(
+                200,
+                json.dumps(
+                    {"transitions": [{"id": "31", "to": {"name": "Done"}}]}
+                ).encode(),
+                {},
+            ),
+            _Response(204, b"", {}),
+            _Response(
+                200,
+                json.dumps(
+                    {
+                        "key": "AGENT-1",
+                        "fields": {
+                            "summary": "x",
+                            "status": {"name": "Done"},
+                            "priority": {"name": "P1"},
+                            "assignee": None,
+                            "labels": [],
+                            "created": "x",
+                            "updated": "z",
+                            "customfield_10042": {"value": "agent-quant"},
+                        },
+                    }
+                ).encode(),
+                {},
+            ),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        t = drv.transition("AGENT-1", "DONE")
+        assert t.column == "DONE"
+
+
+# --- jira_setup CLI tests ------------------------------------------------
+
+
+def _setup_cmd(*args, env_extra=None):
+    cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(cmd, capture_output=True, env=env)
+
+
+def test_register_ap_fuzzy_no_force():
+    """register-ap on a near-duplicate without --force returns ok=false."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps(_mk_data(registered=["agent-fin"])))
+
+        out = _setup_cmd(
+            "register-ap", "--kanban-path", str(kp), "--name", "agent-fix"
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is False
+        assert j["fuzzyMatch"] is True
+        assert any(s["name"] == "agent-fin" and s["distance"] == 1 for s in j["similar"])
+
+
+def test_assign_ap_writes_file():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        kp = proj / "kanban.json"
+        kp.write_text(json.dumps(_mk_data(registered=["agent-fin"])))
+
+        out = _setup_cmd(
+            "assign-ap", "--kanban-path", str(kp), "--name", "agent-fin"
+        )
+        assert out.returncode == 0, out.stderr
+        target = proj / ".claude" / "kanban-agent.json"
+        assert target.exists()
+        j = json.loads(target.read_text())
+        assert j["ap"] == "agent-fin"
+
+        # Refuse unregistered AP.
+        out = _setup_cmd(
+            "assign-ap", "--kanban-path", str(kp), "--name", "agent-other"
+        )
+        assert out.returncode != 0
+
+
+def test_register_ap_validates_name():
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps(_mk_data(registered=[])))
+
+        out = _setup_cmd(
+            "register-ap", "--kanban-path", str(kp), "--name", "Bad Name"
+        )
+        assert out.returncode != 0
+        j = json.loads(out.stdout)
+        assert j["ok"] is False
+        assert "AP" in j["error"] or "match" in j["error"]
+
+
+# --- entry point ---------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("ap_registry", test_ap_registry),
+        ("list_aps_from_kanban", test_list_aps_from_kanban),
+        ("assign_agent_writes_custom_field", test_assign_agent_writes_custom_field),
+        ("transition_refuses_self_approve", test_transition_refuses_self_approve),
+        ("transition_allows_when_ap_differs", test_transition_allows_when_ap_differs),
+        ("register_ap_fuzzy_no_force", test_register_ap_fuzzy_no_force),
+        ("assign_ap_writes_file", test_assign_ap_writes_file),
+        ("register_ap_validates_name", test_register_ap_validates_name),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase3: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase4.py
+++ b/plugins/kanban/scripts/test_phase4.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Phase 4 regression checks for kanban v0.2 (auto-detect, sync, cache).
+
+Run from anywhere:
+    python3 plugins/kanban/scripts/test_phase4.py
+
+Mocked Jira; no live network. Covers:
+  (a) card_parser KEY + URL extraction with project-key filter and dedup
+  (b) card_cache fresh / TTL-expired / invalidate / clear
+  (c) JiraDriver.transition invalidates the cache after success
+  (d) precheck-card returns ap-mismatch warning when AP differs
+  (e) precheck-card honours cache hit (no second Jira fetch)
+  (f) sync-summary renders open-card lines for the current AP
+  (g) hook kanban-card-detect.sh emits additionalContext when card found
+  (h) hook kanban-jira-sync.sh emits sync summary on SessionStart
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import time
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins"))
+
+from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+def _mk_data(*, registered=("agent-fin",), partial=False):
+    return {
+        "version": "0.2",
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "boardUrl": "https://x/boards/1",
+                "boardId": 1,
+                "projectKey": "AGENT",
+                "agentAccountId": "agent-acct",
+                "statusMap": {
+                    "TODO": "To Do",
+                    "DOING": "In Progress",
+                    "DONE": "Done",
+                    "REVIEW": "In Review",
+                    "BLOCKED": "Blocked",
+                    "CANCELLED": "Cancelled",
+                },
+                "partial": partial,
+                "ap": {
+                    "fieldId": "customfield_10042",
+                    "fieldName": "Claude Agent",
+                    "registered": list(registered),
+                },
+            },
+        },
+        "meta": {
+            "priorities": ["P0", "P1"],
+            "categories": [],
+            "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+            "created_at": "x",
+            "updated_at": "x",
+        },
+        "tasks": [],
+    }
+
+
+def _seed_repo(td, *, ap="agent-fin", data=None):
+    proj = pathlib.Path(td)
+    (proj / ".claude").mkdir(parents=True, exist_ok=True)
+    (proj / ".claude" / "kanban-agent.json").write_text(json.dumps({"ap": ap}))
+    (proj / "kanban.json").write_text(json.dumps(data if data is not None else _mk_data()))
+    return proj
+
+
+def _setup_cmd(*args, env_extra=None):
+    cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(cmd, capture_output=True, env=env)
+
+
+# --- card_parser ---------------------------------------------------------
+
+
+def test_card_parser():
+    from kanban.lib import card_parser
+
+    assert card_parser.extract_keys("see AGENT-42 and FIN-103") == ["AGENT-42", "FIN-103"]
+    assert card_parser.extract_keys("AGENT-42 AGENT-42") == ["AGENT-42"]
+    keys = card_parser.extract_keys(
+        "see https://x.atlassian.net/browse/AGENT-7 plus AGENT-9 also "
+        "https://x.atlassian.net/board?selectedIssue=AGENT-12"
+    )
+    assert keys == ["AGENT-7", "AGENT-9", "AGENT-12"]
+    assert card_parser.extract_for_project(
+        "AGENT-1 FIN-3 AGENT-4", "AGENT"
+    ) == ["AGENT-1", "AGENT-4"]
+    assert card_parser.extract_keys("AGENT-42x") == []
+
+
+# --- card_cache ----------------------------------------------------------
+
+
+def test_card_cache():
+    from kanban.lib import card_cache
+
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td)
+        assert card_cache.get(p, "AGENT-1") is None
+        card_cache.put(p, "AGENT-1", {"col": "TODO"})
+        assert card_cache.get(p, "AGENT-1") == {"col": "TODO"}
+        assert card_cache.get(p, "AGENT-1", ttl=0) is None  # immediate expiry
+        card_cache.invalidate(p, "AGENT-1")
+        assert card_cache.get(p, "AGENT-1") is None
+        card_cache.put(p, "AGENT-3", {"x": 1})
+        card_cache.clear(p)
+        assert card_cache.get(p, "AGENT-3") is None
+
+
+# --- driver invalidates cache on writes ---------------------------------
+
+
+def _patched_driver(data, project_root):
+    from kanban.drivers.jira import JiraDriver
+    from kanban.lib import credentials
+
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x",
+        "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        return queue.pop(0)
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token, transport=t, sleep=lambda _: None
+    )
+
+
+def test_driver_invalidates_cache_on_transition():
+    from kanban.lib import card_cache
+
+    with tempfile.TemporaryDirectory() as td:
+        proj = _seed_repo(td, ap="agent-quant")
+        data = _mk_data(registered=("agent-fin", "agent-quant"))
+        drv = _patched_driver(data, proj)
+        # Warm the cache.
+        card_cache.put(proj, "AGENT-1", {"col": "TODO"})
+        assert card_cache.get(proj, "AGENT-1") is not None
+
+        # transition(DOING) call chain (anti-self-approve only fires for DONE):
+        # 1) get_transitions
+        # 2) transition_issue (POST)
+        # 3) get_task (post-transition refresh)
+        queue = [
+            _Response(
+                200,
+                json.dumps(
+                    {"transitions": [{"id": "21", "to": {"name": "In Progress"}}]}
+                ).encode(),
+                {},
+            ),
+            _Response(204, b"", {}),
+            _Response(
+                200,
+                json.dumps(
+                    {
+                        "key": "AGENT-1",
+                        "fields": {
+                            "summary": "x",
+                            "status": {"name": "In Progress"},
+                            "priority": {"name": "P1"},
+                            "assignee": None,
+                            "labels": [],
+                            "created": "x",
+                            "updated": "y",
+                            "customfield_10042": {"value": "agent-fin"},
+                        },
+                    }
+                ).encode(),
+                {},
+            ),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("AGENT-1", "DOING")
+        # Cache should now be empty for AGENT-1.
+        assert card_cache.get(proj, "AGENT-1") is None
+
+
+# --- precheck-card --------------------------------------------------------
+
+
+def test_precheck_card_ap_mismatch():
+    """precheck-card emits ap-mismatch when the cached card is owned by another AP."""
+    from kanban.lib import card_cache, kanban_io
+
+    with tempfile.TemporaryDirectory() as td:
+        proj = _seed_repo(td, ap="agent-fin")
+        # Pre-seed the cache so precheck doesn't make a Jira call.
+        card_cache.put(
+            proj,
+            "AGENT-9",
+            {
+                "id": "AGENT-9",
+                "title": "shared concern",
+                "column": "DOING",
+                "ap": "agent-quant",
+                "priority": "P1",
+                "custom": {"raw_status": "In Progress"},
+                "last_open_question": None,
+            },
+        )
+        out = _setup_cmd(
+            "precheck-card",
+            "--kanban-path", str(proj / "kanban.json"),
+            "--key", "AGENT-9",
+            "--skip-comments",
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["found"] is True
+        assert j["from_cache"] is True
+        assert "ap-mismatch" in j["warnings"]
+        assert "agent-quant" in j["context_block"]
+        assert "agent-fin" in j["context_block"]
+
+
+def test_precheck_card_filters_out_other_projects():
+    with tempfile.TemporaryDirectory() as td:
+        proj = _seed_repo(td)
+        out = _setup_cmd(
+            "precheck-card",
+            "--kanban-path", str(proj / "kanban.json"),
+            "--key", "FIN-1",
+            "--skip-comments",
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j.get("ignored") is True
+        assert j["context_block"] == ""
+
+
+# --- sync-summary ---------------------------------------------------------
+
+
+def test_sync_summary_local_skipped():
+    """sync-summary on local-mode kanban returns a skip marker, no error."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        (proj / "kanban.json").write_text(
+            json.dumps(
+                {
+                    "version": "0.2",
+                    "backend": {"driver": "local"},
+                    "meta": {
+                        "priorities": ["P0"],
+                        "categories": [],
+                        "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+                        "created_at": "x",
+                        "updated_at": "x",
+                    },
+                    "tasks": [],
+                }
+            )
+        )
+        out = _setup_cmd(
+            "sync-summary", "--kanban-path", str(proj / "kanban.json")
+        )
+        assert out.returncode == 0
+        j = json.loads(out.stdout)
+        assert j["summary"] == ""
+        assert j.get("skip")
+
+
+# --- hooks ----------------------------------------------------------------
+
+
+def test_card_detect_hook_emits_context():
+    """kanban-card-detect.sh injects a context block when a card key is in the prompt."""
+    from kanban.lib import card_cache
+
+    with tempfile.TemporaryDirectory() as td:
+        proj = _seed_repo(td)
+        # Pre-seed so the hook doesn't actually call Jira.
+        card_cache.put(
+            proj,
+            "AGENT-42",
+            {
+                "id": "AGENT-42",
+                "title": "concern",
+                "column": "REVIEW",
+                "ap": "agent-fin",
+                "priority": "P1",
+                "custom": {"raw_status": "In Review"},
+                "last_open_question": None,
+            },
+        )
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(proj)
+        payload = json.dumps({"prompt": "please look at AGENT-42 thanks"})
+        out = subprocess.run(
+            ["bash", str(PLUGIN / "scripts" / "kanban-card-detect.sh")],
+            input=payload,
+            text=True,
+            env=env,
+            capture_output=True,
+        )
+        assert out.returncode == 0, out.stderr
+        # The hook either prints a JSON object with hookSpecificOutput, or
+        # nothing if the prompt has no recognisable key.
+        assert "AGENT-42" in out.stdout, out.stdout
+        # Should NOT panic on missing project key for unrelated mentions.
+        env2 = dict(env)
+        out2 = subprocess.run(
+            ["bash", str(PLUGIN / "scripts" / "kanban-card-detect.sh")],
+            input=json.dumps({"prompt": "no card here"}),
+            text=True,
+            env=env2,
+            capture_output=True,
+        )
+        assert out2.returncode == 0
+        assert out2.stdout == "" or "AGENT-" not in out2.stdout
+
+
+def test_jira_sync_hook_silent_for_local():
+    """kanban-jira-sync.sh is silent for local-mode projects."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        (proj / "kanban.json").write_text(
+            json.dumps(
+                {
+                    "version": "0.2",
+                    "backend": {"driver": "local"},
+                    "meta": {
+                        "priorities": ["P0"],
+                        "categories": [],
+                        "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+                        "created_at": "x",
+                        "updated_at": "x",
+                    },
+                    "tasks": [],
+                }
+            )
+        )
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(proj)
+        out = subprocess.run(
+            ["bash", str(PLUGIN / "scripts" / "kanban-jira-sync.sh")],
+            env=env, capture_output=True, text=True,
+        )
+        assert out.returncode == 0
+        assert out.stdout == ""
+
+
+# --- entry point ----------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("card_parser", test_card_parser),
+        ("card_cache", test_card_cache),
+        ("driver_invalidates_cache_on_transition", test_driver_invalidates_cache_on_transition),
+        ("precheck_card_ap_mismatch", test_precheck_card_ap_mismatch),
+        ("precheck_card_filters_out_other_projects", test_precheck_card_filters_out_other_projects),
+        ("sync_summary_local_skipped", test_sync_summary_local_skipped),
+        ("card_detect_hook_emits_context", test_card_detect_hook_emits_context),
+        ("jira_sync_hook_silent_for_local", test_jira_sync_hook_silent_for_local),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase4: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase5.py
+++ b/plugins/kanban/scripts/test_phase5.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Phase 5 regression checks for kanban v0.2 (MCP scan, migration, label round-trip).
+
+Run from anywhere:
+    python3 plugins/kanban/scripts/test_phase5.py
+
+Mocked Jira; no live network. Covers:
+  (a) mcp_conflict_scan picks up matches on name / command / args / url
+  (b) mcp-conflict-scan CLI returns JSON list with absolute source paths
+  (c) import-tasks --dry-run lists what would be imported, writes nothing
+  (d) import-tasks (live) creates Jira issues for TODO/DOING; skips DONE
+       unless --include-done; idempotent on re-run
+  (e) JiraDriver._issue_to_task in partial mode reads back kanban:* labels
+       to canonical columns
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins"))
+
+from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+# --- mcp_conflict_scan tests ---------------------------------------------
+
+
+def test_mcp_scan_matches_keywords():
+    from kanban.lib.mcp_conflict_scan import _scan_servers
+
+    blob = {
+        "mcpServers": {
+            "atlassian-rovo": {"command": "rovo-cli"},
+            "tracker": {"url": "https://x.atlassian.net/api"},
+            "jira-mcp": {"args": ["--base", "x"]},
+            "rovo-args": {"command": "node", "args": ["/path/to/rovo.js"]},
+            "unrelated": {"command": "foo"},
+        }
+    }
+    hits = _scan_servers(blob, pathlib.Path("/x/settings.json"))
+    matched = {h.server_name: h.matched_on for h in hits}
+    assert matched["atlassian-rovo"] == "name"
+    assert matched["tracker"] == "url"
+    assert matched["jira-mcp"] == "name"
+    assert matched["rovo-args"] == "name"
+    assert "unrelated" not in matched
+
+
+def test_mcp_scan_cli():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        (proj / ".claude").mkdir()
+        (proj / ".claude" / "settings.json").write_text(
+            json.dumps({"mcpServers": {"atlassian-rovo": {"command": "x"}}})
+        )
+        (proj / "kanban.json").write_text(json.dumps({
+            "version": "0.2", "backend": {"driver": "jira"},
+            "meta": {"priorities": ["P0"], "categories": [],
+                     "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+                     "created_at": "x", "updated_at": "x"},
+            "tasks": []
+        }))
+        out = subprocess.run(
+            ["python3", str(PLUGIN / "scripts" / "jira_setup.py"),
+             "mcp-conflict-scan", "--kanban-path", str(proj / "kanban.json")],
+            capture_output=True, text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        names = {c["server"] for c in j["conflicts"]}
+        assert "atlassian-rovo" in names
+
+
+# --- migration importer tests --------------------------------------------
+
+
+def _seed_v01_kanban(td) -> pathlib.Path:
+    """v0.1 file with mixed-status tasks."""
+    p = pathlib.Path(td) / "kanban.json"
+    legacy = {
+        "schema_version": 1,
+        "meta": {
+            "priorities": ["P0", "P1", "P2"],
+            "categories": [],
+            "columns": ["TODO", "DOING", "DONE", "BLOCKED"],
+            "created_at": "x",
+            "updated_at": "x",
+        },
+        "tasks": [
+            {
+                "id": "task-001",
+                "title": "todo work",
+                "column": "TODO",
+                "priority": "P1",
+                "tags": ["infra"],
+                "created": "x", "updated": "y",
+            },
+            {
+                "id": "task-002",
+                "title": "doing work",
+                "column": "DOING",
+                "priority": "P2",
+                "tags": [],
+                "created": "x", "updated": "y",
+                "started": "y",
+            },
+            {
+                "id": "task-003",
+                "title": "old work",
+                "column": "DONE",
+                "priority": "P0",
+                "tags": [],
+                "created": "x", "updated": "y",
+                "started": "y",
+                "completed": "y",
+            },
+        ],
+    }
+    p.write_text(json.dumps(legacy))
+    return p
+
+
+def _make_jira_data():
+    """v0.2 jira-mode wrapper around an empty tasks list."""
+    return {
+        "version": "0.2",
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "boardUrl": "https://x/boards/1",
+                "boardId": 1,
+                "projectKey": "AGENT",
+                "agentAccountId": "agent-acct",
+                "statusMap": {
+                    "TODO": "To Do", "DOING": "In Progress", "DONE": "Done",
+                    "BLOCKED": "Blocked", "REVIEW": "In Review", "CANCELLED": "Cancelled",
+                },
+                "ap": {
+                    "fieldId": "customfield_10042",
+                    "fieldName": "Claude Agent",
+                    "registered": ["agent-fin"],
+                },
+            },
+        },
+        "meta": {
+            "priorities": ["P0", "P1", "P2"],
+            "categories": [],
+            "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+            "created_at": "x", "updated_at": "x",
+        },
+        "tasks": [],
+    }
+
+
+def test_import_tasks_dry_run():
+    """--dry-run lists tasks without creating Jira issues or writing the map."""
+    with tempfile.TemporaryDirectory() as td:
+        # Seed the file as a v0.2 jira-mode kanban with legacy tasks left in place.
+        p = pathlib.Path(td) / "kanban.json"
+        data = _make_jira_data()
+        # Inject legacy tasks (simulating mid-migration state).
+        data["tasks"] = json.loads(_seed_v01_kanban(td).read_text())["tasks"]
+        p.write_text(json.dumps(data))
+
+        out = subprocess.run(
+            ["python3", str(PLUGIN / "scripts" / "jira_setup.py"),
+             "import-tasks", "--kanban-path", str(p), "--dry-run"],
+            capture_output=True, text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        assert j["dryRun"] is True
+        # TODO + DOING would be imported; DONE skipped.
+        ids = [t["id"] for t in j["tasks"]]
+        assert "task-001" in ids and "task-002" in ids
+        assert "task-003" not in ids
+        # Map file must NOT be written for dry-run.
+        assert not (pathlib.Path(td) / ".claude" / ".migration-map.json").exists()
+
+
+def test_import_tasks_idempotent():
+    """Live import creates Jira issues; second run reports skipped/already-mapped."""
+    from kanban.drivers.jira import JiraDriver
+    from kanban.lib import credentials
+
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        data = _make_jira_data()
+        data["tasks"] = json.loads(_seed_v01_kanban(td).read_text())["tasks"]
+        p.write_text(json.dumps(data))
+
+        # We need to mock JiraDriver.create_task so import-tasks doesn't hit
+        # the network. The simplest way: patch credentials.read so the
+        # driver builds its client, then monkey-patch driver class. But
+        # import-tasks runs in a subprocess. Workaround: provide a tiny
+        # in-process import path instead of the CLI, which is enough for
+        # this integration test.
+        env = dict(os.environ)
+        # Set fake credentials so JiraClient construction succeeds (but it
+        # never actually fires; we monkey-patch create_task in a sec).
+        creds_dir = pathlib.Path(td) / "fake-cw"
+        creds_dir.mkdir()
+        env["HOME"] = str(creds_dir)
+        creds_dir_inner = creds_dir / ".claude-workbench"
+        creds_dir_inner.mkdir()
+        (creds_dir_inner / ".env").write_text(
+            "JIRA_BASE_URL=https://x\nJIRA_AGENT_EMAIL=a@b\nJIRA_API_TOKEN=tok\n"
+        )
+        os.chmod(creds_dir_inner / ".env", 0o600)
+
+        # Hack the subprocess by setting JIRA_FAKE_DRIVER=1 and patching
+        # create_task within the helper. To keep things simple here, run
+        # import-tasks in-process instead of subprocess.
+        sys.path.insert(0, str(REPO / "plugins"))
+
+        from kanban.drivers import base as base_mod  # noqa: F401
+        from kanban.scripts import jira_setup  # type: ignore[import-not-found]
+
+        # That `from kanban.scripts import` will fail because kanban/scripts
+        # is not a package. Fall back to importing the module via path.
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+
+        # Patch JiraDriver.create_task to a fake.
+        from kanban.drivers.jira import JiraDriver as Jd
+        from kanban.drivers.base import Task
+
+        counter = {"n": 100}
+        created: list[str] = []
+
+        def fake_create(self, task_input):
+            counter["n"] += 1
+            key = f"AGENT-{counter['n']}"
+            created.append(key)
+            return Task(
+                id=key, title=task_input.title, column="TODO", priority=task_input.priority or "P2",
+                created="x", updated="y",
+            )
+
+        orig = Jd.create_task
+        Jd.create_task = fake_create  # type: ignore[assignment]
+        # Patch credentials.read since we don't want the driver to read the
+        # fake .env on filesystem.
+        orig_read = credentials.read
+        credentials.read = lambda prefix=None: {
+            "JIRA_BASE_URL": "https://x",
+            "JIRA_AGENT_EMAIL": "a@b",
+            "JIRA_API_TOKEN": "tok",
+        }
+
+        try:
+            class A: pass
+            a = A()
+            a.kanban_path = str(p)
+            a.dry_run = False
+            a.include_done = False
+
+            # Capture stdout
+            from io import StringIO
+            buf = StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = buf
+            try:
+                rc = mod.cmd_import_tasks(a)
+            finally:
+                sys.stdout = old_stdout
+            assert rc == 0
+            j = json.loads(buf.getvalue())
+            assert j["imported"] == 2
+            assert j["skipped"] == 1   # task-003 (DONE)
+
+            # Re-run — everything is mapped now.
+            buf2 = StringIO()
+            sys.stdout = buf2
+            try:
+                rc = mod.cmd_import_tasks(a)
+            finally:
+                sys.stdout = old_stdout
+            j2 = json.loads(buf2.getvalue())
+            assert j2["imported"] == 0
+            assert j2["skipped"] == 3
+            # already-mapped reasons present
+            assert any(s.get("reason") == "already-mapped" for s in j2["skippedDetail"])
+        finally:
+            Jd.create_task = orig  # type: ignore[assignment]
+            credentials.read = orig_read
+
+        # Map file written and contains both new keys.
+        map_path = pathlib.Path(td) / ".claude" / ".migration-map.json"
+        assert map_path.exists()
+        mapping = json.loads(map_path.read_text())
+        assert "task-001" in mapping and "task-002" in mapping
+
+
+# --- label-fallback round trip ------------------------------------------
+
+
+def test_label_fallback_round_trip():
+    """When partial=True and a card has the kanban:blocked label, reader maps
+    it to the BLOCKED canonical column."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        data = _make_jira_data()
+        data["backend"]["jira"]["partial"] = True
+        data["backend"]["jira"]["labelFallback"] = {
+            "BLOCKED": "kanban:blocked",
+            "REVIEW": "kanban:review",
+            "CANCELLED": "kanban:cancelled",
+        }
+        # Drop BLOCKED/REVIEW/CANCELLED from statusMap (simulate partial).
+        for c in ("BLOCKED", "REVIEW", "CANCELLED"):
+            data["backend"]["jira"]["statusMap"].pop(c, None)
+
+        from kanban.drivers.jira import JiraDriver
+        from kanban.lib import credentials
+
+        orig = credentials.read
+        credentials.read = lambda prefix=None: {
+            "JIRA_BASE_URL": "https://x",
+            "JIRA_AGENT_EMAIL": "a@b",
+            "JIRA_API_TOKEN": "tok",
+        }
+        try:
+            drv = JiraDriver(data, proj)
+        finally:
+            credentials.read = orig
+
+        # Build an issue payload as Jira would: status is "In Progress"
+        # (because partial mode collapses BLOCKED to In Progress + label),
+        # but the kanban:blocked label tells the reader BLOCKED.
+        issue = {
+            "key": "AGENT-99",
+            "fields": {
+                "summary": "stalled",
+                "status": {"name": "In Progress"},
+                "priority": {"name": "P1"},
+                "assignee": None,
+                "labels": ["other-label", "kanban:blocked"],
+                "created": "x",
+                "updated": "y",
+                "customfield_10042": {"value": "agent-fin"},
+            },
+        }
+        task = drv._issue_to_task(issue)
+        assert task.column == "BLOCKED", task.column
+        assert task.ap == "agent-fin"
+
+
+# --- entry point ---------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("mcp_scan_matches_keywords", test_mcp_scan_matches_keywords),
+        ("mcp_scan_cli", test_mcp_scan_cli),
+        ("import_tasks_dry_run", test_import_tasks_dry_run),
+        ("import_tasks_idempotent", test_import_tasks_idempotent),
+        ("label_fallback_round_trip", test_label_fallback_round_trip),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase5: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/skills/kanban-jira-agent/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-agent/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: kanban-jira-agent
+description: Use this skill whenever kanban.json at the project root has backend.driver = "jira", or when the agent is about to claim, comment on, transition, or hand off a Jira card managed by this kanban plugin. Triggers also when the user mentions a Jira KEY-N reference (e.g. AGENT-42), a Jira board URL, or asks to pick the next task in a Jira-mode project.
+---
+
+# Working with kanban (Jira mode)
+
+You are working in a project where kanban tasks live in Jira, not in
+`kanban.json`. Your AP (Agent Property) is recorded in
+`./.claude/kanban-agent.json`. Always operate through `/kanban:*` slash
+commands — never call the Jira REST API directly, and never use any other
+Jira MCP server even if one is available in your environment.
+
+## Session start
+
+`/kanban:sync` runs automatically on `SessionStart`. Read the printed
+summary; cards listed are yours. If you suspect stale state, run
+`/kanban:sync` again explicitly.
+
+## Picking work
+
+- `/kanban:next` — claims the highest-priority TODO card scoped to your AP,
+  transitions it to In Progress, and posts a `[<ap>] [S] claimed` system
+  comment. Do this **before** starting any work.
+- Do not claim a card already DOING by another AP — the precheck hook
+  warns you when you mention such a card.
+
+## During work
+
+- Found a blocker that needs human input? `/kanban:question <KEY> "<text>"`.
+  This posts a Q-prefixed comment **and** moves the card to Blocked. Do not
+  edit the card further until a human (or another AP) replies.
+- Card-key auto-detection: if you mention a key (e.g. `AGENT-42`) or paste a
+  Jira URL, the plugin injects context above your prompt. Read it before
+  acting; pay close attention to ⚠ warnings about AP mismatch.
+
+## Finishing work
+
+- `/kanban:done` transitions DOING → In Review with a system comment. The
+  human reviewer (or another AP) approves the card by transitioning it to
+  Done in the Jira UI.
+- DO NOT push your own card to Done. The plugin refuses (anti-self-approve);
+  the Jira workflow may also reject it. This is intentional.
+
+## Forbidden
+
+- Direct Jira API calls (curl, fetch, any HTTP client)
+- Atlassian Rovo MCP, mcp-atlassian, jira-mcp, or any other Jira MCP — your
+  plugin is the only sanctioned path
+- Editing `kanban.json` directly (the `kanban-guard.sh` PreToolUse hook
+  blocks this anyway)
+- Approving your own cards (the plugin will refuse; do not retry with
+  workarounds)
+- Bypassing PreToolUse hooks via `--no-verify`-style flags
+
+## When to fall back
+
+- If the Jira API is unreachable: `/kanban:status` should report a network
+  error in its Token row. Do not proceed with state-changing commands until
+  the user confirms connectivity.
+- If your AP becomes invalid (registered list changed, Jira admin removed
+  the option): `/kanban:whoami` shows the mismatch. Stop and ask the user.
+
+## Reference: SPEC sections
+
+- §3.4 — agent identity (`.claude/kanban-agent.json`)
+- §5 — auto-detect rules (precheck on UserPromptSubmit)
+- §8 — anti-self-approve invariant
+- §9 — comment prefix grammar
+- §18 — why no other Jira MCP is allowed

--- a/plugins/kanban/skills/kanban-jira-setup/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-setup/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: kanban-jira-setup
+description: Use this skill when the user runs /kanban:initjira, /kanban:reset-credentials, /kanban:register-ap, /kanban:assign-ap, or describes a Jira-mode setup or recovery problem (token rotation, admin permission gaps, MCP conflicts, migration from local mode). It walks the user through the multi-step flow and resolves the most common failure modes.
+---
+
+# Setting up & recovering kanban Jira mode
+
+This skill is for the **owner** running `/kanban:*` setup commands, not
+for the agents working day-to-day inside a Jira-mode project.
+
+## The five-step path through `/kanban:initjira`
+
+| Step | What | Common gotcha |
+|---|---|---|
+| 1 | Capture credentials (base URL, shared agent email, API token) and validate via `GET /myself` | Token comes from https://id.atlassian.com/manage-profile/security/api-tokens; it is account-scoped, not project-scoped |
+| 2 | Parse the board URL into `projectKey + boardId`; validate both | The URL usually contains `/jira/software/projects/<KEY>/boards/<ID>`; `?selectedIssue=...` URLs are not board URLs |
+| 3 | Pull the project workflow statuses; map to canonical `TODO/DOING/BLOCKED/REVIEW/DONE/CANCELLED` | Many out-of-the-box Jira workflows have only 3 statuses; you can either add the missing ones in Jira project settings, or accept partial mode with `--partial` |
+| 4 | Choose `[a] use existing custom field` or `[b] create new (Claude Agent)` | Option `[b]` requires Jira admin; if the helper returns a 403, switch to `[a]` and ask an admin to create the field once |
+| 5 | Register the first AP and set this repo's AP | AP names match `^[a-z][a-z0-9-]{2,40}$`; the registry is a Jira custom-field options list, mirrored in `kanban.json` |
+
+After Step 5, a migration prompt fires if local tasks are present.
+
+## Workflow gap (Step 3): how to add missing statuses in Jira
+
+If `/kanban:initjira` reports missing statuses, the user has two choices:
+
+1. **Add the canonical statuses in Jira**:
+   - Go to `Project settings → Workflows`
+   - Edit the active workflow
+   - Add `Blocked`, `In Review`, `Cancelled` (whichever are missing)
+   - Re-run `/kanban:initjira`; Step 3 should now report `✓ all 6 found`
+
+2. **Accept the partial mapping with `--partial`**:
+   - Re-run `/kanban:initjira --partial`
+   - Missing canonical columns are substituted via labels:
+     `kanban:blocked`, `kanban:review`, `kanban:cancelled`
+   - The driver reads back labels into the canonical column. Audit comments
+     are still posted on every transition.
+   - Trade-off: cards in `BLOCKED/REVIEW/CANCELLED` show the underlying
+     status (e.g. In Progress) plus a label — Jira board UI reflects this
+     differently from native statuses.
+
+## Permission gap (Step 4): no admin to create the field
+
+If `[b] create new field` returns `permission denied`:
+
+1. Ask a Jira admin to create a single-select custom field once
+   (suggested name: `Claude Agent`, description optional).
+2. Have the admin add the field to the project's default screen so it is
+   editable.
+3. Re-run `/kanban:initjira` and choose `[a] Use existing field`. The
+   helper's `find-ap-field` lists fields whose name contains `agent`,
+   `claude`, or `ap`.
+
+## Migration from local mode
+
+When `/kanban:initjira` finds existing `kanban.json#tasks`, it offers to
+import them as Jira issues:
+
+- TODO / DOING are imported by default; DONE / CANCELLED are skipped
+  (override with `--include-done` if the user wants a complete history).
+- Each imported issue gets the label `migrated-from-local`.
+- The mapping `local-task-id → jira-key` is recorded in
+  `.claude/.migration-map.json` so re-running is idempotent.
+- The original `kanban.json#tasks` array stays in place — kanban.json with
+  `backend.driver = "jira"` ignores it on read, so nothing breaks. Rolling
+  back is `set backend.driver = "local"` (manually) and the local tasks
+  re-appear.
+
+Reverse migration (jira → local) is **not supported** in v0.2 — the user
+must scaffold a fresh repo with `/kanban:init` if they need offline.
+
+## Token rotation
+
+Run `/kanban:reset-credentials` when:
+- The token expired or was revoked
+- The agent account password changed (token still works, but rotate as a
+  hygiene measure)
+- The token was exposed (committed, logged, screen-shared)
+
+This command rewrites only the `JIRA_*` lines in `~/.claude-workbench/.env`,
+leaving Pushover and other plugins untouched.
+
+## MCP conflict warning
+
+`/kanban:initjira` (final step) and `/kanban:whoami` both surface any
+`atlassian|jira|rovo|mcp-atlassian` MCP servers configured at user-,
+project-, or `.mcp.json` scope. If the user wants to keep the conflicting
+MCP for personal Confluence browsing:
+
+- Move the entry to **user scope** (`~/.claude/settings.json`) so agents in
+  this repo do not inherit it.
+- The `kanban-jira-agent` skill instructs agents not to call other Jira
+  MCPs, but defense in depth is preferred.
+
+If the user wants to remove the MCP entirely, edit the relevant settings
+file and delete the entry; the next `/kanban:whoami` confirms.
+
+## Diagnostic commands
+
+| Symptom | Run |
+|---|---|
+| Token validity unknown | `/kanban:whoami` (Token row) |
+| AP mismatch on a card | `/kanban:status` to see live state; verify `.claude/kanban-agent.json` |
+| Stuck card / cache stale | `/kanban:sync` to force a refresh |
+| Onboarding a new agent in this repo | `/kanban:assign-ap <existing-name>` (no need to re-init) |
+| Adding a new agent across the team | `/kanban:register-ap <new-name>` then `/kanban:assign-ap` in each repo |
+
+## Reference: SPEC sections
+
+- §3 — data model (driver abstraction, kanban.json layout, secrets)
+- §4 — slash commands
+- §7 — graceful degradation (full vs partial workflow)
+- §8 — anti-self-approve enforcement layers
+- §11 — migration from local mode
+- §18 — MCP conflict policy

--- a/plugins/kanban/skills/kanban-workflow/SKILL.md
+++ b/plugins/kanban/skills/kanban-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kanban-workflow
-description: Use this skill whenever kanban.json exists in the project root, or when the user mentions tasks, TODO, kanban, priorities, or asks "what should I work on next", "pick a task", "繼續工作", etc. This skill governs task lifecycle (TODO → DOING → DONE/BLOCKED) through the kanban.json file.
+description: Use this skill whenever kanban.json exists at the project root with backend.driver = "local" (or no backend block, which implies local), or when the user mentions tasks, TODO, kanban, priorities, or asks "what should I work on next", "pick a task", "繼續工作", etc. This skill governs the local-driver task lifecycle (TODO → DOING → DONE/BLOCKED). For backend.driver = "jira" the kanban-jira-agent skill applies instead.
 ---
 
 # Kanban Workflow

--- a/plugins/kanban/templates/kanban.empty.json
+++ b/plugins/kanban/templates/kanban.empty.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./kanban.schema.json",
-  "schema_version": 1,
+  "version": "0.2",
+  "backend": { "driver": "local" },
   "meta": {
     "priorities": ["P0", "P1", "P2", "P3"],
     "categories": [],

--- a/plugins/kanban/templates/kanban.example.json
+++ b/plugins/kanban/templates/kanban.example.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./kanban.schema.json",
-  "schema_version": 1,
+  "version": "0.2",
+  "backend": { "driver": "local" },
   "meta": {
     "priorities": ["P0", "P1", "P2", "P3"],
     "categories": ["infra", "feature", "bug", "docs"],

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -35,8 +35,31 @@
           "additionalProperties": false,
           "properties": {
             "boardUrl": { "type": "string", "format": "uri" },
+            "boardId": { "type": "integer", "minimum": 1 },
             "projectKey": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+$" },
             "agentAccountId": { "type": "string" },
+            "statusMap": {
+              "type": "object",
+              "description": "Canonical column -> Jira status display name. Built at /kanban:initjira time.",
+              "additionalProperties": false,
+              "properties": {
+                "TODO": { "type": "string" },
+                "DOING": { "type": "string" },
+                "BLOCKED": { "type": "string" },
+                "REVIEW": { "type": "string" },
+                "DONE": { "type": "string" },
+                "CANCELLED": { "type": "string" }
+              }
+            },
+            "partial": {
+              "type": "boolean",
+              "description": "True when the Jira workflow lacks one or more canonical statuses; missing columns fall back to label substitution per SPEC §7."
+            },
+            "labelFallback": {
+              "type": "object",
+              "description": "Canonical column -> Jira label, used only when `partial` is true and the column has no native status.",
+              "additionalProperties": { "type": "string" }
+            },
             "ap": {
               "type": "object",
               "additionalProperties": false,

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -4,16 +4,55 @@
   "title": "Kanban",
   "description": "Schema for kanban.json — the single source of truth for the claude-workbench kanban plugin.",
   "type": "object",
-  "required": ["schema_version", "meta", "tasks"],
+  "required": ["meta", "tasks"],
   "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string"
     },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$",
+      "description": "v0.2+ semantic version. Writers always emit this; readers accept either this or schema_version."
+    },
     "schema_version": {
       "type": "integer",
       "minimum": 1,
-      "description": "Schema version. Bump on breaking changes."
+      "description": "Legacy v0.1 version field. Readers still accept it; new writes use 'version' instead."
+    },
+    "backend": {
+      "type": "object",
+      "description": "Driver selection. Absent ⇒ implicit local mode (v0.1 backwards-compat).",
+      "required": ["driver"],
+      "additionalProperties": false,
+      "properties": {
+        "driver": {
+          "type": "string",
+          "enum": ["local", "jira"]
+        },
+        "jira": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "boardUrl": { "type": "string", "format": "uri" },
+            "projectKey": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+$" },
+            "agentAccountId": { "type": "string" },
+            "ap": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fieldId": { "type": "string", "pattern": "^customfield_[0-9]+$" },
+                "fieldName": { "type": "string" },
+                "registered": {
+                  "type": "array",
+                  "items": { "type": "string", "pattern": "^[a-z][a-z0-9-]{2,40}$" },
+                  "uniqueItems": true
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "meta": {
       "type": "object",
@@ -35,12 +74,12 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["TODO", "DOING", "DONE", "BLOCKED"]
+            "enum": ["TODO", "DOING", "DONE", "BLOCKED", "REVIEW", "CANCELLED"]
           },
           "minItems": 4,
-          "maxItems": 4,
+          "maxItems": 6,
           "uniqueItems": true,
-          "description": "Fixed columns: TODO, DOING, DONE, BLOCKED."
+          "description": "Columns. Local mode uses the 4 canonical [TODO, DOING, DONE, BLOCKED]; Jira mode may add REVIEW and CANCELLED. Driver-side runtime enforces its own subset."
         },
         "created_at": {
           "type": "string",
@@ -74,7 +113,7 @@
         },
         "column": {
           "type": "string",
-          "enum": ["TODO", "DOING", "DONE", "BLOCKED"]
+          "enum": ["TODO", "DOING", "DONE", "BLOCKED", "REVIEW", "CANCELLED"]
         },
         "priority": {
           "type": "string"

--- a/plugins/workbench/.claude-plugin/plugin.json
+++ b/plugins/workbench/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "workbench",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Complete Claude Workbench — kanban + notify + memory. Meta-plugin: installing this pulls in the other three.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",
   "license": "MIT",
   "dependencies": [
-    { "name": "kanban", "version": "^0.1.0" },
+    { "name": "kanban", "version": "^0.2.0" },
     { "name": "notify", "version": "^0.0.1" },
     { "name": "memory", "version": "^0.0.1" }
   ]


### PR DESCRIPTION
## Summary

- Adds Jira Cloud as a second backend driver for the kanban plugin behind a `Driver` Protocol; same `/kanban:*` slash command surface, only the storage layer changes.
- Backwards-compatible — existing v0.1.x `kanban.json` files (no `backend` block, `schema_version: 1`) keep working as local mode with no migration. First write upgrades the file in place.
- Five sequential commits (one per phase): Phase 1 driver abstraction → Phase 2 Jira REST core → Phase 3 AP routing + anti-self-approve → Phase 4 auto-detect + sync + 30 s cache → Phase 5 migration + MCP scan + skills + docs + bump to `0.2.0`.

## What's new

- **Driver abstraction**: `plugins/kanban/drivers/{base,local,jira}.py`. Reader accepts both v0.1 and v0.2 shapes; writer always emits v0.2.
- **`/kanban:initjira`** — credentials → board → workflow check (with `--partial`) → AP custom field (admin-create or pick-existing) → first AP registration → optional local-task migration → MCP-conflict scan.
- **AP routing** — `/kanban:register-ap`, `/kanban:assign-ap`, `/kanban:whoami`. Per-repo identity at `.claude/kanban-agent.json` (commit it; team sees per-repo agent identity).
- **Anti-self-approve (SPEC §8)** — `JiraDriver.transition` refuses DONE when `task.ap == current_repo_ap`.
- **Auto-detect + sync** — `UserPromptSubmit` and `SessionStart` hooks scan for KEY/URL filtered by `projectKey`, run a precheck cached 30 s under `.claude/.kanban-cache/`, inject context. Cache invalidated on every plugin write.
- **`/kanban:sync`** and **`/kanban:question`** — explicit refresh + Q-prefix comment with BLOCKED transition.
- **Comment prefix grammar (§9)** — `**[<ap>] [Q|A|C|S]**` round-trip parsable.
- **Bundled skills** — `kanban-jira-agent` (agent-facing rules, forbidden direct API/MCP) + `kanban-jira-setup` (owner-facing walkthrough).
- **MCP conflict scan** — surfaces `atlassian|jira|rovo|mcp-atlassian` MCP servers across user/project/`.mcp.json` scopes (warning, not block).
- **Graceful degradation** — `--partial` opts into label substitutes (`kanban:blocked` etc.) when Jira workflow lacks canonical statuses; round-trip safe.

## Stats

- 47 files changed; +6168 / −29
- 5 commits, one per phase
- 48 mocked regression tests across 5 phase suites; runnable via `bash plugins/kanban/scripts/test_all.sh`. All green.
- kanban: `0.1.1` → `0.2.0` ; workbench bundle: `0.0.1` → `0.0.2` (kanban dep `^0.1.0` → `^0.2.0`)

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 5 phase suites green (no live Jira required; everything mocked)
- [x] `/security-review` (no high-confidence findings)
- [ ] Manual smoke test in local mode: `/kanban:init` → `/kanban:next` → `/kanban:done` (verify v0.1.x compat)
- [ ] Manual smoke test in Jira mode: `/kanban:initjira` end-to-end against a real test project (covers admin / no-admin paths, partial mode, MCP conflict warning)
- [ ] Verify `~/.claude-workbench/.env` is `0600` after `/kanban:initjira` (atomic write + chmod)
- [ ] Verify cross-prefix preservation: existing `PUSHOVER_*` lines survive a `JIRA_*` write

## Out of scope (tracked for follow-up)

- Reverse migration jira → local (v0.2 not supported)
- Hard MCP exclusion via PreToolUse hook (v0.2 is detect-and-warn; SPEC §16.4)
- Multi-board / sprint planning / webhooks
- Linear / GitHub-Issues drivers (Driver Protocol leaves room)

🤖 Generated with [Claude Code](https://claude.com/claude-code)