### PR TITLE
fix(kanban): 0.2.2 — local helper + marketplace-layout import bugs (#3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,39 @@ For earlier history, see the git log.
 ## 2026-04-30
 
 ### Fixed
-- **kanban 0.2.1** — local-mode mutation commands (`/kanban:init`,
-  `/kanban:next`, `/kanban:done`, `/kanban:block`) no longer trip
-  `kanban-guard.sh` and recover via Bash. They now route through a new
-  `scripts/kanban_local.py` helper that writes via atomic `os.replace`
-  through `kanban_io.save()` — same architecture pattern as the Jira-mode
-  commands' `jira_setup.py`. Result: clean execution, no PreToolUse
-  rejection messages mid-flow. The helper enforces dependency / priority
-  / DONE-immutability rules in one place; slash commands shrink to thin
-  orchestrators that parse arguments and report results. New
-  `scripts/test_phase6.py` (11 cases) covers init / next / done / block /
-  status end-to-end against real filesystem.
+- **kanban 0.2.2** — `/kanban:initjira` no longer fails with
+  `ModuleNotFoundError: No module named 'kanban'` under the marketplace
+  install layout (`<cache>/<repo>/kanban/<version>/...`). Both helpers
+  now anchor `sys.path` at `parents[1]` (the directory holding `lib/`
+  and `drivers/`) and use absolute imports `from lib import …` /
+  `from drivers import …`. The driver modules' relative imports
+  (`from ..lib import …`) — which fail when `drivers` is loaded as a
+  top-level package — are converted to absolute. Tests updated to the
+  same canonical sys.path. Verified end-to-end against a synthetic
+  marketplace layout. Closes Bug B in #3.
+- **kanban 0.2.1** — two bugs filed in #3:
+
+  - **(Bug A)** local-mode mutation commands (`/kanban:init`,
+    `/kanban:next`, `/kanban:done`, `/kanban:block`) no longer trip
+    `kanban-guard.sh` and recover via Bash. They now route through a new
+    `scripts/kanban_local.py` helper that writes via atomic `os.replace`
+    through `kanban_io.save()` — same architecture pattern as the
+    Jira-mode commands' `jira_setup.py`. Result: clean execution, no
+    PreToolUse rejection messages mid-flow. The helper enforces
+    dependency / priority / DONE-immutability rules in one place; slash
+    commands shrink to thin orchestrators. New `scripts/test_phase6.py`
+    (11 cases) covers init / next / done / block / status end-to-end.
+
+  - **(Bug B)** `/kanban:initjira` no longer fails with
+    `ModuleNotFoundError: No module named 'kanban'` under the marketplace
+    install layout (`<cache>/<repo>/kanban/<version>/...`). Both helpers
+    now anchor `sys.path` at `parents[1]` (the directory holding `lib/`
+    and `drivers/`) and use absolute imports `from lib import …` /
+    `from drivers import …`. The driver modules' relative imports
+    (`from ..lib import …`) — which fail when `drivers` is loaded as a
+    top-level package — are converted to absolute. Tests updated to the
+    same canonical sys.path. Verified end-to-end against a synthetic
+    marketplace layout.
 
 ## 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-04-30
+
+### Fixed
+- **kanban 0.2.1** — local-mode mutation commands (`/kanban:init`,
+  `/kanban:next`, `/kanban:done`, `/kanban:block`) no longer trip
+  `kanban-guard.sh` and recover via Bash. They now route through a new
+  `scripts/kanban_local.py` helper that writes via atomic `os.replace`
+  through `kanban_io.save()` — same architecture pattern as the Jira-mode
+  commands' `jira_setup.py`. Result: clean execution, no PreToolUse
+  rejection messages mid-flow. The helper enforces dependency / priority
+  / DONE-immutability rules in one place; slash commands shrink to thin
+  orchestrators that parse arguments and report results. New
+  `scripts/test_phase6.py` (11 cases) covers init / next / done / block /
+  status end-to-end against real filesystem.
+
 ## 2026-04-29
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/block.md
+++ b/plugins/kanban/commands/block.md
@@ -1,50 +1,60 @@
 ---
 description: Move a task to BLOCKED with a required reason.
 argument-hint: <task-id> --reason=<text>
-allowed-tools: Read, Write, Bash(date:*)
+allowed-tools: Read, Bash(python3:*), Bash(date:*)
 ---
 
 # /kanban:block
 
 Arguments: `$ARGUMENTS`
 
-Move a task out of the active flow into `BLOCKED` with a mandatory reason. The Skill `kanban-workflow` governs the rules.
+Move a task into `BLOCKED` with a mandatory reason. The Skill
+`kanban-workflow` governs the rules.
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`.
+If `"jira"`, follow the Jira flow at the end of this file.
 
 ## 1. Parse arguments (local driver)
 
 Required:
-- `<task-id>` — a bare `task-NNN` token.
+- `<task-id>` — bare `task-NNN` token.
 - `--reason=<text>` — non-empty explanation. Quoted values allowed.
 
-If either is missing or empty, stop and ask the user. Do NOT synthesise a reason.
+If either is missing or empty, stop and ask the user. Do NOT synthesise a
+reason.
 
-## 2. Validate
+## 2. Run the helper
 
-Read `kanban.json` fresh. Confirm:
-- Task exists.
-- Current column is `TODO` or `DOING`. If already `BLOCKED`, report and stop. If `DONE`, refuse — DONE is immutable.
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/kanban_local.py block \
+  --kanban-path '<kanban.json path>' \
+  --task-id task-NNN --reason '<text>'
+```
 
-## 3. Transition
+The helper enforces:
+- DONE is terminal (refuses)
+- only TODO or DOING can be moved to BLOCKED
+- `--reason` is required and must be non-empty
+- preserves `started` if the task was DOING
+- appends a `Blocked: <reason>` comment for the audit trail
 
-1. `date -Iseconds` → now.
-2. Produce new kanban.json:
-   - Target task: `column = "BLOCKED"`, `updated = <now>`.
-   - If the task was `DOING`, keep `started` — do NOT clear it. The task retains its started time for when it returns to DOING.
-   - Ensure `custom` exists; set `custom.blocked_reason = <reason>` (verbatim).
-   - Append a comment: `{author: "claude-code", ts: <now>, text: "Blocked: <reason>"}`.
-   - `meta.updated_at = <now>`.
-3. Write.
+It writes atomically. **Do not** call Write/Edit on `kanban.json`.
 
-## 4. Report
+## 3. Report
 
-> ⛔ task-042 "<title>" → BLOCKED
+| Shape | Action |
+|---|---|
+| `{ok: true, id, title, reason, downstream: [...]}` | print the block line; if `downstream` non-empty, list the impacted task ids |
+| `{ok: false, error}` | surface and stop |
+
+Format:
+
+> ⛔ <id> "<title>" → BLOCKED
 > Reason: <reason>
 
-If any other task's `depends` references the blocked task, list them (downstream impact).
+If `downstream` is non-empty, append: `Downstream impact: <id-1>, <id-2>`.
 
 ## Jira flow
 
@@ -55,13 +65,14 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
 ```
 
 The driver posts a `[<ap>] [S] Blocked: <reason>` system comment alongside
-the transition. In `partial` mode (workflow lacks a Blocked status), the
-plugin substitutes the `kanban:blocked` label and posts the same audit
-comment.
+the transition. In `partial` mode, the plugin substitutes the
+`kanban:blocked` label and posts the same audit comment.
 
 ## Absolute rules
 
-- Never move a task to BLOCKED without a reason.
+- Never move a task to BLOCKED without a reason (local mode — helper enforces).
 - Never move from DONE to BLOCKED — DONE is terminal.
-- Never silently drop the old `started` timestamp (local mode).
-- To return a task to active work, use an edit through `/kanban:*` commands that clear `custom.blocked_reason` and move back to TODO (today: manual fix via a future `/kanban:unblock` command; v0.2.0).
+- Never silently drop the old `started` timestamp (local mode — helper preserves).
+- Never call Write/Edit on `kanban.json` — go through the helper.
+- To return a task to active work: today, manual fix via a future
+  `/kanban:unblock` command (v0.2.x).

--- a/plugins/kanban/commands/done.md
+++ b/plugins/kanban/commands/done.md
@@ -1,7 +1,7 @@
 ---
 description: Mark a task (default: current DOING) as DONE.
 argument-hint: [<task-id>] [--note=<text>]
-allowed-tools: Read, Write, Bash(date:*), Bash(jq:*)
+allowed-tools: Read, Bash(python3:*), Bash(date:*)
 ---
 
 # /kanban:done
@@ -12,47 +12,52 @@ Close out a task. The Skill `kanban-workflow` governs the rules.
 
 ## 0. Driver check
 
-Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
+Read `kanban.json`. Look at `backend.driver`. If absent, treat as `"local"`.
+If `"jira"`, follow the Jira flow at the end of this file.
 
-## 1. Resolve target task (local driver)
+## 1. Parse arguments (local driver)
 
-Parse `$ARGUMENTS`:
-- If an explicit `task-NNN` is present: target is that task.
-- Otherwise: find the single task with `column == "DOING"` and `assignee == "claude-code"`. If there are 0 or multiple, list them and ask the user which one.
+- `<task-id>` — explicit task to close. If omitted, the helper finds the
+  single DOING task with `assignee == "claude-code"`. If 0 or >1, the
+  helper returns an error listing the candidates; ask the user which one.
+- `--note=<text>` — optional closing comment. Quoted values supported.
 
-Parse `--note=<text>`: optional closing comment. Support quoted values.
+## 2. Run the helper
 
-## 2. Validate
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/kanban_local.py done \
+  --kanban-path '<kanban.json path>' \
+  [--task-id task-NNN] [--note '<text>']
+```
 
-Re-read `kanban.json` fresh. Confirm:
-- Target task exists.
-- `column == "DOING"`. If it's already DONE, say so and stop. If TODO/BLOCKED, refuse and explain.
+The helper enforces DONE-only-from-DOING, sets `completed`, appends the
+note as a comment, and writes atomically. **Do not** call Write/Edit on
+`kanban.json`.
 
-## 3. Move to DONE
+## 3. Report
 
-1. `date -Iseconds` → now.
-2. Produce new kanban.json:
-   - Target task: `column = "DONE"`, `completed = <now>`, `updated = <now>`.
-   - If `--note=<text>` was passed: append a comment `{author: "claude-code", ts: <now>, text: <note>}` to `comments`.
-   - `meta.updated_at = <now>`.
-3. Write.
+| Shape | Action |
+|---|---|
+| `{ok: true, id, title, completed, unblocked: [...]}` | print done line; if `unblocked` is non-empty, list those task ids |
+| `{ok: false, error, doing: [...]}` | the user has multiple DOING tasks. Show the list and ask which one. |
+| `{ok: false, error}` | surface and stop |
 
-## 4. Report
+Format:
 
-> ✓ task-042 "<title>" → DONE.
-> Unblocked: task-050 (was waiting on task-042).
+> ✓ <id> "<title>" → DONE.
+> Unblocked: <id-1>, <id-2> (was waiting on <id>).
 
-Compute "unblocked" by finding any task in TODO whose `depends` included the closed task and are now fully satisfied. List their ids.
+Omit the "Unblocked" line when none.
 
 ## Jira flow
 
-In Jira mode, `/kanban:done` transitions DOING → REVIEW. The actual DONE
-transition is reserved for a human reviewer (or another agent) — anti-self-
-approve will refuse if the same AP tries to push to DONE.
+In Jira mode, `/kanban:done` transitions DOING → REVIEW. The DONE step is
+reserved for a human reviewer — anti-self-approve refuses if the same AP
+tries to push to DONE.
 
 Identify the target key from `$ARGUMENTS`. If absent, find the single DOING
-card with this repo's AP set (use `/kanban:status` to enumerate; if there is
-not exactly one, ask the user to specify).
+card with this repo's AP set (use `/kanban:status` to enumerate; if there
+is not exactly one, ask the user).
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
@@ -61,17 +66,14 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
 
 On success print `✓ <KEY> → In Review (awaiting reviewer)`.
 
