### PR TITLE
feat(kanban): 0.3.3 — /kanban:block --blocked-by creates Jira issue links (#8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-04-30 (issue links)
+
+### Added
+- **kanban 0.3.3** — `/kanban:block` accepts `--blocked-by KEY[,KEY,...]`.
+  Closes #8. Creates Jira native "is blocked by" issue links before
+  applying the BLOCKED transition, so the dependency surfaces in Jira's
+  "Linked work items" panel and JQL `issueLinkType` queries — instead of
+  being buried in a free-text `blocked_reason` comment.
+
+  Highlights:
+  - `lib/jira_client.py` gains `create_issue_link(type_name, inward_key,
+    outward_key)` mapping to `POST /rest/api/3/issueLink`.
+  - `drivers/jira.py:_link_blockers` validates blocker key format
+    (`^[A-Z][A-Z0-9_]+-\d+$`), refuses self-block, dedupes, skips
+    already-linked blockers (idempotent), and runs **before** the status
+    transition so a 404 leaves the card in its previous state instead of
+    half-blocked.
+  - `_issue_to_task` now reads `issuelinks` and surfaces inward `Blocks`
+    keys as `Task.depends`, giving Jira mode parity with local mode's
+    `depends[]` field.
+  - `cmd_transition` accepts `--blocked-by` (comma-separated). Rejects
+    use with `--to != BLOCKED`. Response gains `depends[]` reflecting
+    the post-operation link state.
+  - `commands/block.md` documents the Jira flow: pass `--blocked-by`
+    explicitly, or confirm extraction from prose via `AskUserQuestion`
+    (no silent inference). Multi-blocker, cross-project links supported.
+  - `test_phase10.py`: 12 new mocked cases covering endpoint payload,
+    `depends` extraction from `issuelinks`, format/self-block rejection,
+    idempotency, atomicity (link-failure aborts before transition),
+    full transition integration, CLI roundtrip. All 10 phase suites
+    (111 tests) green.
+
 ## 2026-04-30 (later still)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/block.md
+++ b/plugins/kanban/commands/block.md
@@ -1,6 +1,6 @@
 ---
 description: Move a task to BLOCKED with a required reason.
-argument-hint: <task-id> --reason=<text>
+argument-hint: <task-id> --reason=<text> [--blocked-by=<KEY>[,<KEY>...]]
 allowed-tools: Read, Bash(python3:*), Bash(date:*)
 ---
 
@@ -58,15 +58,42 @@ If `downstream` is non-empty, append: `Downstream impact: <id-1>, <id-2>`.
 
 ## Jira flow
 
+Parse `$ARGUMENTS` — accept the same `--reason` as local mode, plus an
+optional `--blocked-by=<KEY>[,<KEY>...]` to attach proper Jira "is blocked
+by" issue links. Format must match `^[A-Z][A-Z0-9_]+-\d+$` (e.g.
+`DMI-1099`). Cross-project blockers are fine (Jira links cross projects
+natively).
+
+If the user gives prose like "blocked by DMI-1099 because…", offer to
+extract the key — but **don't auto-link silently**. Confirm via
+`AskUserQuestion`, then pass the confirmed key as `--blocked-by`.
+
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
   --kanban-path '<kanban.json path>' --key '<KEY>' --to BLOCKED \
