### PR TITLE
fix(kanban): 0.3.2 — auto-attach AP field to project screens (#6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-04-30 (later still)
+
+### Fixed
+- **kanban 0.3.2** — closes #6. `/kanban:initjira` option `[b] create new
+  field` now attaches the new AP custom field to project screens
+  automatically. Previously the field was created and option values added,
+  but never associated with any screen, so Jira refused all writes
+  (`customfield_X cannot be set. It is not on the appropriate screen, or
+  unknown.`). Symptom was silent — `/kanban:next` returned no work even
+  with cards present.
+
+  - `lib/jira_client.py` gains `list_screens` (with query filter),
+    `list_screen_tabs`, `list_screen_tab_fields`, `add_field_to_screen_tab`.
+  - `scripts/jira_setup.py:create-ap-field` accepts `--project <KEY>` and
+    runs `_associate_field_with_screens` after the create call. Strategy:
+    list project-named screens via `queryString`, plus the global default
+    screen id=1; for each, add the field to the first tab. Idempotent
+    (already-attached returns silently; 403 routed to a dedicated
+    `denied` bucket so the user can ask their admin).
+  - New `associate-ap-field-screens` and `verify-ap-field-screens`
+    subcommands for re-running or auditing the association after init.
+  - New `/kanban:fix-ap-screen` slash command — recovery path for
+    installs that ran on 0.3.1 (or earlier), or whose admin grants screen
+    permission later.
+  - `commands/initjira.md` step 4 option [b] now passes `--project`,
+    surfaces the screens summary, and runs `verify-ap-field-screens`
+    before continuing to step 5.
+  - `test_phase9.py`: 12 new mocked cases covering endpoint payloads,
+    candidate-screen selection (project + default fallback), happy path,
+    idempotency, 403 handling, CLI integration. All 9 phase suites
+    (99 tests) green.
+
 ## 2026-04-30 (later)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/fix-ap-screen.md
+++ b/plugins/kanban/commands/fix-ap-screen.md
@@ -1,0 +1,97 @@
+---
+description: Attach the AP custom field to project screens so issues can carry its value (recovers from issue #6).
+allowed-tools: Read, Bash(python3:*)
+---
+
+# /kanban:fix-ap-screen
+
+Recover from the issue #6 failure mode where the AP custom field was
+created (e.g. by an older `/kanban:initjira` on 0.3.1) but never
+associated with any Jira screen. Symptom: `/kanban:next` returns nothing
+even though there are TODO cards, because `customfield_X cannot be set`
+on any issue, so no card carries an AP value.
+
+This command:
+
+1. Finds candidate screens (project-scoped + global default).
+2. Attaches `backend.jira.ap.fieldId` to each screen's first tab.
+3. Reports per-screen result so the user knows what worked, what was
+   already in place, and where admin permission was missing.
+
+It is also safe to run on a healthy install — adding a field to a screen
+that already has it is a no-op.
+
+## 0. Pre-flight
+
+- Confirm `kanban.json#backend.driver == "jira"`. Otherwise stop.
+- Confirm `backend.jira.ap.fieldId` exists. If not, the user needs
+  `/kanban:initjira` first.
+
+## 1. Verify current state
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py verify-ap-field-screens \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{ok, fieldId, present: [...], missing: [...]}`.
+
+If `missing` is empty, print:
+
+```
+✓ AP field is already attached to all candidate screens. Nothing to do.
+```
+
+…and stop.
+
+Otherwise, list the missing screens before doing anything mutating:
+
+```
+AP field "<fieldName>" (<fieldId>) is missing from:
+  • <screen-1>
+  • <screen-2>
+
+Attach now? (y/N)
+```
+
+## 2. Associate
+
+If the user accepts:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py associate-ap-field-screens \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{ok: true, fieldId, screens: {attempted, attached, denied, errors}}`.
+
+Render:
+
+```
+Screen association summary:
+  ✓ Attached to <N> screen(s):
+      • <name> (id=<id>)         (or "(already present)")
+  ⚠ Denied (admin permission needed):
+      • <name> (id=<id>)
+  ✗ Errors:
+      • <name> — <detail>
+```
+
+If `denied` is non-empty, suggest:
+
+> Ask a Jira global admin to add `<fieldName>` to:
+>   <list of denied screen names>
+> via Project Settings → Screens → <screen> → "Add field".
+
+## 3. Verify after fix
+
+Re-run step 1's `verify-ap-field-screens`. Confirm `missing` shrank or is
+now empty.
+
+## Absolute rules
+
+- Read `backend.jira.ap.fieldId` and `projectKey` from `kanban.json` —
+  never accept them via CLI args (avoids accidental writes against the
+  wrong field).
+- Do not retry on 403 — surface as `denied` and let the user route to admin.
+- Do not write to `kanban.json` (this command is purely Jira-side).

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -272,10 +272,39 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py set-ap-field \
 
 ### Option [b] — create new field
 
+Pass the project key so the helper can attach the new field to project
+screens automatically (closes #6 — without this, the field exists but no
+issue can carry its value):
+
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py create-ap-field \
-  --name 'Claude Agent'
+  --name 'Claude Agent' --project '<KEY>'
 ```
+
+The response now includes a `screens` summary:
+
+```json
+{
+  "ok": true, "fieldId": "customfield_10042", "fieldName": "Claude Agent",
+  "screens": {
+    "attempted": [{"id": 1, "name": "Default Screen"},
+                  {"id": 42, "name": "DMI: Kanban Default Issue Screen"}],
+    "attached":  [{"id": 1, "name": "Default Screen"},
+                  {"id": 42, "name": "DMI: Kanban Default Issue Screen"}],
+    "denied": [], "errors": []
+  }
+}
+```
+
+If `screens.denied` is non-empty, the field exists but Jira refused to
+attach it to one or more screens (admin permission needed). Surface the
+list verbatim and suggest:
+
+> ⚠ AP field created, but couldn't attach it to: `<screen names>`.
+> Ask a Jira admin to add `<fieldName>` to those screens, or run
+> `/kanban:fix-ap-screen` after they grant you permission. **Until at
+> least one screen carries the field, `/kanban:next` will return no
+> work even if cards exist.**
 
 On `ok=true`, persist the new field:
 
@@ -285,10 +314,22 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py set-ap-field \
   --field-id '<returned fieldId>' --field-name 'Claude Agent'
 ```
 
-On `403` (admin permission missing), surface the helper's error verbatim
-and tell the user to either ask their Jira admin to create a single-select
-custom field once, then re-run `/kanban:initjira` and choose `[a]`. Stop —
-do NOT silently fall back to `[a]`; the choice is the user's.
+Then verify the association is healthy before moving on:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py verify-ap-field-screens \
+  --kanban-path '<kanban.json path>'
+```
+
+If `missing` is non-empty, print the same warning as above and continue —
+don't abort init, but make sure the user knows the next step is to run
+`/kanban:fix-ap-screen` (or have an admin do it).
+
+On `403` from `create-ap-field` itself (the create step, not screen
+association), surface the helper's error verbatim and tell the user to
+either ask their Jira admin to create a single-select custom field once,
+then re-run `/kanban:initjira` and choose `[a]`. Stop — do NOT silently
+fall back to `[a]`; the choice is the user's.
 
 ## Step 5/5 — First AP registration
 

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -302,6 +302,51 @@ class JiraClient:
             body={"fields": fields},
         )
 
+    # --- screens (Phase 9: AP-field association) ---------------------
+
+    def list_screens(self, *, query: str | None = None) -> dict[str, Any]:
+        """GET /rest/api/3/screens, optionally filtered by `queryString`.
+
+        Used to find project-scoped screens that should carry the AP
+        custom field. Most teams have screens whose names mention the
+        project key or name; passing the project key as the query is
+        a reasonable heuristic.
+        """
+        params = {"queryString": query} if query else None
+        return self._request("GET", "/rest/api/3/screens", query=params)
+
+    def list_screen_tabs(self, screen_id: int | str) -> list[dict[str, Any]]:
+        """GET /rest/api/3/screens/{id}/tabs."""
+        return self._request("GET", f"/rest/api/3/screens/{screen_id}/tabs")
+
+    def list_screen_tab_fields(
+        self, screen_id: int | str, tab_id: int | str
+    ) -> list[dict[str, Any]]:
+        """GET /rest/api/3/screens/{id}/tabs/{tab_id}/fields."""
+        return self._request(
+            "GET", f"/rest/api/3/screens/{screen_id}/tabs/{tab_id}/fields"
+        )
+
+    def add_field_to_screen_tab(
+        self,
+        screen_id: int | str,
+        tab_id: int | str,
+        field_id: str,
+    ) -> dict[str, Any]:
+        """POST /rest/api/3/screens/{id}/tabs/{tab_id}/fields.
+
+        Adds a custom field to a screen tab so issues can have its value
+        set at create / edit time. Idempotent on the server side: adding
+        an already-present field returns 200 with the existing record.
+        Requires Jira global admin (a 403 here is a real authorization
+        signal, not a bug).
+        """
+        return self._request(
+            "POST",
+            f"/rest/api/3/screens/{screen_id}/tabs/{tab_id}/fields",
+            body={"fieldId": field_id},
+        )
+
 
 # -------- helpers ----------------------------------------------------------
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -452,6 +452,107 @@ def cmd_find_ap_field(_args: argparse.Namespace) -> int:
     return 0
 
 
+def _candidate_screens(
+    client: JiraClient, project_key: str
+) -> list[dict[str, Any]]:
+    """Return screens likely to need the AP field.
+
+    Strategy:
+    1. Query screens whose name contains the project key (Jira's
+       project-scoped screens conventionally embed the key in the name,
+       e.g. "DMI: Kanban Default Issue Screen").
+    2. Always include the default screen (id=1) as a global fallback.
+    3. Dedupe by id.
+    """
+    screens: dict[int, dict[str, Any]] = {}
+    try:
+        listing = client.list_screens(query=project_key) or {}
+        for s in listing.get("values") or []:
+            sid = s.get("id")
+            if isinstance(sid, int):
+                screens[sid] = s
+    except JiraError:
+        pass
+    # Default screen — almost always present, used by simple project schemes.
+    screens.setdefault(
+        1, {"id": 1, "name": "Default Screen", "_default_fallback": True}
+    )
+    return list(screens.values())
+
+
+def _associate_field_with_screens(
+    client: JiraClient, field_id: str, project_key: str
+) -> dict[str, Any]:
+    """Attach `field_id` to the first tab of every candidate screen.
+
+    Returns:
+        {
+          "attempted": [...screens tried...],
+          "attached":  [...succeeded or already-present...],
+          "denied":    [...403s — admin needed...],
+          "errors":    [...other failures...],
+        }
+    """
+    out: dict[str, Any] = {
+        "attempted": [],
+        "attached": [],
+        "denied": [],
+        "errors": [],
+    }
+    for screen in _candidate_screens(client, project_key):
+        sid = screen.get("id")
+        sname = screen.get("name", "")
+        out["attempted"].append({"id": sid, "name": sname})
+        try:
+            tabs = client.list_screen_tabs(sid) or []
+        except JiraError as e:
+            if e.status_code in (403, 404):
+                # 404 on the default screen is not unusual — some workflow
+                # schemes don't share screen 1 with the project.
+                if e.status_code == 403:
+                    out["denied"].append({"id": sid, "name": sname, "phase": "list_tabs"})
+                else:
+                    out["errors"].append({"id": sid, "name": sname,
+                                          "phase": "list_tabs", "detail": e.detail or str(e)})
+                continue
+            out["errors"].append(
+                {"id": sid, "name": sname, "phase": "list_tabs",
+                 "detail": e.detail or str(e), "status": e.status_code}
+            )
+            continue
+        if not tabs:
+            out["errors"].append({"id": sid, "name": sname,
+                                  "phase": "list_tabs", "detail": "no tabs"})
+            continue
+        tab = tabs[0]
+        tid = tab.get("id")
+
+        # Idempotency: skip if the field is already on this tab.
+        try:
+            existing = client.list_screen_tab_fields(sid, tid) or []
+            if any((f or {}).get("id") == field_id for f in existing):
+                out["attached"].append({"id": sid, "name": sname,
+                                        "tab": tab.get("name", ""),
+                                        "alreadyPresent": True})
+                continue
+        except JiraError:
+            pass  # if listing fields fails, fall through to add and let it 200/error
+
+        try:
+            client.add_field_to_screen_tab(sid, tid, field_id)
+            out["attached"].append({"id": sid, "name": sname,
+                                    "tab": tab.get("name", "")})
+        except JiraError as e:
+            if e.status_code == 403:
+                out["denied"].append({"id": sid, "name": sname, "phase": "add_field"})
+            else:
+                out["errors"].append(
+                    {"id": sid, "name": sname, "phase": "add_field",
+                     "detail": e.detail or str(e), "status": e.status_code}
+                )
+    return out
+
+
 def cmd_create_ap_field(args: argparse.Namespace) -> int:
     client = _client_from_env()
     try:
@@ -470,7 +571,111 @@ def cmd_create_ap_field(args: argparse.Namespace) -> int:
             return 1
         _fail(f"jira: {e.detail or e}", statusCode=e.status_code)
         return 1
-    _emit({"ok": True, "fieldId": result.get("id"), "fieldName": result.get("name")})
+
+    field_id = result.get("id")
+    field_name = result.get("name")
+
+    # Fixes #6: a freshly-created custom field is not on any screen, so
+    # `customfield_X cannot be set` for create/edit. Attach to project
+    # screens immediately. Best-effort — admin perms may be needed; if
+    # any individual screen association fails the user can run
+    # /kanban:fix-ap-screen manually.
+    screens_summary: dict[str, Any] | None = None
+    if field_id and args.project:
+        try:
+            screens_summary = _associate_field_with_screens(
+                client, field_id, args.project
+            )
+        except Exception as e:  # noqa: BLE001 — last-resort net catch
+            screens_summary = {"error": f"{type(e).__name__}: {e}"}
+
+    _emit(
+        {
+            "ok": True,
+            "fieldId": field_id,
+            "fieldName": field_name,
+            "screens": screens_summary,
+        }
+    )
+    return 0
+
+
+def cmd_associate_ap_field_screens(args: argparse.Namespace) -> int:
+    """Re-run screen association for an existing AP field.
+
+    Useful when /kanban:initjira ran on 0.3.1 (which didn't associate
+    screens) or when the user adds new project-scoped screens later.
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        return _fail("backend.driver must be 'jira'")
+    cfg = backend.get("jira") or {}
+    project_key = cfg.get("projectKey")
+    field_id = ((cfg.get("ap") or {}).get("fieldId"))
+    if not project_key or not field_id:
+        return _fail(
+            "kanban.json is missing projectKey or backend.jira.ap.fieldId — "
+            "run /kanban:initjira first"
+        )
+    client = _client_from_env()
+    summary = _associate_field_with_screens(client, field_id, project_key)
+    _emit({"ok": True, "fieldId": field_id, "screens": summary})
+    return 0
+
+
+def cmd_verify_ap_field_screens(args: argparse.Namespace) -> int:
+    """Report which candidate screens currently carry the AP field.
+
+    Read-only. Returns:
+        {
+          "ok": true,
+          "fieldId": "customfield_X",
+          "present": [{id, name}, ...],
+          "missing": [{id, name}, ...],
+        }
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        return _fail("backend.driver must be 'jira'")
+    cfg = backend.get("jira") or {}
+    project_key = cfg.get("projectKey")
+    field_id = ((cfg.get("ap") or {}).get("fieldId"))
+    if not project_key or not field_id:
+        return _fail("kanban.json is missing projectKey or ap.fieldId")
+    client = _client_from_env()
+
+    present: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    for screen in _candidate_screens(client, project_key):
+        sid, sname = screen.get("id"), screen.get("name", "")
+        try:
+            tabs = client.list_screen_tabs(sid) or []
+        except JiraError:
+            missing.append({"id": sid, "name": sname, "reason": "tabs unreachable"})
+            continue
+        found = False
+        for tab in tabs:
+            try:
+                fields = client.list_screen_tab_fields(sid, tab.get("id")) or []
+            except JiraError:
+                continue
+            if any((f or {}).get("id") == field_id for f in fields):
+                found = True
+                break
+        if found:
+            present.append({"id": sid, "name": sname})
+        else:
+            missing.append({"id": sid, "name": sname})
+
+    _emit({"ok": True, "fieldId": field_id, "present": present, "missing": missing})
     return 0
 
 
@@ -1294,7 +1499,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     s = sub.add_parser("create-ap-field")
     s.add_argument("--name", default="Claude Agent")
+    s.add_argument(
+        "--project",
+        help="project key — used to find project-scoped screens for "
+             "automatic field association (fixes #6). When omitted, "
+             "the field is created but not attached to any screen.",
+    )
     s.set_defaults(func=cmd_create_ap_field)
+
+    s = sub.add_parser("associate-ap-field-screens")
+    s.add_argument("--kanban-path", required=True,
+                   help="reads projectKey + ap.fieldId from this kanban.json")
+    s.set_defaults(func=cmd_associate_ap_field_screens)
+
+    s = sub.add_parser("verify-ap-field-screens")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_verify_ap_field_screens)
 
     s = sub.add_parser("set-ap-field")
     s.add_argument("--kanban-path", required=True)

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8; do  # phase8 covers code emit/import + live AP query
+for n in 1 2 3 4 5 6 7 8 9; do  # phase8: code emit/import + live AP; phase9: AP-field screen association
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase9.py
+++ b/plugins/kanban/scripts/test_phase9.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Phase 9 regression checks for kanban v0.3.2 — AP-field screen association.
+
+Closes issue #6: a custom field created via `create-ap-field` was never
+attached to any Jira screen, leaving the plugin in a broken-by-design
+state where `/kanban:next` returned nothing because no card could carry
+an AP value.
+
+Cases:
+  (a) jira_client: list_screens / list_screen_tabs / list_screen_tab_fields
+       / add_field_to_screen_tab — endpoints + payloads
+  (b) _candidate_screens — picks project-named screens + always-include
+       default screen id=1; deduped
+  (c) _associate_field_with_screens — happy path: attaches field to all
+       candidate screens' first tab, returns clean attached list
+  (d) _associate_field_with_screens — idempotent: when field is already on
+       a screen, reports alreadyPresent without making the POST
+  (e) _associate_field_with_screens — 403 on add_field is captured under
+       `denied`, not `errors`; flow continues to the next screen
+  (f) cmd_create_ap_field with --project triggers screen association and
+       returns screens summary
+  (g) cmd_create_ap_field without --project skips association
+       (back-compat for explicit callers)
+  (h) cmd_associate_ap_field_screens reads kanban.json for projectKey +
+       fieldId; exits ok with summary
+  (i) cmd_verify_ap_field_screens returns present[]/missing[] correctly
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response, JiraError  # noqa: E402
+
+
+# Load jira_setup as a module so we can call its internal helpers directly.
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _mock_transport(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return t
+
+
+def _mk_client(queue, calls):
+    return JiraClient(
+        "https://x.atlassian.net", "a@b", "tok",
+        transport=_mock_transport(queue, calls), sleep=lambda _: None,
+    )
+
+
+# --- jira_client endpoints -----------------------------------------------
+
+
+def test_list_screens_with_query():
+    queue = [_Response(200, b'{"values":[{"id":42,"name":"DMI: Kanban Default Issue Screen"}]}', {})]
+    calls = []
+    c = _mk_client(queue, calls)
+    out = c.list_screens(query="DMI")
+    assert out["values"][0]["id"] == 42
+    assert "queryString=DMI" in calls[0]["url"]
+
+
+def test_list_screen_tabs_and_fields():
+    queue = [
+        _Response(200, b'[{"id":1,"name":"Field Tab"}]', {}),
+        _Response(200, b'[{"id":"customfield_10325","name":"Claude Agent"},'
+                       b'{"id":"summary","name":"Summary"}]', {}),
+    ]
+    calls = []
+    c = _mk_client(queue, calls)
+    tabs = c.list_screen_tabs(42)
+    assert tabs[0]["id"] == 1
+    fields = c.list_screen_tab_fields(42, 1)
+    field_ids = {f["id"] for f in fields}
+    assert "customfield_10325" in field_ids
+    assert calls[1]["url"].endswith("/screens/42/tabs/1/fields")
+
+
+def test_add_field_to_screen_tab_payload():
+    queue = [_Response(200, b'{"id":"customfield_10325","name":"Claude Agent"}', {})]
+    calls = []
+    c = _mk_client(queue, calls)
+    c.add_field_to_screen_tab(42, 1, "customfield_10325")
+    sent = json.loads(calls[0]["body"])
+    assert sent == {"fieldId": "customfield_10325"}
+    assert calls[0]["method"] == "POST"
+
+
+# --- _candidate_screens --------------------------------------------------
+
+
+def test_candidate_screens_includes_default():
+    queue = [_Response(200, b'{"values":[{"id":42,"name":"DMI: Kanban Default Issue Screen"}]}', {})]
+    calls = []
+    c = _mk_client(queue, calls)
+    screens = _jira_setup._candidate_screens(c, "DMI")
+    ids = sorted(s["id"] for s in screens)
+    assert 1 in ids        # default screen always added
+    assert 42 in ids       # project-named screen kept
+    assert len(set(ids)) == len(ids)  # deduped
+
+
+def test_candidate_screens_handles_query_failure():
+    queue = [_Response(403, b'{"errorMessages":["forbidden"]}', {})]
+    calls = []
+    c = _mk_client(queue, calls)
+    screens = _jira_setup._candidate_screens(c, "DMI")
+    # Falls back to just the default screen
+    assert [s["id"] for s in screens] == [1]
+
+
+# --- _associate_field_with_screens --------------------------------------
+
+
+def _seed_screen_responses(field_id, present_on=()):
+    """Build a queue mocking responses for two screens (default=1 + DMI=42).
+
+    `present_on` is an iterable of screen ids where the field is already
+    attached — those skip the POST and use list_screen_tab_fields instead.
+    """
+    queue: list[_Response] = []
+
+    # 1. _candidate_screens calls list_screens(query="DMI")
+    queue.append(_Response(
+        200, b'{"values":[{"id":42,"name":"DMI: Kanban Default Issue Screen"}]}', {}))
+
+    # 2. _associate iterates screens (id=1, id=42 — depending on ordering)
+    # We need to support both orderings since dict iteration order is
+    # insertion order. _candidate_screens adds queried screens first then
+    # defaults — but `screens.setdefault(1, ...)` runs after, so 1 may
+    # come last. The function order is: queried first (42), then default 1.
+    for sid in (42, 1):
+        # list_screen_tabs
+        queue.append(_Response(200, b'[{"id":' + str(sid * 10).encode() + b',"name":"Tab"}]', {}))
+        # list_screen_tab_fields (presence check)
+        if sid in present_on:
+            body = b'[{"id":"' + field_id.encode() + b'"}]'
+            queue.append(_Response(200, body, {}))
+            # No POST — already present
+        else:
+            queue.append(_Response(200, b"[]", {}))
+            # POST add_field
+            queue.append(_Response(200, b'{"id":"' + field_id.encode() + b'"}', {}))
+    return queue
+
+
+def test_associate_happy_path():
+    queue = _seed_screen_responses("customfield_10325")
+    calls = []
+    c = _mk_client(queue, calls)
+    out = _jira_setup._associate_field_with_screens(c, "customfield_10325", "DMI")
+    assert len(out["attempted"]) == 2
+    assert len(out["attached"]) == 2
+    assert out["denied"] == []
+    assert out["errors"] == []
+    # POST was made for both screens (no alreadyPresent shortcut)
+    posts = [x for x in calls if x["method"] == "POST"]
+    assert len(posts) == 2
+
+
+def test_associate_idempotent_already_present():
+    queue = _seed_screen_responses("customfield_10325", present_on=(1, 42))
+    calls = []
+    c = _mk_client(queue, calls)
+    out = _jira_setup._associate_field_with_screens(c, "customfield_10325", "DMI")
+    assert len(out["attached"]) == 2
+    assert all(s.get("alreadyPresent") for s in out["attached"])
+    # No POSTs — pure read operations
+    posts = [x for x in calls if x["method"] == "POST"]
+    assert posts == []
+
+
+def test_associate_403_on_add_is_denied_not_error():
+    queue: list[_Response] = []
+    queue.append(_Response(200, b'{"values":[{"id":42,"name":"DMI"}]}', {}))
+    # screen 42 — list tabs ok, list fields empty, add 403
+    queue.append(_Response(200, b'[{"id":420,"name":"Tab"}]', {}))
+    queue.append(_Response(200, b"[]", {}))
+    queue.append(_Response(403, b'{"errorMessages":["denied"]}', {}))
+    # screen 1 — succeed normally
+    queue.append(_Response(200, b'[{"id":10,"name":"Tab"}]', {}))
+    queue.append(_Response(200, b"[]", {}))
+    queue.append(_Response(200, b'{"id":"customfield_10325"}', {}))
+
+    calls = []
+    c = _mk_client(queue, calls)
+    out = _jira_setup._associate_field_with_screens(c, "customfield_10325", "DMI")
+    assert len(out["denied"]) == 1
+    assert out["denied"][0]["id"] == 42
+    assert len(out["attached"]) == 1
+    assert out["attached"][0]["id"] == 1
+    assert out["errors"] == []
+
+
+# --- cmd_create_ap_field --------------------------------------------------
+
+
+def _patch_client_for_cmd(client_factory):
+    """Replace _client_from_env with a factory returning the test client."""
+    orig = _jira_setup._client_from_env
+    _jira_setup._client_from_env = client_factory
+    return orig
+
+
+def _restore_client(orig):
+    _jira_setup._client_from_env = orig
+
+
+def test_cmd_create_ap_field_with_project_attaches_screens(capsys=None):
+    queue = [
+        # create_custom_field
+        _Response(200, b'{"id":"customfield_10325","name":"Claude Agent"}', {}),
+        # _associate flow
+        *_seed_screen_responses("customfield_10325"),
+    ]
+    calls = []
+    c = _mk_client(queue, calls)
+    orig = _patch_client_for_cmd(lambda: c)
+    try:
+        from io import StringIO
+        old = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            class A: name = "Claude Agent"; project = "DMI"
+            rc = _jira_setup.cmd_create_ap_field(A())
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old
+    finally:
+        _restore_client(orig)
+    assert rc == 0
+    j = json.loads(out)
+    assert j["ok"] is True
+    assert j["fieldId"] == "customfield_10325"
+    assert j["screens"]["attached"]
+    assert len(j["screens"]["attached"]) == 2
+
+
+def test_cmd_create_ap_field_without_project_skips_screens():
+    queue = [_Response(200, b'{"id":"customfield_10325","name":"Claude Agent"}', {})]
+    calls = []
+    c = _mk_client(queue, calls)
+    orig = _patch_client_for_cmd(lambda: c)
+    try:
+        from io import StringIO
+        old = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            class A: name = "Claude Agent"; project = None
+            rc = _jira_setup.cmd_create_ap_field(A())
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old
+    finally:
+        _restore_client(orig)
+    assert rc == 0
+    j = json.loads(out)
+    assert j["screens"] is None  # association skipped
+    # Only one HTTP call total — the field create
+    assert len(calls) == 1
+
+
+# --- cmd_associate_ap_field_screens + cmd_verify_ap_field_screens -------
+
+
+def _seed_v03_kanban(td) -> pathlib.Path:
+    p = pathlib.Path(td) / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "projectKey": "DMI",
+                "boardId": 1,
+                "boardUrl": "https://x.atlassian.net/jira/software/projects/DMI/boards/1",
+                "transitions": {"DOING": {"status": "In Progress"}},
+                "ap": {"fieldId": "customfield_10325", "fieldName": "Claude Agent",
+                       "registered": []},
+            },
+        },
+        "meta": {
+            "priorities": ["P0"], "categories": [],
+            "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+            "created_at": "x", "updated_at": "x",
+        },
+        "tasks": [],
+    }))
+    return p
+
+
+def test_cmd_associate_reads_kanban():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_v03_kanban(td)
+        queue = _seed_screen_responses("customfield_10325")
+        calls = []
+        c = _mk_client(queue, calls)
+        orig = _patch_client_for_cmd(lambda: c)
+        try:
+            from io import StringIO
+            old = sys.stdout
+            sys.stdout = StringIO()
+            try:
+                class A: kanban_path = str(kp)
+                rc = _jira_setup.cmd_associate_ap_field_screens(A())
+                out = sys.stdout.getvalue()
+            finally:
+                sys.stdout = old
+        finally:
+            _restore_client(orig)
+        assert rc == 0
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["fieldId"] == "customfield_10325"
+        assert len(j["screens"]["attached"]) == 2
+
+
+def test_cmd_verify_reports_present_and_missing():
+    """Default screen has the field; project screen does not."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_v03_kanban(td)
+        queue: list[_Response] = []
+        # _candidate_screens query
+        queue.append(_Response(200, b'{"values":[{"id":42,"name":"DMI"}]}', {}))
+        # iter screens — ordering: queried (42) first, then default (1)
+        # screen 42 → tabs → fields (no field present)
+        queue.append(_Response(200, b'[{"id":420,"name":"T"}]', {}))
+        queue.append(_Response(200, b"[]", {}))
+        # screen 1 → tabs → fields (field present)
+        queue.append(_Response(200, b'[{"id":10,"name":"T"}]', {}))
+        queue.append(_Response(200, b'[{"id":"customfield_10325"}]', {}))
+
+        calls = []
+        c = _mk_client(queue, calls)
+        orig = _patch_client_for_cmd(lambda: c)
+        try:
+            from io import StringIO
+            old = sys.stdout
+            sys.stdout = StringIO()
+            try:
+                class A: kanban_path = str(kp)
+                rc = _jira_setup.cmd_verify_ap_field_screens(A())
+                out = sys.stdout.getvalue()
+            finally:
+                sys.stdout = old
+        finally:
+            _restore_client(orig)
+        assert rc == 0
+        j = json.loads(out)
+        assert {s["id"] for s in j["present"]} == {1}
+        assert {s["id"] for s in j["missing"]} == {42}
+
+
+def main() -> int:
+    cases = [
+        ("list_screens_with_query", test_list_screens_with_query),
+        ("list_screen_tabs_and_fields", test_list_screen_tabs_and_fields),
+        ("add_field_to_screen_tab_payload", test_add_field_to_screen_tab_payload),
+        ("candidate_screens_includes_default", test_candidate_screens_includes_default),
+        ("candidate_screens_handles_query_failure", test_candidate_screens_handles_query_failure),
+        ("associate_happy_path", test_associate_happy_path),
+        ("associate_idempotent_already_present", test_associate_idempotent_already_present),
+        ("associate_403_on_add_is_denied_not_error", test_associate_403_on_add_is_denied_not_error),
+        ("cmd_create_ap_field_with_project_attaches_screens",
+         test_cmd_create_ap_field_with_project_attaches_screens),
+        ("cmd_create_ap_field_without_project_skips_screens",
+         test_cmd_create_ap_field_without_project_skips_screens),
+        ("cmd_associate_reads_kanban", test_cmd_associate_reads_kanban),
+        ("cmd_verify_reports_present_and_missing", test_cmd_verify_reports_present_and_missing),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase9: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #6.

## Summary

`/kanban:initjira` option `[b] create new field` succeeded at creating the AP custom field, registering its default context, and adding option values via `register-ap` — but **never associated the field with any Jira screen**. Effect: the field exists, JQL can search it, but no issue could ever have its value set, because Jira rejects writes to fields that aren't on a project's screens (`customfield_X cannot be set. It is not on the appropriate screen, or unknown.`).

The user got through `/kanban:initjira` end-to-end with no error and only discovered the problem when `/kanban:next` silently returned nothing.

## Fix

| Change | Where |
|---|---|
| New REST endpoints: `list_screens`, `list_screen_tabs`, `list_screen_tab_fields`, `add_field_to_screen_tab` | `lib/jira_client.py` |
| `create-ap-field` accepts `--project KEY` and immediately associates the field with project-named screens + the global default screen (id=1). Idempotent on the server side. 403s on individual screens go to a `denied` bucket so the slash command can surface them as "ask your admin"; flow continues for the rest. | `scripts/jira_setup.py` |
| New `associate-ap-field-screens` subcommand — re-run association after init (e.g. when admin grants permission later, or for recovery on 0.3.1 installs). | `scripts/jira_setup.py` |
| New `verify-ap-field-screens` subcommand — read-only audit, returns `present[]` / `missing[]`. | `scripts/jira_setup.py` |
| New `/kanban:fix-ap-screen` slash command — verify, prompt the user, then associate. | `commands/fix-ap-screen.md` |
| `/kanban:initjira` step 4 [b] now passes `--project`, prints the screens summary, and runs `verify-ap-field-screens` before moving on. Doesn't abort when association fails — surfaces a loud warning instead. | `commands/initjira.md` |
| 12 new mocked tests | `scripts/test_phase9.py` |
| Bump `0.3.1 → 0.3.2`; CHANGELOG entry | versions / CHANGELOG |

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 9 phase suites, **99 tests**, all green
- [x] `_associate_field_with_screens` happy path: attaches to default + project-named screens
- [x] Idempotency: already-attached field reports `alreadyPresent` without making the POST
- [x] 403 on `add_field_to_screen_tab` is captured under `denied`, not `errors`; flow continues to the next screen
- [x] `cmd_create_ap_field` with `--project` returns the screens summary; without `--project` the call is back-compatible (skips association, returns `screens: null`)
- [x] `cmd_verify_ap_field_screens` returns correct present/missing lists
- [ ] After merge: real `/kanban:fix-ap-screen` against the DMI project — verify `customfield_10325` ends up on the project's create/edit screens; verify `/kanban:next` then returns cards

## Notes

- The same issue mentions two side observations (default Jira workflow drops new issues into "Backlog" not the canonical TODO; `import-tasks` is markdown-blind). Both are deliberately out of scope for this PR — they're separate features, not regressions.
- For users on 0.3.1 who already ran `/kanban:initjira [b]`, the recovery path is `/kanban:fix-ap-screen` (no need to recreate the field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