-If the user explicitly asks to mark DONE — for example a one-person team
-where the human owner uses Jira UI normally — they should approve via the
-Jira UI from a different account, not via this slash command. The plugin
-deliberately refuses self-approval; do not search for workarounds.
-
 If the helper exits with `kind: self-approve`, surface the error verbatim
-and explain that another reviewer is required.
+and explain another reviewer is required. Do NOT search for workarounds.
 
 ## Absolute rules
 
-- Never close a task that isn't DOING (local mode).
+- Never close a task that isn't DOING (local mode — helper enforces).
 - Never retroactively edit `created` or `started`.
-- Never close multiple tasks in one invocation — one at a time keeps the commit log clean.
-- Jira mode: never push REVIEW → DONE for a card whose AP equals this repo's AP. The plugin refuses; do not retry with `--force` or hand-rolled API calls.
+- Never close multiple tasks in one invocation.
+- Never call Write/Edit on `kanban.json` — go through the helper.
+- Jira mode: never push REVIEW → DONE for a card whose AP equals this
+  repo's AP. The plugin refuses; do not retry.

--- a/plugins/kanban/commands/init.md
+++ b/plugins/kanban/commands/init.md
@@ -1,51 +1,68 @@
 ---
 description: Initialize kanban.json + kanban.schema.json in the current project.
 argument-hint: [--with-examples]
-allowed-tools: Read, Write, Bash(date:*), Bash(cp:*), Bash(test:*), Bash(ls:*)
+allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*)
 ---
 
 # /kanban:init
 
 Arguments: `$ARGUMENTS`
 
-You are initialising kanban in the project root (`$CLAUDE_PROJECT_DIR` or cwd if unset). Follow these steps exactly:
+Scaffold `kanban.json` (v0.2 shape, `backend.driver=local`) and the matching
+`kanban.schema.json` at the project root.
 
-## 1. Pre-flight checks
+The actual work — copying templates, substituting timestamps, atomic write —
+runs in `${CLAUDE_PLUGIN_ROOT}/scripts/kanban_local.py`. The helper writes
+through `kanban_io.save()` (atomic `os.replace`), so the `kanban-guard.sh`
+PreToolUse hook does NOT fire and there is no Write-tool error to recover
+from. **Do not** call the Write or Edit tool directly on `kanban.json`.
 
-Run these checks. If any fail, stop and report:
+## 1. Locate project root
 
-- If `kanban.json` already exists in the project root, STOP. Ask the user whether to overwrite (`rm kanban.json && re-run`) rather than silently clobbering.
-- Confirm we are at the project root (look for `.git` or common markers). If unsure, ask before proceeding.
+`$CLAUDE_PROJECT_DIR` if set, else `git rev-parse --show-toplevel`, else
+the current working directory. The kanban file lives at
+`<project-root>/kanban.json`.
 
-## 2. Choose template
+## 2. Pre-flight
 
-- If `$ARGUMENTS` contains `--with-examples`: use `${CLAUDE_PLUGIN_ROOT}/templates/kanban.example.json`.
-- Otherwise: use `${CLAUDE_PLUGIN_ROOT}/templates/kanban.empty.json`.
+If `kanban.json` already exists, stop and ask the user whether to overwrite.
+The helper supports `--force` for the destructive case; pass it through
+only after explicit user confirmation.
 
-## 3. Copy schema
+## 3. Run the helper
 