-  --reason '<reason text>'
+  --reason '<reason text>' \
+  [--blocked-by 'DMI-1099,INFRA-7']
 ```
 
-The driver posts a `[<ap>] [S] Blocked: <reason>` system comment alongside
-the transition. In `partial` mode, the plugin substitutes the
-`kanban:blocked` label and posts the same audit comment.
+Order of operations (matters for atomicity):
+
+1. **Validate + create issue links first.** A typoed blocker key (404)
+   aborts before the status transition, so the card stays in its current
+   state instead of half-blocked. Idempotent — already-linked blockers
+   are skipped.
+2. Apply the status transition + label add per the canonical mapping.
+3. Post the `[<ap>] [S] Blocked: <reason>` audit comment.
+
+Response includes a `depends` list reflecting the issue's "is blocked by"
+links after the operation. Surface it in the report:
+
+> ⛔ <KEY> "<title>" → BLOCKED
+> Reason: <reason>
+> Blocked by: DMI-1099, INFRA-7   (omit if empty)
+
+In `partial` mode (legacy v0.2.x configs that still have `partial: true`),
+the plugin substitutes the `kanban:blocked` label and posts the same
+audit comment.
 
 ## Absolute rules
 
@@ -74,5 +101,8 @@ the transition. In `partial` mode, the plugin substitutes the
 - Never move from DONE to BLOCKED — DONE is terminal.
 - Never silently drop the old `started` timestamp (local mode — helper preserves).
 - Never call Write/Edit on `kanban.json` — go through the helper.
+- Jira mode: never invent a blocker key. The user must explicitly state
+  it (or confirm extraction from their prose).
+- Jira mode: never block a card by itself (`--blocked-by <self>` is rejected).
 - To return a task to active work: today, manual fix via a future
   `/kanban:unblock` command (v0.2.x).

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -122,6 +122,20 @@ class JiraDriver:
         if assignee_obj.get("accountId"):
             member = HumanRef(accountId=assignee_obj["accountId"])
 
+        # Surface "is blocked by" links as the canonical `depends` list, so
+        # downstream code (read-only display, /kanban:next dep checks) gets
+        # parity with local-mode `depends`. We pull the inwardIssue.key of
+        # every `Blocks` link — that's the issue that blocks us.
+        depends: list[str] = []
+        for link in f.get("issuelinks") or []:
+            ltype = (link.get("type") or {}).get("name")
+            if ltype != "Blocks":
+                continue
+            inward = link.get("inwardIssue") or {}
+            inward_key = inward.get("key")
+            if inward_key:
+                depends.append(inward_key)
+
         return Task(
             id=issue.get("key", ""),
             title=f.get("summary", ""),
@@ -131,11 +145,15 @@ class JiraDriver:
             updated=f.get("updated", ""),
             description=adf_to_text(f.get("description")) if f.get("description") else "",
             tags=labels,
-            depends=[],  # epic/issuelink resolution deferred (out of scope v0.2)
+            depends=depends,
             assignee=member,
             ap=ap_value,
             comments=[],
-            custom={"raw_status": status_name, "raw_labels": labels},
+            custom={
+                "raw_status": status_name,
+                "raw_labels": labels,
+                "raw_issuelinks": f.get("issuelinks") or [],
+            },
         )
 
     @staticmethod
@@ -203,7 +221,7 @@ class JiraDriver:
 
         jql = " AND ".join(clauses) + " ORDER BY priority DESC, created ASC"
         fields = ["summary", "status", "priority", "assignee", "labels",
-                  "created", "updated", "description"]
+                  "created", "updated", "description", "issuelinks"]
         if self.ap_field_id:
             fields.append(self.ap_field_id)
         max_results = filter.limit if filter and filter.limit else 50
@@ -214,7 +232,7 @@ class JiraDriver:
     def get_task(self, key: str) -> Task:
         client = self._client_or_raise()
         fields = ["summary", "status", "priority", "assignee", "labels",
-                  "created", "updated", "description"]
+                  "created", "updated", "description", "issuelinks"]
         if self.ap_field_id:
             fields.append(self.ap_field_id)
         issue = client.get_issue(key, fields=fields)
@@ -259,8 +277,8 @@ class JiraDriver:
         if not target_status:
             raise RuntimeError(f"transition spec for {to_column!r} missing `status`")
 
-        # One pre-flight read serves both anti-self-approve and the
-        # already-in-target-status fast path.
+        # One pre-flight read serves anti-self-approve, the already-in-
+        # target-status fast path, and the blocked_by idempotency check.
         existing_for_status = self.get_task(key)
         if to_column == "DONE":
             current_ap = self._current_repo_ap()
@@ -271,6 +289,14 @@ class JiraDriver:
                     "agent or a human reviewer to approve"
                 )
         client = self._client_or_raise()
+
+        # Step 0 — blocked_by issue links (only meaningful when transitioning
+        # TO a BLOCKED column). Done BEFORE the status transition so a bad
+        # blocker key (404) leaves the card in its current state instead of
+        # half-blocked. See SPEC §10 / issue #8.
+        blocked_by = kwargs.get("blocked_by") or []
+        if to_column == "BLOCKED" and blocked_by:
+            self._link_blockers(client, key, blocked_by, existing_for_status)
 
         # Step A — status transition (find the right transition id).
         # Skip if the issue is already in the target status (avoids the API
@@ -355,6 +381,76 @@ class JiraDriver:
             text=body,
             kind=kind,
         )
+
+    _BLOCKER_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]+-\d+$")
+
+    def _existing_blocker_keys(self, task: Task) -> set[str]:
+        """Return the set of inwardIssue keys whose link type is `Blocks`."""
+        out: set[str] = set()
+        for link in task.custom.get("raw_issuelinks") or []:
+            ltype = (link.get("type") or {}).get("name")
+            if ltype != "Blocks":
+                continue
+            inward = link.get("inwardIssue") or {}
+            inward_key = inward.get("key")
+            if isinstance(inward_key, str):
+                out.add(inward_key)
+        return out
+
+    def _link_blockers(
+        self,
+        client: JiraClient,
+        key: str,
+        blocked_by: list[str],
+        existing: Task,
+    ) -> None:
+        """Validate + create `Blocks` links from each blocker to `key`.
+
+        Done before the status transition. Raises RuntimeError on any
+        validation failure so the slash command surfaces the error and
+        the card stays in its previous state.
+
+        Idempotent: skips blockers that already have an inward `Blocks`
+        link to this card.
+        """
+        # Validate format and self-link rule first — purely local checks
+        # so we fail fast without any network round-trips.
+        for raw in blocked_by:
+            if not isinstance(raw, str) or not self._BLOCKER_KEY_RE.match(raw):
+                raise RuntimeError(
+                    f"invalid blocker key {raw!r} — expected format like "
+                    "'AGENT-42' (uppercase project + dash + digits)"
+                )
+            if raw == key:
+                raise RuntimeError(
+                    f"refusing self-block: {key} cannot be blocked by itself"
+                )
+
+        # Dedup the input list (case the caller passed duplicates) and
+        # filter out blockers already linked.
+        seen_existing = self._existing_blocker_keys(existing)
+        seen_local: set[str] = set()
+        to_link: list[str] = []
+        for raw in blocked_by:
+            if raw in seen_existing or raw in seen_local:
+                continue
+            seen_local.add(raw)
+            to_link.append(raw)
+
+        for blocker in to_link:
+            try:
+                client.create_issue_link(
+                    type_name="Blocks",
+                    inward_key=blocker,
+                    outward_key=key,
+                )
+            except JiraError as e:
+                # 404 most likely — blocker key doesn't exist or no view
+                # permission. Surface verbatim so the user can fix.
+                raise RuntimeError(
+                    f"blocker {blocker} could not be linked: "
+                    f"{e.detail or e} (status {e.status_code})"
+                ) from e
 
     def _post_system_comment(self, key: str, body: str) -> None:
         try:

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -302,7 +302,7 @@ class JiraClient:
             body={"fields": fields},
         )
 
-    # --- screens (Phase 9: AP-field association) ---------------------
+    # --- screens (0.3.2: AP-field association, #6) -------------------
 
     def list_screens(self, *, query: str | None = None) -> dict[str, Any]:
         """GET /rest/api/3/screens, optionally filtered by `queryString`.
@@ -345,6 +345,31 @@ class JiraClient:
             "POST",
             f"/rest/api/3/screens/{screen_id}/tabs/{tab_id}/fields",
             body={"fieldId": field_id},
+        )
+
+    # --- issue links (0.3.3: /kanban:block --blocked-by, #8) ---------
+
+    def create_issue_link(
+        self, type_name: str, inward_key: str, outward_key: str
+    ) -> None:
+        """POST /rest/api/3/issueLink — link two issues.
+
+        Jira link types are bidirectional. `type_name="Blocks"` reads as
+        `inwardIssue` blocks `outwardIssue`; equivalently `outwardIssue`
+        is blocked by `inwardIssue`. So when /kanban:block creates a
+        link, the *blocker* is `inwardIssue` and the card we're
+        transitioning is `outwardIssue`.
+
+        Returns 201 No Content on success. 404 if either key is missing.
+        """
+        self._request(
+            "POST",
+            "/rest/api/3/issueLink",
+            body={
+                "type": {"name": type_name},
+                "inwardIssue": {"key": inward_key},
+                "outwardIssue": {"key": outward_key},
+            },
         )
 
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1092,6 +1092,16 @@ def cmd_transition(args: argparse.Namespace) -> int:
     kwargs: dict[str, Any] = {}
     if args.reason:
         kwargs["reason"] = args.reason
+    if args.blocked_by:
+        # Comma-separated list of Jira keys; trim whitespace, drop empties.
+        blockers = [k.strip() for k in args.blocked_by.split(",") if k.strip()]
+        if args.to != "BLOCKED" and blockers:
+            _fail(
+                "--blocked-by is only valid when --to=BLOCKED; transitioning "
+                f"to {args.to!r} won't create links",
+            )
+            return 1
+        kwargs["blocked_by"] = blockers
     try:
         t = driver.transition(args.key, args.to, **kwargs)
     except SelfApproveRefused as e:
@@ -1100,7 +1110,13 @@ def cmd_transition(args: argparse.Namespace) -> int:
     except Exception as e:  # noqa: BLE001
         _fail(f"{type(e).__name__}: {e}")
         return 1
-    _emit({"ok": True, "key": t.id, "column": t.column, "raw_status": t.custom.get("raw_status")})
+    _emit({
+        "ok": True,
+        "key": t.id,
+        "column": t.column,
+        "raw_status": t.custom.get("raw_status"),
+        "depends": list(t.depends or []),
+    })
     return 0
 
 
@@ -1550,6 +1566,13 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--key", required=True)
     s.add_argument("--to", required=True, choices=("TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"))
     s.add_argument("--reason")
+    s.add_argument(
+        "--blocked-by",
+        help="(BLOCKED only) comma-separated list of Jira keys (e.g. "
+             "DMI-1099,INFRA-7) to attach as `is blocked by` issue links "
+             "before applying the transition. Idempotent — already-linked "
+             "blockers are skipped.",
+    )
     s.set_defaults(func=cmd_transition)
 
     s = sub.add_parser("precheck-card")

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9; do  # phase8: code emit/import + live AP; phase9: AP-field screen association
+for n in 1 2 3 4 5 6 7 8 9 10; do  # phase8: code/live-AP; phase9: AP-field screen assoc (#6); phase10: --blocked-by (#8)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase10.py
+++ b/plugins/kanban/scripts/test_phase10.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Phase 10 regression checks for kanban v0.3.3 — `--blocked-by` issue links.
+
+Closes issue #8: `/kanban:block` now accepts `--blocked-by KEY[,KEY,...]`
+and creates Jira "Blocks" issue links before applying the status
+transition. The link points from the blocker (inwardIssue) to the card
+being blocked (outwardIssue), so Jira's "Linked work items" panel and
+JQL `issueLinkType` queries see the dependency.
+
+Cases:
+  (a) jira_client.create_issue_link payload + endpoint
+  (b) _issue_to_task surfaces "Blocks" inwardIssue keys as Task.depends
+  (c) _link_blockers validates key format (rejects bad shapes)
+  (d) _link_blockers rejects self-block (key blocks itself)
+  (e) _link_blockers idempotent: skips already-linked blockers (no POST)
+  (f) _link_blockers raises before transition when create_issue_link fails
+       (issue #8 invariant: don't leave the card half-blocked)
+  (g) transition(BLOCKED, blocked_by=[...]) creates links + transitions
+  (h) transition(BLOCKED) without blocked_by doesn't touch issueLink endpoint
+       (back-compat with v0.3.1)
+  (i) cmd_transition with --blocked-by parses comma list, passes to driver
+  (j) cmd_transition rejects --blocked-by when --to != BLOCKED
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response, JiraError  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _mock_transport(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return t
+
+
+def _seed_jira_data():
+    return {
+        "version": "0.2",
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "projectKey": "AGENT",
+                "boardId": 1,
+                "agentAccountId": "shared-agent",
+                "transitions": {
+                    "TODO":      {"status": "Selected for Development"},
+                    "DOING":     {"status": "In Progress"},
+                    "BLOCKED":   {"status": "In Progress",
+                                  "addLabels": ["kanban:blocked"]},
+                    "DONE":      {"status": "Done"},
+                },
+            },
+        },
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    from drivers.jira import JiraDriver
+    from lib import credentials
+
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=_mock_transport(queue, calls), sleep=lambda _: None,
+    )
+
+
+def _issue(key, status="In Progress", labels=(), issuelinks=None):
+    return {
+        "key": key,
+        "fields": {
+            "summary": key,
+            "status": {"name": status},
+            "priority": {"name": "P1"},
+            "assignee": None,
+            "labels": list(labels),
+            "created": "x", "updated": "y",
+            "issuelinks": list(issuelinks or []),
+        },
+    }
+
+
+# --- jira_client ---------------------------------------------------------
+
+
+def test_create_issue_link_payload():
+    queue = [_Response(201, b"", {})]
+    calls = []
+    c = JiraClient("https://x.atlassian.net", "a@b", "tok",
+                   transport=_mock_transport(queue, calls), sleep=lambda _: None)
+    c.create_issue_link(type_name="Blocks",
+                        inward_key="DMI-1099", outward_key="DMI-200")
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["url"].endswith("/rest/api/3/issueLink")
+    sent = json.loads(calls[0]["body"])
+    assert sent == {
+        "type": {"name": "Blocks"},
+        "inwardIssue": {"key": "DMI-1099"},
+        "outwardIssue": {"key": "DMI-200"},
+    }
+
+
+# --- _issue_to_task surfaces depends from issuelinks --------------------
+
+
+def test_issue_to_task_extracts_depends_from_blocks():
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        issue = _issue("AGENT-200", issuelinks=[
+            # Blocks link, inwardIssue = blocker
+            {"type": {"name": "Blocks"},
+             "inwardIssue": {"key": "AGENT-100"}},
+            # Same type, second blocker
+            {"type": {"name": "Blocks"},
+             "inwardIssue": {"key": "INFRA-7"}},
+            # Outward direction (we block another) — not a depends
+            {"type": {"name": "Blocks"},
+             "outwardIssue": {"key": "AGENT-300"}},
+            # Different link type — ignored
+            {"type": {"name": "Relates"},
+             "inwardIssue": {"key": "AGENT-50"}},
+        ])
+        t = drv._issue_to_task(issue)
+        assert t.depends == ["AGENT-100", "INFRA-7"]
+
+
+# --- _link_blockers validation -------------------------------------------
+
+
+def test_link_blockers_rejects_invalid_format():
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        existing = drv._issue_to_task(_issue("AGENT-1"))
+        for bad in ("agent-1", "AGENT-", "-1", "agent 1", "", None):
+            try:
+                drv._link_blockers(
+                    drv._client_or_raise() if drv._token else None,  # never reached
+                    "AGENT-1", [bad] if bad is not None else [None],  # type: ignore
+                    existing,
+                )
+                assert False, f"should reject {bad!r}"
+            except RuntimeError as e:
+                assert "invalid blocker key" in str(e)
+
+
+def test_link_blockers_rejects_self():
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        existing = drv._issue_to_task(_issue("AGENT-1"))
+        try:
+            drv._link_blockers(None, "AGENT-1", ["AGENT-1"], existing)  # type: ignore
+            assert False
+        except RuntimeError as e:
+            assert "self-block" in str(e)
+
+
+def test_link_blockers_idempotent_skips_existing():
+    """When a card is already linked to a blocker, no POST is made."""
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        existing = drv._issue_to_task(_issue("AGENT-1", issuelinks=[
+            {"type": {"name": "Blocks"}, "inwardIssue": {"key": "AGENT-99"}}
+        ]))
+        queue = []  # No requests should be made if everything is already linked
+        calls = []
+        _attach_mock(drv, queue, calls)
+        drv._link_blockers(drv._client, "AGENT-1", ["AGENT-99"], existing)
+        assert calls == []
+
+
+def test_link_blockers_creates_only_new_ones():
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        existing = drv._issue_to_task(_issue("AGENT-1", issuelinks=[
+            {"type": {"name": "Blocks"}, "inwardIssue": {"key": "AGENT-99"}}
+        ]))
+        # AGENT-99 already linked, AGENT-100 new
+        queue = [_Response(201, b"", {})]
+        calls = []
+        _attach_mock(drv, queue, calls)
+        drv._link_blockers(drv._client, "AGENT-1",
+                           ["AGENT-99", "AGENT-100"], existing)
+        assert len(calls) == 1
+        sent = json.loads(calls[0]["body"])
+        assert sent["inwardIssue"]["key"] == "AGENT-100"
+        assert sent["outwardIssue"]["key"] == "AGENT-1"
+
+
+def test_link_blockers_404_raises_before_transition():
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        existing = drv._issue_to_task(_issue("AGENT-1"))
+        queue = [_Response(404, b'{"errorMessages":["Issue does not exist"]}', {})]
+        calls = []
+        _attach_mock(drv, queue, calls)
+        try:
+            drv._link_blockers(drv._client, "AGENT-1", ["TYPO-9999"], existing)
+            assert False, "should have raised"
+        except RuntimeError as e:
+            assert "TYPO-9999" in str(e)
+            assert "could not be linked" in str(e)
+
+
+# --- transition() integration --------------------------------------------
+
+
+def test_transition_blocked_creates_links_then_transitions():
+    """transition(BLOCKED, blocked_by=[...]) order: pre-flight read →
+    create issue links → status transition (if needed) → label add → comment."""
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        # Pre-flight: card in 'Selected for Development', no labels, no links
+        pre = _issue("AGENT-1", status="Selected for Development")
+        # Final read post-transition: now in 'In Progress' + kanban:blocked
+        post = _issue("AGENT-1", status="In Progress",
+                      labels=["kanban:blocked"],
+                      issuelinks=[{"type": {"name": "Blocks"},
+                                   "inwardIssue": {"key": "AGENT-99"}}])
+        # Mid-flight: also list_comments will be called by post_comment for the
+        # Blocked: <reason> system comment. The driver fires add_comment.
+
+        queue = [
+            # 1) pre-flight get_task
+            _Response(200, json.dumps(pre).encode(), {}),
+            # 2) create_issue_link for AGENT-99
+            _Response(201, b"", {}),
+            # 3) get_transitions (needed because pre status != target)
+            _Response(200, json.dumps(
+                {"transitions": [{"id": "21", "to": {"name": "In Progress"}}]}
+            ).encode(), {}),
+            # 4) transition_issue
+            _Response(204, b"", {}),
+            # 5) PUT labels (add kanban:blocked)
+            _Response(204, b"", {}),
+            # 6) post_comment (add_comment) — for the Blocked: <reason>
+            _Response(201, b'{"created":"x"}', {}),
+            # 7) final get_task refresh
+            _Response(200, json.dumps(post).encode(), {}),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+        t = drv.transition("AGENT-1", "BLOCKED",
+                           reason="Waiting on schema decision",
+                           blocked_by=["AGENT-99"])
+        assert t.column == "BLOCKED"
+        assert "AGENT-99" in t.depends
+
+        # Order check: issueLink POST happens BEFORE transition POST.
+        link_idx = next(i for i, c in enumerate(calls)
+                        if c["url"].endswith("/issueLink"))
+        trans_idx = next(i for i, c in enumerate(calls)
+                         if "/transitions" in c["url"]
+                         and c["method"] == "POST")
+        assert link_idx < trans_idx, "issueLink must precede transition"
+
+
+def test_transition_blocked_without_blocked_by_skips_links():
+    """When --blocked-by is absent, no /issueLink call is made."""
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        pre = _issue("AGENT-1", status="In Progress")  # already at target
+        post = _issue("AGENT-1", status="In Progress",
+                      labels=["kanban:blocked"])
+        queue = [
+            _Response(200, json.dumps(pre).encode(), {}),    # pre-flight
+            # No issueLink, no get_transitions (status already correct)
+            _Response(204, b"", {}),                         # PUT labels
+            _Response(201, b'{"created":"x"}', {}),          # comment
+            _Response(200, json.dumps(post).encode(), {}),   # final get
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+        t = drv.transition("AGENT-1", "BLOCKED",
+                           reason="Waiting on input")
+        assert t.column == "BLOCKED"
+        assert all("/issueLink" not in c["url"] for c in calls)
+
+
+def test_transition_link_failure_aborts_before_status_change():
+    """If create_issue_link fails, the status transition is NOT attempted."""
+    with tempfile.TemporaryDirectory() as td:
+        drv = _patched_driver(_seed_jira_data(), pathlib.Path(td))
+        pre = _issue("AGENT-1", status="Selected for Development")
+        queue = [
+            _Response(200, json.dumps(pre).encode(), {}),         # pre-flight
+            _Response(404, b'{"errorMessages":["Issue does not exist"]}', {}),  # link 404
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+        try:
+            drv.transition("AGENT-1", "BLOCKED",
+                           reason="x", blocked_by=["TYPO-9999"])
+            assert False, "should have raised"
+        except RuntimeError as e:
+            assert "TYPO-9999" in str(e)
+        # No transitions endpoint hit, no PUT labels, no comment add — the
+        # card stays in its previous state.
+        assert all("/transitions" not in c["url"] for c in calls)
+        assert all(c["method"] != "PUT" for c in calls)
+
+
+# --- cmd_transition CLI integration --------------------------------------
+
+
+def test_cmd_transition_passes_blocked_by_to_driver():
+    """End-to-end: --blocked-by goes through the helper into driver kwargs."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps(_seed_jira_data()))
+
+        # Patch get_driver to a stub that records kwargs
+        captured = {}
+        from drivers.base import Task
+
+        class StubDriver:
+            name = "jira"
+
+            def transition(self, key, to_column, **kwargs):
+                captured["key"] = key
+                captured["to"] = to_column
+                captured["kwargs"] = kwargs
+                return Task(id=key, title="x", column=to_column,
+                            priority="P1", created="x", updated="y",
+                            depends=["DMI-1099"],
+                            custom={"raw_status": "In Progress"})
+
+        # cmd_transition does `from drivers import get_driver` inside, so
+        # we monkey-patch the loaded module
+        import drivers as _drv_mod
+        _orig_get = _drv_mod.get_driver
+        _drv_mod.get_driver = lambda data, root: StubDriver()
+        try:
+            from io import StringIO
+            old = sys.stdout
+            sys.stdout = StringIO()
+            try:
+                class A:
+                    kanban_path = str(kp)
+                    key = "DMI-200"
+                    to = "BLOCKED"
+                    reason = "waiting on AuditPort"
+                    blocked_by = "DMI-1099, INFRA-7"
+                rc = _jira_setup.cmd_transition(A())
+                out = sys.stdout.getvalue()
+            finally:
+                sys.stdout = old
+        finally:
+            _drv_mod.get_driver = _orig_get
+        assert rc == 0, out
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["depends"] == ["DMI-1099"]
+        assert captured["kwargs"]["blocked_by"] == ["DMI-1099", "INFRA-7"]
+        assert captured["kwargs"]["reason"] == "waiting on AuditPort"
+
+
+def test_cmd_transition_rejects_blocked_by_without_blocked_target():
+    """--blocked-by --to=DOING is a usage error."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps(_seed_jira_data()))
+        from io import StringIO
+        old = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            class A:
+                kanban_path = str(kp); key = "DMI-200"
+                to = "DOING"; reason = None
+                blocked_by = "DMI-1099"
+            try:
+                _jira_setup.cmd_transition(A())
+                rc = 0
+            except SystemExit as e:
+                rc = e.code
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old
+        assert rc != 0
+        j = json.loads(out)
+        assert j["ok"] is False
+        assert "BLOCKED" in j["error"]
+
+
+# --- entry point ---------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("create_issue_link_payload", test_create_issue_link_payload),
+        ("issue_to_task_extracts_depends_from_blocks",
+         test_issue_to_task_extracts_depends_from_blocks),
+        ("link_blockers_rejects_invalid_format",
+         test_link_blockers_rejects_invalid_format),
+        ("link_blockers_rejects_self", test_link_blockers_rejects_self),
+        ("link_blockers_idempotent_skips_existing",
+         test_link_blockers_idempotent_skips_existing),
+        ("link_blockers_creates_only_new_ones",
+         test_link_blockers_creates_only_new_ones),
+        ("link_blockers_404_raises_before_transition",
+         test_link_blockers_404_raises_before_transition),
+        ("transition_blocked_creates_links_then_transitions",
+         test_transition_blocked_creates_links_then_transitions),
+        ("transition_blocked_without_blocked_by_skips_links",
+         test_transition_blocked_without_blocked_by_skips_links),
+        ("transition_link_failure_aborts_before_status_change",
+         test_transition_link_failure_aborts_before_status_change),
+        ("cmd_transition_passes_blocked_by_to_driver",
+         test_cmd_transition_passes_blocked_by_to_driver),
+        ("cmd_transition_rejects_blocked_by_without_blocked_target",
+         test_cmd_transition_rejects_blocked_by_without_blocked_target),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase10: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #8.

> **Rebased after PR #7 (issue #6) landed as 0.3.2.** Now bumps to **0.3.3** and uses `test_phase10.py` instead of `test_phase9.py` (which is occupied by PR #7's screen-association tests). No semantic conflicts — the two PRs add disjoint methods to `lib/jira_client.py`.

## Summary

`/kanban:block` previously captured a free-text reason and added a `kanban:blocked` label, but didn't make any structural connection to *what* was blocking the card. This PR adds `--blocked-by KEY[,KEY,...]` so the operation creates Jira native "is blocked by" issue links — surfacing the dependency in Jira's "Linked work items" panel and letting JQL `issueLinkType` queries see it.

Implements **Option A** from the issue. Inference from reason text (Option B) is deliberately omitted — the user's own write-up flagged it as "convenience-grade", and the cost/value ratio favors the explicit flag.

## What changed

| Concern | File |
|---|---|
| New `create_issue_link(type, inward, outward)` REST endpoint | `lib/jira_client.py` |
| `_link_blockers`: key-format regex + self-block refusal + dedup + idempotency (skip already-linked) | `drivers/jira.py` |
| `transition()` runs link creation **before** status transition (issue #8 atomicity invariant) | `drivers/jira.py` |
| `_issue_to_task` reads `issuelinks` and surfaces inward `Blocks` keys as `Task.depends` (Jira mode now matches local mode's `depends[]`) | `drivers/jira.py` |
| `get_task` / `list_tasks` field list gains `issuelinks` | `drivers/jira.py` |
| `cmd_transition` accepts `--blocked-by`; rejects use with `--to != BLOCKED`; response includes post-operation `depends[]` | `scripts/jira_setup.py` |
| `commands/block.md` documents the Jira flow + the no-silent-inference rule | `commands/block.md` |
| 12 new mocked tests | `scripts/test_phase10.py` |
| Bump `0.3.2 → 0.3.3`; CHANGELOG entry | versions / CHANGELOG |

## Atomicity (issue #8 explicit requirement)

Order:
1. Pre-flight `get_task` (anti-self-approve + already-in-target shortcut + idempotency check)
2. Validate blocker keys (format, no self-block) — local, fail fast
3. Create new issue links via `POST /rest/api/3/issueLink` (inward = blocker, outward = card)
4. **Only then**: status transition + label add + reason comment

If step 3 fails (typo'd key, no view permission), step 4 is **not** attempted. The card stays in its previous state. Verified by `test_link_blockers_404_raises_before_transition` and `test_transition_link_failure_aborts_before_status_change`.

## Edge cases covered

| Case | Test |
|---|---|
| Single blocker | `transition_blocked_creates_links_then_transitions` |
| Multiple blockers (comma-separated) | `link_blockers_creates_only_new_ones` (mixed new + existing) |
| Self-block | `link_blockers_rejects_self` |
| Already-linked (idempotent, no POST) | `link_blockers_idempotent_skips_existing` |
| Cross-project blocker (e.g. `INFRA-7` from outside) | implicit — regex doesn't constrain project portion |
| Bad key format (`agent-1`, `AGENT-`, etc.) | `link_blockers_rejects_invalid_format` |
| 404 on blocker → abort before transition | `transition_link_failure_aborts_before_status_change` |
| Back-compat: omit `--blocked-by` → no link calls | `transition_blocked_without_blocked_by_skips_links` |

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 10 phase suites, **111 tests**, all green
- [x] PR #7's phase 9 (screen association) preserved unchanged
- [x] Code-based sharing — preserved (phase 8)
- [x] AP field create/assign/register fall-back paths — preserved (phase 3 + 8)
- [ ] After merge: real `/kanban:block <KEY> --reason "..." --blocked-by DMI-1099` against the DMI project — verify the "Linked work items" panel shows `DMI-1099` as inward `is blocked by`, AND the *blocking* card shows the outward `Blocks` link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