-Copy `${CLAUDE_PLUGIN_ROOT}/templates/kanban.schema.json` to `<project-root>/kanban.schema.json`.
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/kanban_local.py init \
+  --kanban-path '<project-root>/kanban.json' \
+  [--with-examples]   # only if $ARGUMENTS contains --with-examples
+  [--force]           # only after the user said yes to overwriting
+```
 
-## 4. Materialise kanban.json
+The helper prints a JSON object:
 
-1. Read the chosen template file.
-2. Generate a current ISO 8601 timestamp with timezone via Bash: `date -Iseconds`. Capture the output exactly.
-3. Replace **every** occurrence of `__CREATED_AT__` and `__UPDATED_AT__` with that timestamp.
-4. Write the result to `<project-root>/kanban.json`.
+```json
+{ "ok": true, "kanban_path": "...", "schema_path": "...", "tasks": 0, "with_examples": false }
+```
 
-## 5. Verify
+On `ok: false`, surface the `error` field and stop.
 
-- Read back `kanban.json` and confirm no `__CREATED_AT__` / `__UPDATED_AT__` placeholders remain.
-- Report what was created, e.g.:
+## 4. Report
 
-> ✓ Created kanban.json v0.2 (local driver, empty / with 4 example tasks) and kanban.schema.json.
-> Next: try `/kanban:status` or `/kanban:next`.
+```
+✓ Created kanban.json v0.2 (local driver, 0 tasks) and kanban.schema.json.
+  Next: try /kanban:status or /kanban:next.
+```
+
+If `--with-examples` was used, mention the 4 example tasks. If `--force`
+overwrote an existing file, mention that previous tasks were discarded.
 
 The template ships with `backend: { driver: "local" }`. To switch to the
-Jira backend later, run `/kanban:initjira` (added in plugin v0.2.0+).
+Jira backend later, run `/kanban:initjira`.
 
 ## Absolute rules
 
+- Do NOT use the Write or Edit tool on `kanban.json` — the helper is the
+  only sanctioned mutation path.
 - Do NOT create extra files beyond `kanban.json` and `kanban.schema.json`.
 - Do NOT commit. Let the `kanban-autocommit.sh` hook or the user decide.
 - Do NOT populate tasks yourself — templates are the only source.

--- a/plugins/kanban/commands/next.md
+++ b/plugins/kanban/commands/next.md
@@ -1,95 +1,78 @@
 ---
 description: Pick the next kanban task and move it to DOING.
-argument-hint: [--category=X] [--priority=Y]
-allowed-tools: Read, Write, Bash(date:*), Bash(jq:*)
+argument-hint: [--category=X] [--priority=Y] [<task-id>]
+allowed-tools: Read, Bash(python3:*), Bash(date:*)
 ---
 
 # /kanban:next
 
 Arguments: `$ARGUMENTS`
 
-Pick the next eligible TODO task, move it to DOING, then begin executing it. The Skill `kanban-workflow` (loaded automatically) governs the rules.
+Pick the next eligible TODO task and transition it to DOING. The Skill
+`kanban-workflow` (loaded automatically) governs the rules.
 
 ## 0. Driver check
 
-Read `kanban.json` first. Look at `backend.driver`. If absent, treat as `"local"`. If `"jira"`, follow the Jira flow at the end of this file.
+Read `kanban.json` first. Look at `backend.driver`. If absent, treat as
+`"local"`. If `"jira"`, follow the Jira flow at the end of this file.
 
-## 1. Load state (local driver)
-
-Read `kanban.json` fresh. Do not rely on earlier reads from this session.
-
-## 2. Parse filters from `$ARGUMENTS`
+## 1. Parse arguments (local driver)
 
 Support:
-- `--category=<cat>` → only consider tasks with that category.
-- `--priority=<prio>` → only consider tasks at or above that priority (i.e. `priorityIndex ≤ index_of(<prio>)`).
-- No argument → no filter.
+- `--category=<cat>` — only consider tasks with that category.
+- `--priority=<prio>` — only consider tasks at or above that priority.
+- A bare `task-NNN` token — claim that specific task instead of auto-picking.
+- No argument — auto-pick.
 
-## 3. Build candidate set
+## 2. Run the helper
 
-Apply, in order:
-1. `column == "TODO"`.
-2. Every id in `depends` exists **and** is in column `DONE`.
-3. User filters from step 2.
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/kanban_local.py next \
+  --kanban-path '<kanban.json path>' \
+  [--category <cat>] [--priority <prio>] [--task-id task-NNN]
+```
 
-## 4. Rank
+The helper enforces all dependency / priority / DONE-immutability rules and
+writes the file via atomic `os.replace`, sidestepping the kanban-guard
+PreToolUse hook. **Do not** call the Write or Edit tool on `kanban.json`.
 
-Sort by:
-1. `meta.priorities.indexOf(task.priority)` ascending.
-2. `created` ascending.
-3. `id` ascending.
+## 3. Handle the response
 
-## 5. Handle the result
+| Shape | Action |
+|---|---|
+| `{ok: true, claimed: {id, title, priority, deps, ...}}` | print the claim line and begin executing the task |
+| `{ok: true, claimed: null, candidates: [...top-3...], reason}` | the top priority is tied — list the candidates and ask the user to pick by `task-id`, then re-run with `--task-id` |
+| `{ok: true, claimed: null, candidates: [], reason}` | nothing to claim (no TODOs / all blocked / filters too strict). Print the reason verbatim and stop. |
+| `{ok: false, error}` | surface the error and stop |
 
-- **0 candidates**: report why (no TODO? all blocked by deps? filtered out?) and stop. Do NOT start anything.
-- **1 candidate**: proceed to step 6.
-- **≥ 2 candidates in the same top priority**: show the top 3 with id / title / priority / category and ask the user to pick. Stop until they answer.
+When you have a successful claim, briefly report:
 
-## 6. Move to DOING
+> Starting <id> "<title>" (P<n>, category=<cat>).
+> Deps satisfied: <list>.
 
-1. Re-read `kanban.json` (concurrency guard). Confirm the chosen task is still in TODO with deps satisfied. If not, abort and report.
-2. Get current timestamp: `date -Iseconds`.
-3. Produce a new kanban.json with:
-   - Chosen task: `column = "DOING"`, `started = <now>`, `updated = <now>`, `assignee = "claude-code"` if unset.
-   - `meta.updated_at = <now>`.
-   - All other tasks unchanged.
-4. Write the file. (The `kanban-guard.sh` hook blocks ad-hoc edits, but this command is explicitly allowed.)
-
-## 7. Announce and begin
-
-Briefly report:
-
-> Starting task-042 "<title>" (P1, category=trading).
-> Deps satisfied: task-038, task-040.
-
-Then begin executing the task described in `description`. Treat `description` as the brief — ask the user for clarification if anything is ambiguous rather than guessing.
+Then begin executing the task described in `description`. Treat
+`description` as the brief — ask the user for clarification if anything is
+ambiguous rather than guessing.
 
 ## Jira flow
-
-Pick the highest-priority TODO card scoped to this repo's AP, transition it
-to `In Progress`, and post a `[<ap>] [S] claimed` system comment. The driver
-honours the `statusMap` configured at init time.
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py claim-next \
   --kanban-path '<kanban.json path>'
 ```
 
-Parse the response:
-
 | Shape | Action |
 |---|---|
-| `{ok: true, claimed: {id, title, priority, ap}}` | print `Claiming <id> "<title>" (P<n>, ap=<ap>)`, then begin executing the card |
+| `{ok: true, claimed: {id, title, priority, ap}}` | print `Claiming <id> "<title>" (P<n>, ap=<ap>)`, begin executing |
 | `{ok: true, claimed: null, reason}` | print `No TODO cards for AP <ap>` and stop |
-| `{ok: false, error}` | surface verbatim and stop. If error mentions `kanban-agent.json`, suggest `/kanban:assign-ap`. |
-
-Then read the card details if you need them (`get_task` via the helper or by
-asking Jira directly through `/kanban:status`) — the description there is
-your brief.
+| `{ok: false, error}` | surface verbatim. If error mentions `kanban-agent.json`, suggest `/kanban:assign-ap`. |
 
 ## Absolute rules
 
-- Never start a task whose deps are not all DONE (local mode).
+- Never start a task whose deps are not all DONE (local mode — helper enforces).
 - Never start a task in DONE or BLOCKED.
-- Never start more than one task at a time in the same session. If a DOING task already exists with assignee `claude-code`, confirm with the user before starting a new one.
+- Never start more than one task at a time in the same session. If a DOING
+  task already exists with assignee `claude-code`, confirm with the user
+  before starting a new one.
+- Never call the Write/Edit tool on `kanban.json` — go through the helper.
 - Jira mode: never bypass `claim-next` — it enforces AP routing.

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -16,9 +16,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ..lib import card_cache, credentials
-from ..lib.jira_client import JiraClient, JiraError, adf_to_text, text_to_adf
-from .base import (
+from lib import card_cache, credentials
+from lib.jira_client import JiraClient, JiraError, adf_to_text, text_to_adf
+from drivers.base import (
     AgentRef,
     Comment,
     CommentKind,

--- a/plugins/kanban/drivers/local.py
+++ b/plugins/kanban/drivers/local.py
@@ -11,8 +11,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ..lib import kanban_io
-from .base import (
+from lib import kanban_io
+from drivers.base import (
     AgentRef,
     Comment,
     CommentKind,

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -79,17 +79,20 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Import package modules with relative path. Plugin layout: scripts/ is a
-# sibling of lib/ and drivers/. Python doesn't auto-import "kanban" in this
-# layout, so we resolve plugins/ as the path root and import as
-# `kanban.lib.*` etc.
+# Plugin layout: scripts/ is a sibling of lib/ and drivers/. Adding the
+# plugin root (the directory containing lib/ and drivers/) to sys.path lets
+# us use absolute imports `from lib import …` and `from drivers import …`,
+# which works under both:
+#   1. Source layout:           plugins/kanban/scripts/jira_setup.py
+#   2. Marketplace install:     <cache>/<repo>/kanban/<version>/scripts/jira_setup.py
+# In both cases `parents[1]` resolves to the directory holding lib/ + drivers/.
 HERE = Path(__file__).resolve()
-PLUGINS_ROOT = HERE.parents[2]   # .../plugins
-sys.path.insert(0, str(PLUGINS_ROOT))
+PLUGIN_ROOT = HERE.parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
 
-from kanban.lib import ap_registry, card_cache, credentials, kanban_io  # noqa: E402
-from kanban.lib import mcp_conflict_scan  # noqa: E402
-from kanban.lib.jira_client import JiraClient, JiraError  # noqa: E402
+from lib import ap_registry, card_cache, credentials, kanban_io  # noqa: E402
+from lib import mcp_conflict_scan  # noqa: E402
+from lib.jira_client import JiraClient, JiraError  # noqa: E402
 
 
 # --- helpers --------------------------------------------------------------
@@ -306,8 +309,8 @@ def cmd_list_tasks(args: argparse.Namespace) -> int:
         _fail(f"kanban.json not found at {p}")
         return 1
     data = kanban_io.load(p)
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import TaskFilter
+    from drivers import get_driver
+    from drivers.base import TaskFilter
 
     driver = get_driver(data, p.parent)
     flt = TaskFilter(column=args.column, limit=args.limit)
@@ -539,8 +542,8 @@ def cmd_claim_next(args: argparse.Namespace) -> int:
         _fail("kanban-agent.json present but `ap` is empty")
         return 1
 
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import CommentKind, TaskFilter
+    from drivers import get_driver
+    from drivers.base import CommentKind, TaskFilter
 
     driver = get_driver(data, p.parent)
     todos = driver.list_tasks(TaskFilter(column="TODO", ap=ap, limit=1))
@@ -575,9 +578,9 @@ def cmd_transition(args: argparse.Namespace) -> int:
         _fail(f"kanban.json not found at {p}")
         return 1
     data = kanban_io.load(p)
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import CommentKind
-    from kanban.drivers.jira import SelfApproveRefused
+    from drivers import get_driver
+    from drivers.base import CommentKind
+    from drivers.jira import SelfApproveRefused
 
     driver = get_driver(data, p.parent)
     kwargs: dict[str, Any] = {}
@@ -717,7 +720,7 @@ def cmd_precheck_card(args: argparse.Namespace) -> int:
         )
         return 0
 
-    from kanban.drivers import get_driver
+    from drivers import get_driver
 
     driver = get_driver(data, p.parent)
     try:
@@ -779,8 +782,8 @@ def cmd_sync_summary(args: argparse.Namespace) -> int:
     repo_ap = _read_repo_ap(p)
     project_key = (backend.get("jira") or {}).get("projectKey") or ""
 
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import TaskFilter
+    from drivers import get_driver
+    from drivers.base import TaskFilter
 
     driver = get_driver(data, p.parent)
     open_columns = ("TODO", "DOING", "BLOCKED", "REVIEW")
@@ -863,8 +866,8 @@ def cmd_import_tasks(args: argparse.Namespace) -> int:
     else:
         mapping = {}
 
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import TaskInput
+    from drivers import get_driver
+    from drivers.base import TaskInput
 
     driver = get_driver(data, p.parent)
 
@@ -925,7 +928,7 @@ def cmd_health(args: argparse.Namespace) -> int:
         _fail(f"kanban.json not found at {p}")
         return 1
     data = kanban_io.load(p)
-    from kanban.drivers import get_driver
+    from drivers import get_driver
 
     driver = get_driver(data, p.parent)
     h = driver.health()

--- a/plugins/kanban/scripts/kanban_local.py
+++ b/plugins/kanban/scripts/kanban_local.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Local-mode helper invoked by /kanban:init / next / done / block / status.
+
+Mirrors the architecture used by jira_setup.py: every state-mutating slash
+command in local mode calls this helper via Bash, which writes kanban.json
+through `kanban_io.save()` (atomic os.replace) — that path is invisible to
+the kanban-guard.sh PreToolUse hook, which only blocks Edit/Write tools.
+
+Subcommands print one JSON object to stdout. Errors print JSON to stdout
+with `ok: false` and exit non-zero.
+
+  init --kanban-path P [--with-examples]
+       -> {"ok": true, "kanban_path": ..., "schema_path": ..., "tasks": <count>}
+
+  next --kanban-path P [--category C] [--priority P] [--task-id ID]
+       -> {"ok": true, "claimed": {"id":..., "title":..., "priority":...}}
+       -> {"ok": true, "claimed": null, "candidates": [...top 3...], "reason": "..."}
+       -> {"ok": false, "error": "..."}
+
+  done --kanban-path P [--task-id ID] [--note TEXT]
+       -> {"ok": true, "id": ..., "unblocked": [...]}
+
+  block --kanban-path P --task-id ID --reason TEXT
+       -> {"ok": true, "id": ..., "downstream": [...]}
+
+  status --kanban-path P
+       -> {"ok": true, "counts": {...}, "doing": [...], "next": [...], "blocked": [...]}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve()
+PLUGIN_ROOT = HERE.parents[1]               # plugins/kanban
+PLUGINS_ROOT = HERE.parents[2]              # plugins/
+TEMPLATES = PLUGIN_ROOT / "templates"
+sys.path.insert(0, str(PLUGINS_ROOT))
+
+from kanban.lib import kanban_io  # noqa: E402
+
+
+LOCAL_COLUMNS = ("TODO", "DOING", "DONE", "BLOCKED")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    json.dump(obj, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+
+def _fail(msg: str, code: int = 1, **extra: Any) -> int:
+    _emit({"ok": False, "error": msg, **extra})
+    return code
+
+
+def _load(p: Path) -> dict[str, Any]:
+    return kanban_io.load(p)
+
+
+def _save(p: Path, data: dict[str, Any]) -> None:
+    data.setdefault("meta", {})["updated_at"] = _now_iso()
+    kanban_io.save(p, data)
+
+
+def _require_local(data: dict[str, Any]) -> str | None:
+    backend = data.get("backend") or {}
+    driver = backend.get("driver", "local")
+    if driver != "local":
+        return f"backend.driver must be 'local'; got {driver!r}"
+    return None
+
+
+def _find_task(data: dict[str, Any], task_id: str) -> dict[str, Any] | None:
+    for t in data.get("tasks") or []:
+        if t.get("id") == task_id:
+            return t
+    return None
+
+
+def _next_task_id(tasks: list[dict[str, Any]]) -> str:
+    nums = []
+    for t in tasks:
+        tid = t.get("id", "")
+        if tid.startswith("task-"):
+            try:
+                nums.append(int(tid[5:]))
+            except ValueError:
+                pass
+    n = (max(nums) + 1) if nums else 1
+    return f"task-{n:03d}"
+
+
+# --- subcommands ---------------------------------------------------------
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if p.exists() and not args.force:
+        return _fail(
+            f"{p} already exists — pass --force to overwrite (this destroys existing tasks)"
+        )
+
+    src_name = "kanban.example.json" if args.with_examples else "kanban.empty.json"
+    src = TEMPLATES / src_name
+    schema_src = TEMPLATES / "kanban.schema.json"
+    if not src.exists() or not schema_src.exists():
+        return _fail(f"template not found in {TEMPLATES}")
+
+    p.parent.mkdir(parents=True, exist_ok=True)
+    schema_dst = p.parent / "kanban.schema.json"
+    shutil.copy(schema_src, schema_dst)
+
+    body = src.read_text(encoding="utf-8")
+    ts = _now_iso()
+    body = body.replace("__CREATED_AT__", ts).replace("__UPDATED_AT__", ts)
+    p.write_text(body, encoding="utf-8")
+
+    # Round-trip through kanban_io to enforce v0.2 normalised shape on disk.
+    data = _load(p)
+    kanban_io.save(p, data)
+
+    _emit(
+        {
+            "ok": True,
+            "kanban_path": str(p),
+            "schema_path": str(schema_dst),
+            "tasks": len(data.get("tasks") or []),
+            "with_examples": bool(args.with_examples),
+        }
+    )
+    return 0
+
+
+def _candidate_tasks(
+    data: dict[str, Any],
+    category: str | None,
+    priority: str | None,
+) -> list[dict[str, Any]]:
+    """TODO tasks whose deps are all DONE, after applying user filters."""
+    tasks = data.get("tasks") or []
+    done_ids = {t.get("id") for t in tasks if t.get("column") == "DONE"}
+    priorities = (data.get("meta") or {}).get("priorities") or []
+    cutoff = priorities.index(priority) if priority and priority in priorities else None
+
+    out: list[dict[str, Any]] = []
+    for t in tasks:
+        if t.get("column") != "TODO":
+            continue
+        if category and t.get("category") != category:
+            continue
+        if cutoff is not None:
+            tp = t.get("priority")
+            if tp not in priorities or priorities.index(tp) > cutoff:
+                continue
+        deps = t.get("depends") or []
+        if any(d not in done_ids for d in deps):
+            continue
+        out.append(t)
+
+    def sort_key(t: dict[str, Any]):
+        p = t.get("priority")
+        idx = priorities.index(p) if p in priorities else len(priorities)
+        return (idx, t.get("created") or "", t.get("id") or "")
+
+    out.sort(key=sort_key)
+    return out
+
+
+def cmd_next(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p} — run /kanban:init first")
+    data = _load(p)
+    if (err := _require_local(data)):
+        return _fail(err)
+
+    if args.task_id:
+        target = _find_task(data, args.task_id)
+        if not target:
+            return _fail(f"task {args.task_id!r} not found")
+        if target.get("column") != "TODO":
+            return _fail(
+                f"task {args.task_id} is in {target.get('column')!r}, not TODO"
+            )
+        candidates = [target]
+    else:
+        candidates = _candidate_tasks(data, args.category, args.priority)
+        if not candidates:
+            tasks = data.get("tasks") or []
+            todos = [t for t in tasks if t.get("column") == "TODO"]
+            if not todos:
+                reason = "no TODO tasks"
+            elif args.category or args.priority:
+                reason = "no TODO tasks match the given filters"
+            else:
+                reason = "all TODO tasks have unresolved dependencies"
+            _emit({"ok": True, "claimed": None, "candidates": [], "reason": reason})
+            return 0
+
+    # Top-3 ambiguity: if the top two share the same priority, surface them
+    # rather than guess. The slash command will ask the user.
+    if not args.task_id and len(candidates) >= 2:
+        priorities = (data.get("meta") or {}).get("priorities") or []
+        top_p = candidates[0].get("priority")
+        same_top = [c for c in candidates if c.get("priority") == top_p]
+        if len(same_top) >= 2:
+            _emit(
+                {
+                    "ok": True,
+                    "claimed": None,
+                    "candidates": [
+                        {
+                            "id": c.get("id"),
+                            "title": c.get("title"),
+                            "priority": c.get("priority"),
+                            "category": c.get("category"),
+                        }
+                        for c in candidates[:3]
+                    ],
+                    "reason": "tie at top priority — pick one",
+                }
+            )
+            return 0
+
+    pick = candidates[0]
+    ts = _now_iso()
+    pick["column"] = "DOING"
+    pick["started"] = pick.get("started") or ts
+    pick["updated"] = ts
+    pick.setdefault("assignee", "claude-code")
+    if not pick.get("assignee"):
+        pick["assignee"] = "claude-code"
+    _save(p, data)
+
+    _emit(
+        {
+            "ok": True,
+            "claimed": {
+                "id": pick["id"],
+                "title": pick.get("title"),
+                "priority": pick.get("priority"),
+                "category": pick.get("category"),
+                "deps": list(pick.get("depends") or []),
+            },
+        }
+    )
+    return 0
+
+
+def cmd_done(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = _load(p)
+    if (err := _require_local(data)):
+        return _fail(err)
+
+    tasks = data.get("tasks") or []
+
+    if args.task_id:
+        target = _find_task(data, args.task_id)
+    else:
+        doing = [
+            t for t in tasks
+            if t.get("column") == "DOING" and t.get("assignee") == "claude-code"
+        ]
+        if len(doing) == 0:
+            return _fail("no DOING task assigned to claude-code; pass --task-id")
+        if len(doing) > 1:
+            return _fail(
+                "multiple DOING tasks; pass --task-id",
+                doing=[t.get("id") for t in doing],
+            )
+        target = doing[0]
+
+    if not target:
+        return _fail(f"task {args.task_id!r} not found")
+    col = target.get("column")
+    if col == "DONE":
+        return _fail(f"{target['id']} is already DONE")
+    if col != "DOING":
+        return _fail(f"{target['id']} is in {col!r}, not DOING")
+
+    ts = _now_iso()
+    target["column"] = "DONE"
+    target["completed"] = ts
+    target["updated"] = ts
+    if not target.get("started"):
+        target["started"] = ts
+    if args.note:
+        target.setdefault("comments", []).append(
+            {"author": "claude-code", "ts": ts, "text": args.note}
+        )
+    _save(p, data)
+
+    # Compute newly unblocked tasks: TODO whose deps now all DONE.
+    done_ids = {t.get("id") for t in data.get("tasks") or [] if t.get("column") == "DONE"}
+    unblocked = []
+    for t in data.get("tasks") or []:
+        if t.get("column") != "TODO":
+            continue
+        deps = t.get("depends") or []
+        if not deps or target["id"] not in deps:
+            continue
+        if all(d in done_ids for d in deps):
+            unblocked.append({"id": t.get("id"), "title": t.get("title")})
+
+    _emit(
+        {
+            "ok": True,
+            "id": target["id"],
+            "title": target.get("title"),
+            "completed": ts,
+            "unblocked": unblocked,
+        }
+    )
+    return 0
+
+
+def cmd_block(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    if not args.reason or not args.reason.strip():
+        return _fail("--reason is required and must be non-empty")
+    data = _load(p)
+    if (err := _require_local(data)):
+        return _fail(err)
+    target = _find_task(data, args.task_id)
+    if not target:
+        return _fail(f"task {args.task_id!r} not found")
+    col = target.get("column")
+    if col == "BLOCKED":
+        return _fail(f"{target['id']} is already BLOCKED")
+    if col == "DONE":
+        return _fail(f"{target['id']} is DONE — terminal, cannot be blocked")
+    if col not in {"TODO", "DOING"}:
+        return _fail(f"unexpected column {col!r}")
+
+    ts = _now_iso()
+    target["column"] = "BLOCKED"
+    target["updated"] = ts
+    target.setdefault("custom", {})["blocked_reason"] = args.reason
+    target.setdefault("comments", []).append(
+        {"author": "claude-code", "ts": ts, "text": f"Blocked: {args.reason}"}
+    )
+    _save(p, data)
+
+    downstream = [
+        {"id": t.get("id"), "title": t.get("title")}
+        for t in (data.get("tasks") or [])
+        if args.task_id in (t.get("depends") or [])
+    ]
+    _emit(
+        {
+            "ok": True,
+            "id": target["id"],
+            "title": target.get("title"),
+            "reason": args.reason,
+            "downstream": downstream,
+        }
+    )
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = _load(p)
+    if (err := _require_local(data)):
+        return _fail(err)
+
+    tasks = data.get("tasks") or []
+    counts: dict[str, int] = {c: 0 for c in LOCAL_COLUMNS}
+    for t in tasks:
+        c = t.get("column")
+        if c in counts:
+            counts[c] += 1
+
+    doing = [
+        {
+            "id": t.get("id"),
+            "title": t.get("title"),
+            "priority": t.get("priority"),
+            "started": t.get("started"),
+            "assignee": t.get("assignee"),
+        }
+        for t in tasks
+        if t.get("column") == "DOING"
+    ]
+    blocked = [
+        {
+            "id": t.get("id"),
+            "title": t.get("title"),
+            "priority": t.get("priority"),
+            "reason": (t.get("custom") or {}).get("blocked_reason"),
+        }
+        for t in tasks
+        if t.get("column") == "BLOCKED"
+    ]
+    next_up = _candidate_tasks(data, None, None)[:3]
+    next_summary = [
+        {
+            "id": t.get("id"),
+            "title": t.get("title"),
+            "priority": t.get("priority"),
+            "category": t.get("category"),
+        }
+        for t in next_up
+    ]
+
+    _emit(
+        {
+            "ok": True,
+            "counts": counts,
+            "doing": doing,
+            "blocked": blocked,
+            "next": next_summary,
+            "version": data.get("version") or "0.2",
+        }
+    )
+    return 0
+
+
+# --- entry point ---------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="kanban_local")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("init")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--with-examples", action="store_true")
+    s.add_argument("--force", action="store_true",
+                   help="overwrite an existing kanban.json (destructive)")
+    s.set_defaults(func=cmd_init)
+
+    s = sub.add_parser("next")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--category")
+    s.add_argument("--priority")
+    s.add_argument("--task-id",
+                   help="claim a specific TODO task instead of auto-picking")
+    s.set_defaults(func=cmd_next)
+
+    s = sub.add_parser("done")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--task-id")
+    s.add_argument("--note")
+    s.set_defaults(func=cmd_done)
+
+    s = sub.add_parser("block")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--task-id", required=True)
+    s.add_argument("--reason", required=True)
+    s.set_defaults(func=cmd_block)
+
+    s = sub.add_parser("status")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_status)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/kanban_local.py
+++ b/plugins/kanban/scripts/kanban_local.py
@@ -37,12 +37,11 @@ from pathlib import Path
 from typing import Any
 
 HERE = Path(__file__).resolve()
-PLUGIN_ROOT = HERE.parents[1]               # plugins/kanban
-PLUGINS_ROOT = HERE.parents[2]              # plugins/
+PLUGIN_ROOT = HERE.parents[1]               # holds lib/, drivers/, templates/
 TEMPLATES = PLUGIN_ROOT / "templates"
-sys.path.insert(0, str(PLUGINS_ROOT))
+sys.path.insert(0, str(PLUGIN_ROOT))
 
-from kanban.lib import kanban_io  # noqa: E402
+from lib import kanban_io  # noqa: E402
 
 
 LOCAL_COLUMNS = ("TODO", "DOING", "DONE", "BLOCKED")

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5; do
+for n in 1 2 3 4 5 6; do
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase1.py
+++ b/plugins/kanban/scripts/test_phase1.py
@@ -23,7 +23,7 @@ import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parents[3]
 PLUGIN = REPO / "plugins" / "kanban"
-sys.path.insert(0, str(REPO / "plugins"))
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
 
 def _seed_meta() -> dict:
@@ -37,7 +37,7 @@ def _seed_meta() -> dict:
 
 
 def test_kanban_io():
-    from kanban.lib import kanban_io
+    from lib import kanban_io
 
     # (a) v0.1 normalize
     v01 = {
@@ -80,7 +80,7 @@ def test_kanban_io():
 
 
 def test_credentials_isolation():
-    from kanban.lib import credentials
+    from lib import credentials
 
     with tempfile.TemporaryDirectory() as td:
         # Override module-level paths.
@@ -123,8 +123,8 @@ def test_credentials_isolation():
 
 
 def test_local_driver():
-    from kanban.drivers import get_driver
-    from kanban.drivers.base import HumanRef, NotSupported, TaskFilter, TaskInput
+    from drivers import get_driver
+    from drivers.base import HumanRef, NotSupported, TaskFilter, TaskInput
 
     with tempfile.TemporaryDirectory() as td:
         proj = pathlib.Path(td)

--- a/plugins/kanban/scripts/test_phase2.py
+++ b/plugins/kanban/scripts/test_phase2.py
@@ -26,9 +26,9 @@ import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parents[3]
 PLUGIN = REPO / "plugins" / "kanban"
-sys.path.insert(0, str(REPO / "plugins"))
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
-from kanban.lib.jira_client import (  # noqa: E402
+from lib.jira_client import (  # noqa: E402
     JiraClient,
     JiraError,
     _Response,
@@ -144,8 +144,8 @@ def _mk_kanban_data(*, partial=False, label_fallback=None, ap_field=None):
 def _patched_driver(data, monkeypatch_creds=None):
     """Build a JiraDriver with credentials mocked in via monkey-patch on
     credentials.read."""
-    from kanban.lib import credentials
-    from kanban.drivers.jira import JiraDriver
+    from lib import credentials
+    from drivers.jira import JiraDriver
 
     orig_read = credentials.read
     creds = monkeypatch_creds or {
@@ -171,15 +171,15 @@ def _attach_mock(drv, queue, calls):
 
 
 def test_dispatch_to_jira_driver():
-    from kanban.drivers import get_driver
-    from kanban.drivers.jira import JiraDriver
+    from drivers import get_driver
+    from drivers.jira import JiraDriver
 
     data = _mk_kanban_data()
     with tempfile.TemporaryDirectory() as td:
         drv = _patched_driver(data)
         # _patched_driver builds a fresh driver with td root; here we just
         # verify get_driver returns the right class.
-        from kanban.lib import credentials
+        from lib import credentials
         orig = credentials.read
         credentials.read = lambda prefix=None: {"JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b", "JIRA_API_TOKEN": "tok"}
         try:
@@ -220,7 +220,7 @@ def test_list_tasks_builds_jql():
     calls = []
     _attach_mock(drv, queue, calls)
 
-    from kanban.drivers.base import TaskFilter
+    from drivers.base import TaskFilter
 
     tasks = drv.list_tasks(TaskFilter(column="TODO", limit=10))
     assert len(tasks) == 1
@@ -297,7 +297,7 @@ def test_post_comment_prefixes():
     calls = []
     _attach_mock(drv, queue, calls)
 
-    from kanban.drivers.base import CommentKind
+    from drivers.base import CommentKind
 
     drv.post_comment("AGENT-1", "Body of question?", CommentKind.QUESTION)
     sent = json.loads(calls[0]["body"])

--- a/plugins/kanban/scripts/test_phase3.py
+++ b/plugins/kanban/scripts/test_phase3.py
@@ -26,9 +26,9 @@ import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parents[3]
 PLUGIN = REPO / "plugins" / "kanban"
-sys.path.insert(0, str(REPO / "plugins"))
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
-from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
 
 
 def _mock_transport(queue, calls):
@@ -79,8 +79,8 @@ def _mk_data(ap_field_id="customfield_10042", registered=None, partial=False):
 
 def _patched_driver(data, project_root):
     """Return a JiraDriver with credentials.read mocked."""
-    from kanban.drivers.jira import JiraDriver
-    from kanban.lib import credentials
+    from drivers.jira import JiraDriver
+    from lib import credentials
 
     orig = credentials.read
     credentials.read = lambda prefix=None: {
@@ -107,7 +107,7 @@ def _attach_mock(drv, queue, calls):
 
 
 def test_ap_registry():
-    from kanban.lib import ap_registry as ap
+    from lib import ap_registry as ap
 
     ap.validate_ap_name("agent-fin-exchange")
     for bad in ("", "A", "ab", "1agent", "agent_x", "-agent", "a"*42):
@@ -169,7 +169,7 @@ def test_assign_agent_writes_custom_field():
         calls = []
         _attach_mock(drv, queue, calls)
 
-        from kanban.drivers.base import AgentRef
+        from drivers.base import AgentRef
 
         result = drv.assign("AGENT-1", AgentRef(ap="agent-fin"))
         assert result.ap == "agent-fin"
@@ -218,7 +218,7 @@ def test_transition_refuses_self_approve():
         calls = []
         _attach_mock(drv, queue, calls)
 
-        from kanban.drivers.jira import SelfApproveRefused
+        from drivers.jira import SelfApproveRefused
 
         try:
             drv.transition("AGENT-1", "DONE")

--- a/plugins/kanban/scripts/test_phase4.py
+++ b/plugins/kanban/scripts/test_phase4.py
@@ -26,9 +26,9 @@ import time
 
 REPO = pathlib.Path(__file__).resolve().parents[3]
 PLUGIN = REPO / "plugins" / "kanban"
-sys.path.insert(0, str(REPO / "plugins"))
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
-from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
 
 
 def _mk_data(*, registered=("agent-fin",), partial=False):
@@ -88,7 +88,7 @@ def _setup_cmd(*args, env_extra=None):
 
 
 def test_card_parser():
-    from kanban.lib import card_parser
+    from lib import card_parser
 
     assert card_parser.extract_keys("see AGENT-42 and FIN-103") == ["AGENT-42", "FIN-103"]
     assert card_parser.extract_keys("AGENT-42 AGENT-42") == ["AGENT-42"]
@@ -107,7 +107,7 @@ def test_card_parser():
 
 
 def test_card_cache():
-    from kanban.lib import card_cache
+    from lib import card_cache
 
     with tempfile.TemporaryDirectory() as td:
         p = pathlib.Path(td)
@@ -126,8 +126,8 @@ def test_card_cache():
 
 
 def _patched_driver(data, project_root):
-    from kanban.drivers.jira import JiraDriver
-    from kanban.lib import credentials
+    from drivers.jira import JiraDriver
+    from lib import credentials
 
     orig = credentials.read
     credentials.read = lambda prefix=None: {
@@ -152,7 +152,7 @@ def _attach_mock(drv, queue, calls):
 
 
 def test_driver_invalidates_cache_on_transition():
-    from kanban.lib import card_cache
+    from lib import card_cache
 
     with tempfile.TemporaryDirectory() as td:
         proj = _seed_repo(td, ap="agent-quant")
@@ -208,7 +208,7 @@ def test_driver_invalidates_cache_on_transition():
 
 def test_precheck_card_ap_mismatch():
     """precheck-card emits ap-mismatch when the cached card is owned by another AP."""
-    from kanban.lib import card_cache, kanban_io
+    from lib import card_cache, kanban_io
 
     with tempfile.TemporaryDirectory() as td:
         proj = _seed_repo(td, ap="agent-fin")
@@ -293,7 +293,7 @@ def test_sync_summary_local_skipped():
 
 def test_card_detect_hook_emits_context():
     """kanban-card-detect.sh injects a context block when a card key is in the prompt."""
-    from kanban.lib import card_cache
+    from lib import card_cache
 
     with tempfile.TemporaryDirectory() as td:
         proj = _seed_repo(td)

--- a/plugins/kanban/scripts/test_phase5.py
+++ b/plugins/kanban/scripts/test_phase5.py
@@ -24,16 +24,16 @@ import tempfile
 
 REPO = pathlib.Path(__file__).resolve().parents[3]
 PLUGIN = REPO / "plugins" / "kanban"
-sys.path.insert(0, str(REPO / "plugins"))
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
-from kanban.lib.jira_client import JiraClient, _Response  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
 
 
 # --- mcp_conflict_scan tests ---------------------------------------------
 
 
 def test_mcp_scan_matches_keywords():
-    from kanban.lib.mcp_conflict_scan import _scan_servers
+    from lib.mcp_conflict_scan import _scan_servers
 
     blob = {
         "mcpServers": {
@@ -189,8 +189,8 @@ def test_import_tasks_dry_run():
 
 def test_import_tasks_idempotent():
     """Live import creates Jira issues; second run reports skipped/already-mapped."""
-    from kanban.drivers.jira import JiraDriver
-    from kanban.lib import credentials
+    from drivers.jira import JiraDriver
+    from lib import credentials
 
     with tempfile.TemporaryDirectory() as td:
         p = pathlib.Path(td) / "kanban.json"
@@ -220,13 +220,11 @@ def test_import_tasks_idempotent():
         # Hack the subprocess by setting JIRA_FAKE_DRIVER=1 and patching
         # create_task within the helper. To keep things simple here, run
         # import-tasks in-process instead of subprocess.
-        sys.path.insert(0, str(REPO / "plugins"))
+        sys.path.insert(0, str(REPO / "plugins" / "kanban"))
 
-        from kanban.drivers import base as base_mod  # noqa: F401
-        from kanban.scripts import jira_setup  # type: ignore[import-not-found]
+        from drivers import base as base_mod  # noqa: F401
 
-        # That `from kanban.scripts import` will fail because kanban/scripts
-        # is not a package. Fall back to importing the module via path.
+        # scripts/ is not a package — load jira_setup.py via importlib.
         import importlib.util
         spec = importlib.util.spec_from_file_location(
             "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
@@ -235,8 +233,8 @@ def test_import_tasks_idempotent():
         spec.loader.exec_module(mod)  # type: ignore[union-attr]
 
         # Patch JiraDriver.create_task to a fake.
-        from kanban.drivers.jira import JiraDriver as Jd
-        from kanban.drivers.base import Task
+        from drivers.jira import JiraDriver as Jd
+        from drivers.base import Task
 
         counter = {"n": 100}
         created: list[str] = []
@@ -324,8 +322,8 @@ def test_label_fallback_round_trip():
         for c in ("BLOCKED", "REVIEW", "CANCELLED"):
             data["backend"]["jira"]["statusMap"].pop(c, None)
 
-        from kanban.drivers.jira import JiraDriver
-        from kanban.lib import credentials
+        from drivers.jira import JiraDriver
+        from lib import credentials
 
         orig = credentials.read
         credentials.read = lambda prefix=None: {

--- a/plugins/kanban/scripts/test_phase6.py
+++ b/plugins/kanban/scripts/test_phase6.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Phase 6 regression checks for kanban_local.py — local-mode helper CLI.
+
+Covers what /kanban:init / next / done / block actually exercise after the
+0.2.1 fix. No mocks needed — local mode talks only to the filesystem.
+
+Cases:
+  (a) init creates v0.2 file + schema; reports tasks=0
+  (b) init --with-examples ships 4 example tasks
+  (c) init refuses to overwrite without --force
+  (d) next on empty board returns claimed=null with reason
+  (e) next picks highest priority (P0 first), sets started, assignee
+  (f) next surfaces a tied top-3 instead of guessing
+  (g) next refuses to claim a task whose deps are not all DONE
+  (h) done sets completed and returns unblocked downstream
+  (i) done refuses on non-DOING task
+  (j) block requires --reason, refuses DONE source, preserves started, posts comment
+  (k) status returns counts + DOING + BLOCKED + next-3
+  (l) all writes round-trip through kanban_io as v0.2 (no schema_version)
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+HELPER = PLUGIN / "scripts" / "kanban_local.py"
+
+
+def run(*args: str) -> tuple[int, dict]:
+    r = subprocess.run(
+        ["python3", str(HELPER), *args], capture_output=True, text=True
+    )
+    try:
+        body = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        body = {"_raw": r.stdout, "_stderr": r.stderr}
+    return r.returncode, body
+
+
+def _ensure_v02(p: pathlib.Path) -> dict:
+    on_disk = json.loads(p.read_text())
+    assert on_disk.get("version") == "0.2", on_disk
+    assert "schema_version" not in on_disk
+    assert on_disk.get("backend") == {"driver": "local"}
+    return on_disk
+
+
+def test_init_creates_files():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        rc, j = run("init", "--kanban-path", str(p))
+        assert rc == 0 and j["ok"]
+        assert j["tasks"] == 0
+        assert p.exists() and (pathlib.Path(td) / "kanban.schema.json").exists()
+        on_disk = _ensure_v02(p)
+        assert on_disk.get("tasks") == []
+
+
+def test_init_with_examples_has_4_tasks():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        rc, j = run("init", "--kanban-path", str(p), "--with-examples")
+        assert rc == 0 and j["ok"] and j["tasks"] == 4
+        _ensure_v02(p)
+
+
+def test_init_refuses_overwrite():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        rc, j = run("init", "--kanban-path", str(p))
+        assert rc != 0 and j["ok"] is False
+        # --force overrides
+        rc, j = run("init", "--kanban-path", str(p), "--force")
+        assert rc == 0 and j["ok"]
+
+
+def test_next_on_empty_board():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        rc, j = run("next", "--kanban-path", str(p))
+        assert rc == 0 and j["ok"]
+        assert j["claimed"] is None
+        assert j["reason"]
+
+
+def _seed(p: pathlib.Path, tasks: list[dict]) -> None:
+    base = json.loads(p.read_text())
+    base["tasks"] = tasks
+    p.write_text(json.dumps(base))
+
+
+def test_next_picks_highest_priority():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "low", "column": "TODO",
+             "priority": "P2", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+            {"id": "task-002", "title": "high", "column": "TODO",
+             "priority": "P0", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+        ])
+        rc, j = run("next", "--kanban-path", str(p))
+        assert rc == 0 and j["ok"]
+        assert j["claimed"]["id"] == "task-002", j
+        on_disk = json.loads(p.read_text())
+        t2 = next(t for t in on_disk["tasks"] if t["id"] == "task-002")
+        assert t2["column"] == "DOING"
+        assert t2["started"]
+        assert t2["assignee"] == "claude-code"
+
+
+def test_next_surfaces_tie():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "a", "column": "TODO",
+             "priority": "P0", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+            {"id": "task-002", "title": "b", "column": "TODO",
+             "priority": "P0", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:01+08:00",
+             "updated": "2026-04-29T00:00:01+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+        ])
+        rc, j = run("next", "--kanban-path", str(p))
+        assert j["claimed"] is None and len(j["candidates"]) == 2
+        # File untouched — no claim made.
+        on_disk = json.loads(p.read_text())
+        assert all(t["column"] == "TODO" for t in on_disk["tasks"])
+
+        # Explicit task-id resolves the tie.
+        rc, j = run("next", "--kanban-path", str(p), "--task-id", "task-002")
+        assert j["ok"] and j["claimed"]["id"] == "task-002"
+
+
+def test_next_skips_unsatisfied_deps():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "blocker", "column": "TODO",
+             "priority": "P0", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+            {"id": "task-002", "title": "blocked", "column": "TODO",
+             "priority": "P1", "tags": [], "depends": ["task-001"],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+        ])
+        rc, j = run("next", "--kanban-path", str(p))
+        # task-001 has no deps and is P0 — it's the pick. task-002 must
+        # not be picked because its dep is not DONE.
+        assert j["claimed"]["id"] == "task-001"
+        # If we now finish task-001, task-002 becomes claimable.
+        run("done", "--kanban-path", str(p), "--task-id", "task-001")
+        rc, j = run("next", "--kanban-path", str(p))
+        assert j["claimed"]["id"] == "task-002"
+
+
+def test_done_unblocks_downstream():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "first", "column": "DOING",
+             "priority": "P1", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": "2026-04-29T00:00:00+08:00",
+             "completed": None, "assignee": "claude-code",
+             "description": "", "comments": [], "custom": {}},
+            {"id": "task-002", "title": "second", "column": "TODO",
+             "priority": "P1", "tags": [], "depends": ["task-001"],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+        ])
+        rc, j = run("done", "--kanban-path", str(p))
+        assert j["ok"] and j["id"] == "task-001"
+        assert any(u["id"] == "task-002" for u in j["unblocked"])
+
+
+def test_done_refuses_non_doing():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "x", "column": "TODO",
+             "priority": "P1", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": None, "completed": None, "assignee": None,
+             "description": "", "comments": [], "custom": {}},
+        ])
+        rc, j = run("done", "--kanban-path", str(p), "--task-id", "task-001")
+        assert rc != 0 and j["ok"] is False
+
+
+def test_block_required_reason_and_done_immune():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p))
+        _seed(p, [
+            {"id": "task-001", "title": "active", "column": "DOING",
+             "priority": "P1", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": "2026-04-29T00:00:00+08:00",
+             "completed": None, "assignee": "claude-code",
+             "description": "", "comments": [], "custom": {}},
+            {"id": "task-002", "title": "closed", "column": "DONE",
+             "priority": "P1", "tags": [], "depends": [],
+             "created": "2026-04-29T00:00:00+08:00",
+             "updated": "2026-04-29T00:00:00+08:00",
+             "started": "2026-04-29T00:00:00+08:00",
+             "completed": "2026-04-29T00:00:00+08:00",
+             "assignee": "claude-code",
+             "description": "", "comments": [], "custom": {}},
+        ])
+
+        # Block requires --reason at argparse layer.
+        rc, j = run("block", "--kanban-path", str(p), "--task-id", "task-001",
+                    "--reason", "")
+        assert rc != 0 and j["ok"] is False  # empty reason rejected
+
+        # DONE is terminal.
+        rc, j = run("block", "--kanban-path", str(p), "--task-id", "task-002",
+                    "--reason", "wat")
+        assert rc != 0 and j["ok"] is False
+
+        # Successful block preserves `started` and posts an audit comment.
+        rc, j = run("block", "--kanban-path", str(p), "--task-id", "task-001",
+                    "--reason", "awaiting input")
+        assert rc == 0 and j["ok"]
+        on_disk = json.loads(p.read_text())
+        t = next(x for x in on_disk["tasks"] if x["id"] == "task-001")
+        assert t["column"] == "BLOCKED"
+        assert t["started"]   # preserved
+        assert t["custom"]["blocked_reason"] == "awaiting input"
+        assert any("Blocked:" in c.get("text", "") for c in t.get("comments", []))
+
+
+def test_status_summary():
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "kanban.json"
+        run("init", "--kanban-path", str(p), "--with-examples")
+        rc, j = run("status", "--kanban-path", str(p))
+        assert rc == 0 and j["ok"]
+        assert sum(j["counts"].values()) == 4
+        assert j["counts"]["DOING"] >= 1
+        assert isinstance(j["next"], list)
+
+
+def main() -> int:
+    cases = [
+        ("init_creates_files", test_init_creates_files),
+        ("init_with_examples_has_4_tasks", test_init_with_examples_has_4_tasks),
+        ("init_refuses_overwrite", test_init_refuses_overwrite),
+        ("next_on_empty_board", test_next_on_empty_board),
+        ("next_picks_highest_priority", test_next_picks_highest_priority),
+        ("next_surfaces_tie", test_next_surfaces_tie),
+        ("next_skips_unsatisfied_deps", test_next_skips_unsatisfied_deps),
+        ("done_unblocks_downstream", test_done_unblocks_downstream),
+        ("done_refuses_non_doing", test_done_refuses_non_doing),
+        ("block_required_reason_and_done_immune", test_block_required_reason_and_done_immune),
+        ("status_summary", test_status_summary),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase6: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #3 (Bugs A + B).

## Summary

Two bugs surfaced when bringing `kanban@0.2.0` up on a fresh project:

- **Bug A** — `/kanban:init` (and all local-mode mutation commands) tripped `kanban-guard.sh` because the slash command instructed Claude to use the `Write` tool on `kanban.json`. Claude recovered via Bash + `sed`, but the visible PreToolUse rejection during a clean init was confusing.
- **Bug B** — `/kanban:initjira` failed immediately with `ModuleNotFoundError: No module named 'kanban'`. Root cause: the helper scripts assumed source layout (`plugins/kanban/scripts/...`) but the marketplace installs at `<cache>/<repo>/kanban/<version>/scripts/...`, so `parents[2]` walked one level too far up and `from kanban.lib import …` couldn't resolve.

Both fixed in this PR. Bug B is a hard blocker for Jira mode; Bug A is UX/architecture noise.

## What changed

| Change | File | Bug |
|---|---|---|
| New `kanban_local.py` helper (init / next / done / block / status) writing via atomic `os.replace` through `kanban_io.save()` — same pattern as `jira_setup.py` | `scripts/kanban_local.py` (new) | A |
| Slash commands shrink to thin orchestrators; explicit "do not use Write/Edit on kanban.json" rule | `commands/{init,next,done,block}.md` | A |
| 11 new end-to-end tests covering the helper | `scripts/test_phase6.py` (new) | A |
| Anchor `sys.path` at `parents[1]` + absolute `from lib import …` / `from drivers import …` (works in both source and marketplace layouts) | `scripts/jira_setup.py`, `scripts/kanban_local.py` | B |
| Convert driver-module `from ..lib import …` to absolute `from lib import …` (relative imports beyond top-level fail when `drivers` is loaded as a top-level package) | `drivers/{jira,local}.py` | B |
| Update tests to the new canonical `sys.path` (`plugins/kanban/`) | `scripts/test_phase{1..5}.py` | B |
| Version bumps + CHANGELOG entries | `plugin.json`, `marketplace.json`, `CHANGELOG.md` | both |

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 6 phase suites, **58 tests**, all green
- [x] **Marketplace-layout repro** — synthesised the cache layout in a temp dir; confirmed `kanban_local.py init`, `jira_setup.py health`, `kanban_local.py status`, and `kanban_local.py next` all return `ok: true` with no `ModuleNotFoundError`
- [ ] Real `/plugin install kanban@kirinchen/claude-workbench` → `/reload-plugins` → `/kanban:init` → `/kanban:initjira` after merge

## Versions

- kanban: `0.2.0` → `0.2.1` (Bug A, commit `bfc0c59`) → `0.2.2` (Bug B, commit `e7a30b0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
