### PR TITLE
feat(kanban): 0.3.4 — share-code carries team conventions (#10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-04-30 (conventions)
+
+### Added
+- **kanban 0.3.4** — share-code carries team conventions. Closes #10.
+  The `/kanban:showjira-code` payload now travels with a small block
+  of soft team agreements alongside the existing hard wiring
+  (transitions / AP / board). Schema bumped to `kanban-jira-code/2`;
+  receivers still accept v1 codes for back-compat.
+
+  Scope is deliberately narrow — narrative-only plus one opt-in toggle.
+  `summaryPrefix` / `defaultEpic` / `requiredLabels` / `commentTemplates`
+  / `reviewerAccountId` were considered and **rejected** in this round
+  to avoid slippery-slope / overlap with existing config (each can be
+  re-proposed individually if a real use case lands).
+
+  Highlights:
+  - `lib/conventions.py` — normalize / validate / hash_conventions /
+    record_ack / has_recent_ack. Length guardrails (200 chars × 10
+    notes) are advisory; helpers warn but never reject.
+  - `backend.jira.conventions = { notes: [string],
+    blockedRequiresLink: bool }` (schema additive).
+  - `/kanban:edit-conventions` — interactive author flow (per-note
+    keep/edit/delete, length checks, toggle prompt).
+  - `/kanban:show-conventions` — read-only render with ack status.
+  - `/kanban:initjira-by-code` — when imported code carries non-empty
+    notes, requires the literal phrase `I have read these` before
+    init completes (no `yes`/`Y`/etc. — the friction is the feature,
+    matching #10 §Receiver UX). Ack persists as a hash + timestamp in
+    `.claude/kanban-agent.json`; same conventions on re-import skips
+    the prompt.
+  - `blockedRequiresLink: true` (per-team opt-in) — when set,
+    `cmd_transition` refuses BLOCKED transitions without `--blocked-by`.
+    Pairs with the `--blocked-by` shipped in 0.3.3 (#8); each team
+    decides whether to enforce.
+  - New helper subcommands: `set-conventions`, `read-conventions`,
+    `record-conventions-ack`.
+  - `test_phase11.py`: 15 mocked cases covering normalize / validate /
+    hash / ack persistence / emit/import roundtrip with both v1 and v2
+    schemas / set-and-warn / record-and-read / blockedRequiresLink
+    enforcement on and off. All 11 phase suites (114 tests) green.
+
 ## 2026-04-30 (issue links)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/edit-conventions.md
+++ b/plugins/kanban/commands/edit-conventions.md
@@ -1,0 +1,93 @@
+---
+description: Author or edit the team's `conventions` block — narrative notes + per-team toggles.
+allowed-tools: Read, Bash(python3:*), AskUserQuestion
+---
+
+# /kanban:edit-conventions
+
+Interactive editor for `backend.jira.conventions`. Use this on the team's
+**source-of-truth repo** (the one whose `/kanban:showjira-code` other
+machines paste from). After editing, regenerate the share code so
+teammates see the new rules on their next import.
+
+## 0. Pre-flight
+
+- `kanban.json` exists and `backend.driver == "jira"`.
+
+## 1. Show current state
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-conventions \
+  --kanban-path '<kanban.json path>'
+```
+
+Render the existing `notes` (numbered) and toggles (`blockedRequiresLink`).
+
+## 2. Notes editor (interactive)
+
+For each existing note (in order), ask via `AskUserQuestion`:
+
+> Note <N>: "<existing text>"
+>   [k]eep / [e]dit / [d]elete
+
+On `e`: capture the new text. Validate length ≤ 200 chars. If longer,
+warn and ask whether to truncate or re-enter.
+
+After cycling through existing notes, ask:
+
+> Add a new note? (y/N)
+>   When yes, capture text. Repeat until the user says no, or until 10
+>   notes total (the guardrail).
+
+If the user tries to add an 11th note:
+
+> Convention notes guardrail is 10. Long-form material belongs in an
+> ADR or wiki — link it from a note instead. Skip this addition.
+
+## 3. Toggles
+
+Show current state of each toggle and ask whether to flip:
+
+```
+blockedRequiresLink: <current value>
+  When ON, /kanban:block refuses calls without --blocked-by KEY.
+  This is per-team — don't enable it unless your team has agreed.
+
+  Change? (y/N)
+```
+
+## 4. Persist
+
+Build the new conventions JSON and write:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py set-conventions \
+  --kanban-path '<kanban.json path>' \
+  --conventions-json '<json>'
+```
+
+Surface any `warnings[]` from the response (notes too long, etc.).
+
+## 5. Suggest re-share
+
+After a successful edit, remind the user:
+
+```
+✓ Conventions updated.
+
+Teammates on other repos / machines will see the new rules the next
+time they re-import. To push the update now:
+
+  1. Run /kanban:showjira-code in this repo
+  2. Share the printed JSON with your team
+  3. Each teammate runs /kanban:initjira-by-code on their repo and
+     pastes the new code (the ack flow re-fires because the hash changed)
+```
+
+## Absolute rules
+
+- Never invent notes or toggle values — every change comes from the user.
+- Never bypass the length guardrails silently — warn and re-prompt.
+- Never write conventions on behalf of another repo. The source-of-truth
+  is wherever the user is running this command. Other repos pull via
+  `/kanban:initjira-by-code`.

--- a/plugins/kanban/commands/initjira-by-code.md
+++ b/plugins/kanban/commands/initjira-by-code.md
@@ -42,8 +42,9 @@ Ask the user via `AskUserQuestion` to paste the JSON code emitted by
 whitespace and any surrounding code-fence backticks (the user is likely
 copy-pasting from a chat).
 
-Validate the structure: must be a JSON object with
-`schema == "kanban-jira-code/1"`. Surface any parse error verbatim.
+Validate the structure: must be a JSON object with `schema` equal to
+`kanban-jira-code/1` or `kanban-jira-code/2`. Surface any parse error
+verbatim.
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py import-jira-code \
@@ -53,10 +54,51 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py import-jira-code \
 
 | Response | Action |
 |---|---|
-| `{ok: true, imported: {...}}` | print one-line summary: imported `<projectKey>/<boardId>`, `<N>` transitions, AP field `<fieldName>` |
+| `{ok: true, imported: {...}, schema, conventions, ackRequired}` | print one-line summary: imported `<projectKey>/<boardId>`, `<N>` transitions, AP field `<fieldName>`. If `ackRequired` is true, proceed to step 2.5. |
 | `{ok: false, error: ..., errors?: [...]}` | surface the error(s); ask the user to re-paste |
 
 After two validation failures, abort.
+
+## Step 2.5/3 — Acknowledge team conventions (only if `ackRequired`)
+
+When the imported code carries a non-empty `conventions` block (notes
+the team agreed to share), the user must read them before init can
+complete. The friction is intentional — pasting code is not the same as
+having read it.
+
+Render the notes as a numbered list, then ask via `AskUserQuestion`:
+
+```
+⚠ Team conventions you should know before starting work:
+
+  1. <note 1>
+  2. <note 2>
+  3. <note 3>
+
+If `blockedRequiresLink` is true:
+  ⚙ This team requires `--blocked-by KEY` on every /kanban:block call.
+
+Type the literal phrase 'I have read these' to acknowledge and continue:
+```
+
+The ack must be the **exact** string `I have read these` (case-sensitive,
+trim leading/trailing whitespace). Other answers (`yes`, `Y`, `ok`,
+`sure`, `已讀`, etc.) are **not** accepted — re-prompt once. After two
+mismatches, abort init with:
+
+> Init aborted — conventions not acknowledged. Re-run when ready, or run
+> `/kanban:show-conventions` to read them outside the init flow.
+
+Once the literal phrase is entered, persist the ack:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py record-conventions-ack \
+  --kanban-path '<kanban.json path>'
+```
+
+This writes a hash + timestamp to `.claude/kanban-agent.json` so future
+re-runs of `/kanban:initjira-by-code` (with the same conventions) skip
+this step.
 
 ## Step 3/3 — Assign this repo's AP
 

--- a/plugins/kanban/commands/show-conventions.md
+++ b/plugins/kanban/commands/show-conventions.md
@@ -1,0 +1,65 @@
+---
+description: Display the team's `conventions` block — notes + per-team toggles, no edits.
+allowed-tools: Read, Bash(python3:*)
+---
+
+# /kanban:show-conventions
+
+Read-only display of the current repo's `backend.jira.conventions` —
+team rules that travel with the board mapping (issue #10).
+
+## 0. Pre-flight
+
+- Confirm `kanban.json` exists and `backend.driver == "jira"`. If local
+  mode, tell the user this is a Jira-mode-only feature.
+
+## 1. Read
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-conventions \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{ok, conventions, isEmpty, ackHash, alreadyAcked}`.
+
+## 2. Render
+
+If `isEmpty: true`:
+
+```
+This board has no team conventions defined yet.
+
+Conventions are short notes the team agrees on (e.g. "use CANCELLED, not
+DELETE", "[@Kirin]-tagged tasks aren't claimed by agents") plus a couple
+of per-team toggles. They travel with /kanban:showjira-code so teammates
+on other repos / machines see the same rules at import time.
+
+Author them via /kanban:edit-conventions.
+```
+
+Otherwise:
+
+```
+Team conventions:
+
+Notes (<N>):
+  1. <note 1>
+  2. <note 2>
+  ...
+
+Toggles:
+  blockedRequiresLink: <true | false (default)>
+
+Acknowledgement: <✓ acknowledged | ⚠ not acknowledged in this repo>
+```
+
+If `alreadyAcked` is false, append:
+
+> Run `/kanban:initjira-by-code` (re-paste the same code) to ack, or
+> just type `I have read these` next time you re-init.
+
+## Absolute rules
+
+- Read-only. Never write.
+- Never reveal the ack hash to the user — it's an implementation
+  detail used to detect convention drift.

--- a/plugins/kanban/commands/showjira-code.md
+++ b/plugins/kanban/commands/showjira-code.md
@@ -14,11 +14,17 @@ everywhere.
 
 ## What's in the code
 
+- `schema`: `"kanban-jira-code/2"` (writers default to /2; receivers
+  accept both /1 and /2)
 - `boardUrl`, `boardId`, `projectKey`
 - `transitions` (the entire compound mapping from
   `/kanban:initjira` step 3)
 - `ap.fieldId`, `ap.fieldName` (so the receiver maps to the same Jira
   custom field)
+- `conventions` (since /2): team narrative notes + per-team toggles
+  (e.g. `blockedRequiresLink`). Empty by default — author via
+  `/kanban:edit-conventions`. Receivers must acknowledge non-empty
+  notes before `/kanban:initjira-by-code` completes.
 
 ## What's deliberately excluded
 

--- a/plugins/kanban/lib/conventions.py
+++ b/plugins/kanban/lib/conventions.py
@@ -1,0 +1,177 @@
+"""Team-convention block (kanban-jira-code/2).
+
+The plugin distinguishes two layers of team configuration:
+
+1. **Hard wiring** — `transitions`, `ap.fieldId`, `boardUrl`. The plugin
+   needs these to function. Lives in `backend.jira.{transitions,ap,...}`.
+
+2. **Soft agreements** — narrative notes ("Review 一律 assign kirin",
+   "service@ has no Delete permission, use CANCELLED") plus a couple of
+   per-team opt-in toggles. Lives in `backend.jira.conventions`.
+
+This module owns the conventions block: validation, hashing for ack, and
+the small public surface needed by the slash commands and helper CLI.
+
+Public surface:
+    DEFAULT_NOTES_MAX_LEN          # 200 chars per note
+    DEFAULT_NOTES_MAX_COUNT        # 10 notes total
+    validate(conventions) -> list[str]            # warnings, never errors
+    hash_conventions(conventions) -> str          # stable for ack tracking
+    record_ack(repo_root, conventions) -> Path    # writes timestamp to .claude/kanban-agent.json
+    has_recent_ack(repo_root, conventions) -> bool
+    blocked_requires_link(conventions) -> bool    # convenience accessor
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_NOTES_MAX_LEN = 200
+DEFAULT_NOTES_MAX_COUNT = 10
+
+
+def normalize(conventions: dict[str, Any] | None) -> dict[str, Any]:
+    """Return a fresh dict with required defaults filled in.
+
+    `conventions` may be None (no block at all) or a partial dict. The
+    output always has `notes` (list, possibly empty) and never carries
+    keys this version doesn't recognise — forward-incompatible fields
+    from a future plugin version are dropped on purpose so this version
+    doesn't render half-understood data.
+    """
+    src = conventions or {}
+    out: dict[str, Any] = {"notes": []}
+    if isinstance(src.get("notes"), list):
+        out["notes"] = [n for n in src["notes"] if isinstance(n, str)]
+    if "blockedRequiresLink" in src:
+        out["blockedRequiresLink"] = bool(src["blockedRequiresLink"])
+    return out
+
+
+def validate(conventions: dict[str, Any] | None) -> list[str]:
+    """Return advisory warnings. Empty list = clean."""
+    warnings: list[str] = []
+    if conventions is None:
+        return warnings
+    notes = conventions.get("notes")
+    if notes is None:
+        return warnings
+    if not isinstance(notes, list):
+        warnings.append("conventions.notes must be a list of strings")
+        return warnings
+    if len(notes) > DEFAULT_NOTES_MAX_COUNT:
+        warnings.append(
+            f"conventions.notes has {len(notes)} entries — guardrail is "
+            f"{DEFAULT_NOTES_MAX_COUNT}; consider moving long-form material "
+            "to an ADR or wiki"
+        )
+    for i, n in enumerate(notes):
+        if not isinstance(n, str):
+            warnings.append(f"conventions.notes[{i}] is not a string")
+            continue
+        if len(n) > DEFAULT_NOTES_MAX_LEN:
+            warnings.append(
+                f"conventions.notes[{i}] is {len(n)} chars — guardrail is "
+                f"{DEFAULT_NOTES_MAX_LEN}; trim or move to an ADR"
+            )
+        if not n.strip():
+            warnings.append(f"conventions.notes[{i}] is empty / whitespace")
+    return warnings
+
+
+def is_empty(conventions: dict[str, Any] | None) -> bool:
+    """A convention block is "empty" if it has no notes and no other
+    actionable settings worth surfacing. Used by the receiver UX to
+    decide whether to skip the ack flow entirely.
+    """
+    if conventions is None:
+        return True
+    if conventions.get("notes"):
+        return False
+    if "blockedRequiresLink" in conventions:
+        return False
+    return True
+
+
+def blocked_requires_link(conventions: dict[str, Any] | None) -> bool:
+    if not conventions:
+        return False
+    return bool(conventions.get("blockedRequiresLink"))
+
+
+# --- ack tracking --------------------------------------------------------
+
+
+def hash_conventions(conventions: dict[str, Any] | None) -> str:
+    """Stable hash over the canonical-json form of `conventions`.
+
+    Used to detect "user already ack'd this exact set" so the receiver UX
+    doesn't re-prompt on every command. Sorting keys is required; trailing
+    whitespace differences in notes count as different content (intentional
+    — even cosmetic edits should be re-acknowledged).
+    """
+    canon = normalize(conventions)
+    blob = json.dumps(canon, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _agent_path(repo_root: str | os.PathLike[str]) -> Path:
+    return Path(repo_root) / ".claude" / "kanban-agent.json"
+
+
+def record_ack(
+    repo_root: str | os.PathLike[str],
+    conventions: dict[str, Any] | None,
+) -> Path:
+    """Persist an acknowledgement of `conventions` into `.claude/kanban-agent.json`.
+
+    Adds the field `acknowledgedConventions` with the hash and an ISO
+    timestamp. Other fields in the file (notably `ap`) are preserved.
+    """
+    p = _agent_path(repo_root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    if p.exists():
+        try:
+            existing = json.loads(p.read_text(encoding="utf-8"))
+            if not isinstance(existing, dict):
+                existing = {}
+        except Exception:
+            existing = {}
+    else:
+        existing = {}
+    existing["acknowledgedConventions"] = {
+        "hash": hash_conventions(conventions),
+        "at": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+    }
+    p.write_text(
+        json.dumps(existing, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def has_recent_ack(
+    repo_root: str | os.PathLike[str],
+    conventions: dict[str, Any] | None,
+) -> bool:
+    """Return True iff `.claude/kanban-agent.json` records an ack whose
+    hash matches `conventions`. Allows /kanban:initjira-by-code to skip
+    the friction prompt when the user has already acknowledged this exact
+    convention set in this repo.
+    """
+    p = _agent_path(repo_root)
+    if not p.exists():
+        return False
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    ack = (data or {}).get("acknowledgedConventions") or {}
+    if not isinstance(ack, dict):
+        return False
+    return ack.get("hash") == hash_conventions(conventions)

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -91,6 +91,7 @@ PLUGIN_ROOT = HERE.parents[1]
 sys.path.insert(0, str(PLUGIN_ROOT))
 
 from lib import ap_registry, card_cache, credentials, kanban_io  # noqa: E402
+from lib import conventions as _cv  # noqa: E402
 from lib import mcp_conflict_scan, transitions as _tr  # noqa: E402
 from lib.jira_client import JiraClient, JiraError  # noqa: E402
 
@@ -786,7 +787,7 @@ def cmd_emit_jira_code(args: argparse.Namespace) -> int:
         return _fail("no transitions defined — run /kanban:initjira first")
 
     code: dict[str, Any] = {
-        "schema": "kanban-jira-code/1",
+        "schema": "kanban-jira-code/2",
         "boardUrl": cfg.get("boardUrl"),
         "boardId": cfg.get("boardId"),
         "projectKey": cfg.get("projectKey"),
@@ -798,6 +799,9 @@ def cmd_emit_jira_code(args: argparse.Namespace) -> int:
     if ap.get("fieldId"):
         code["ap"] = {"fieldId": ap["fieldId"], "fieldName": ap.get("fieldName", "")}
         # `registered` deliberately omitted — that's live state on Jira.
+    # Always include the conventions block (empty by default — the slot
+    # itself nudges teams to write their rules down). v1 receivers ignore it.
+    code["conventions"] = _cv.normalize(cfg.get("conventions"))
 
     _emit({"ok": True, "code": code})
     return 0
@@ -814,9 +818,11 @@ def cmd_import_jira_code(args: argparse.Namespace) -> int:
         return _fail(f"code is not valid JSON: {e}")
     if not isinstance(code, dict):
         return _fail("code must be a JSON object")
-    if code.get("schema") != "kanban-jira-code/1":
+    schema = code.get("schema")
+    if schema not in ("kanban-jira-code/1", "kanban-jira-code/2"):
         return _fail(
-            f"unsupported code schema {code.get('schema')!r}; expected kanban-jira-code/1"
+            f"unsupported code schema {schema!r}; "
+            "expected kanban-jira-code/1 or /2"
         )
 
     transitions = code.get("transitions")
@@ -850,13 +856,94 @@ def cmd_import_jira_code(args: argparse.Namespace) -> int:
             "fieldName": code["ap"].get("fieldName", ""),
             "registered": [],   # populated live via cmd_live_list_aps when needed
         }
+    # Conventions arrive only on /2 codes. Normalize so unknown future
+    # fields are dropped and `notes` is always a list.
+    incoming_conv = code.get("conventions") if schema == "kanban-jira-code/2" else None
+    cfg["conventions"] = _cv.normalize(incoming_conv)
     cfg = {k: v for k, v in cfg.items() if v is not None}
 
     data["backend"] = {"driver": "jira", "jira": cfg}
     meta = data.setdefault("meta", {})
     meta["columns"] = list(CANONICAL_COLUMNS)
     kanban_io.save(p, data)
-    _emit({"ok": True, "imported": cfg})
+    _emit({
+        "ok": True,
+        "imported": cfg,
+        "schema": schema,
+        "conventions": cfg["conventions"],
+        "ackRequired": not _cv.is_empty(cfg["conventions"])
+                       and not _cv.has_recent_ack(p.parent, cfg["conventions"]),
+    })
+    return 0
+
+
+def cmd_set_conventions(args: argparse.Namespace) -> int:
+    """Persist `backend.jira.conventions` to kanban.json.
+
+    Accepts a full conventions block (notes + per-team toggles) as JSON.
+    Validation is advisory — guardrails surface as `warnings`, never
+    block the write.
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    try:
+        incoming = json.loads(args.conventions_json)
+    except json.JSONDecodeError as e:
+        return _fail(f"--conventions-json is not valid JSON: {e}")
+    if not isinstance(incoming, dict):
+        return _fail("--conventions-json must be a JSON object")
+
+    normalized = _cv.normalize(incoming)
+    warnings = _cv.validate(normalized)
+
+    data = kanban_io.load(p)
+    backend = data.setdefault("backend", {"driver": "jira"})
+    if backend.get("driver") != "jira":
+        return _fail("backend.driver must be 'jira'")
+    jira_cfg = backend.setdefault("jira", {})
+    jira_cfg["conventions"] = normalized
+    kanban_io.save(p, data)
+    _emit({"ok": True, "conventions": normalized, "warnings": warnings})
+    return 0
+
+
+def cmd_read_conventions(args: argparse.Namespace) -> int:
+    """Read backend.jira.conventions from kanban.json. Includes `ackHash`
+    so callers can decide whether to re-prompt.
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    cfg = (data.get("backend") or {}).get("jira") or {}
+    norm = _cv.normalize(cfg.get("conventions"))
+    _emit(
+        {
+            "ok": True,
+            "conventions": norm,
+            "isEmpty": _cv.is_empty(norm),
+            "ackHash": _cv.hash_conventions(norm),
+            "alreadyAcked": _cv.has_recent_ack(p.parent, norm),
+        }
+    )
+    return 0
+
+
+def cmd_record_conventions_ack(args: argparse.Namespace) -> int:
+    """Record that the user has acknowledged the current conventions.
+
+    Reads conventions from kanban.json so the slash command can't pass
+    a forged ack for a different convention set.
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    cfg = (data.get("backend") or {}).get("jira") or {}
+    norm = _cv.normalize(cfg.get("conventions"))
+    target = _cv.record_ack(p.parent, norm)
+    _emit({"ok": True, "ackHash": _cv.hash_conventions(norm), "path": str(target)})
     return 0
 
 
@@ -1092,8 +1179,10 @@ def cmd_transition(args: argparse.Namespace) -> int:
     kwargs: dict[str, Any] = {}
     if args.reason:
         kwargs["reason"] = args.reason
+
+    # Comma-separated list of Jira keys; trim whitespace, drop empties.
+    blockers: list[str] = []
     if args.blocked_by:
-        # Comma-separated list of Jira keys; trim whitespace, drop empties.
         blockers = [k.strip() for k in args.blocked_by.split(",") if k.strip()]
         if args.to != "BLOCKED" and blockers:
             _fail(
@@ -1102,6 +1191,23 @@ def cmd_transition(args: argparse.Namespace) -> int:
             )
             return 1
         kwargs["blocked_by"] = blockers
+
+    # Per-team convention: blockedRequiresLink. When opted in by the team
+    # (set via /kanban:edit-conventions), refuse to transition to BLOCKED
+    # without --blocked-by. The flag lives on the team's shared mapping
+    # so the rule travels with the kanban-jira-code/2 payload.
+    if args.to == "BLOCKED":
+        cfg = (data.get("backend") or {}).get("jira") or {}
+        if _cv.blocked_requires_link(cfg.get("conventions")) and not blockers:
+            _fail(
+                "team convention `blockedRequiresLink` is enabled — pass "
+                "--blocked-by KEY[,KEY,...] when transitioning to BLOCKED. "
+                "(see /kanban:show-conventions; the team can disable this "
+                "via /kanban:edit-conventions)",
+                code=1,
+                kind="convention",
+            )
+            return 1
     try:
         t = driver.transition(args.key, args.to, **kwargs)
     except SelfApproveRefused as e:
@@ -1629,6 +1735,22 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("live-list-aps")
     s.add_argument("--kanban-path", required=True)
     s.set_defaults(func=cmd_live_list_aps)
+
+    s = sub.add_parser("set-conventions")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument(
+        "--conventions-json", required=True,
+        help='JSON object: {"notes": ["..."], "blockedRequiresLink": bool}',
+    )
+    s.set_defaults(func=cmd_set_conventions)
+
+    s = sub.add_parser("read-conventions")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_read_conventions)
+
+    s = sub.add_parser("record-conventions-ack")
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_record_conventions_ack)
 
     s = sub.add_parser("set-transitions")
     s.add_argument("--kanban-path", required=True)

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10; do  # phase8: code/live-AP; phase9: AP-field screen assoc (#6); phase10: --blocked-by (#8)
+for n in 1 2 3 4 5 6 7 8 9 10 11; do  # phase8/9/10/11: code-AP/screens (#6)/blocked-by (#8)/conventions (#10)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase11.py
+++ b/plugins/kanban/scripts/test_phase11.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Phase 11 regression checks for kanban v0.3.4 — team conventions (issue #10).
+
+Soft agreements (`backend.jira.conventions`) travel with the share code
+(`kanban-jira-code/2`). Receiver UX requires literal-phrase ack before
+init completes. One opt-in machine-actionable toggle:
+`blockedRequiresLink`.
+
+Cases:
+  (a) lib.conventions.normalize fills defaults and drops unknown keys
+  (b) lib.conventions.validate flags >200-char notes and >10-note count
+  (c) lib.conventions.is_empty distinguishes default vs populated
+  (d) lib.conventions.hash_conventions is stable across normalised input
+  (e) lib.conventions.record_ack / has_recent_ack roundtrip + preserves
+       sibling fields in kanban-agent.json (notably `ap`)
+  (f) emit-jira-code emits schema /2 with conventions block (empty by
+       default)
+  (g) emit-jira-code preserves user-set notes + blockedRequiresLink
+  (h) import-jira-code accepts /1 (back-compat — conventions empty)
+  (i) import-jira-code accepts /2 with conventions; ackRequired=True when
+       notes non-empty AND no ack on file
+  (j) import-jira-code rejects unknown schema versions (e.g. /3)
+  (k) set-conventions writes block, returns warnings on guardrail breach
+  (l) read-conventions returns block + ackHash + alreadyAcked
+  (m) record-conventions-ack writes the right hash; subsequent
+       read-conventions reflects alreadyAcked=True
+  (n) cmd_transition refuses BLOCKED without --blocked-by when
+       blockedRequiresLink is true; allows it when false
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib import conventions as cv  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+# --- lib.conventions ----------------------------------------------------
+
+
+def test_normalize_fills_defaults_drops_unknown():
+    assert cv.normalize(None) == {"notes": []}
+    assert cv.normalize({}) == {"notes": []}
+    assert cv.normalize({"notes": ["a", 1, "b"]}) == {"notes": ["a", "b"]}
+    out = cv.normalize({"notes": ["x"], "blockedRequiresLink": True, "futureField": 99})
+    assert out == {"notes": ["x"], "blockedRequiresLink": True}
+
+
+def test_validate_flags_guardrails():
+    warns = cv.validate({"notes": ["a" * 201, "ok"]})
+    assert any("201 chars" in w for w in warns)
+    warns = cv.validate({"notes": ["x"] * 15})
+    assert any("15 entries" in w for w in warns)
+    warns = cv.validate({"notes": ["", "   ", "real"]})
+    assert any("empty" in w for w in warns)
+    assert cv.validate({"notes": ["use CANCELLED not DELETE"]}) == []
+    assert cv.validate(None) == []
+
+
+def test_is_empty():
+    assert cv.is_empty(None) is True
+    assert cv.is_empty({}) is True
+    assert cv.is_empty({"notes": []}) is True
+    assert cv.is_empty({"notes": ["x"]}) is False
+    assert cv.is_empty({"blockedRequiresLink": True}) is False
+
+
+def test_hash_stability():
+    h1 = cv.hash_conventions({"notes": ["a", "b"]})
+    h2 = cv.hash_conventions({"notes": ["a", "b"]})
+    h3 = cv.hash_conventions({"notes": ["a", "c"]})
+    assert h1 == h2
+    assert h1 != h3
+    h4 = cv.hash_conventions({"notes": ["a", "b"], "futureField": 1})
+    assert h1 == h4
+
+
+def test_record_ack_preserves_existing_fields():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        agent_dir = repo / ".claude"
+        agent_dir.mkdir()
+        (agent_dir / "kanban-agent.json").write_text(
+            json.dumps({"ap": "agent-fin"}) + "\n"
+        )
+        conv = {"notes": ["use CANCELLED not DELETE"]}
+        assert not cv.has_recent_ack(repo, conv)
+        cv.record_ack(repo, conv)
+        assert cv.has_recent_ack(repo, conv)
+        on_disk = json.loads((agent_dir / "kanban-agent.json").read_text())
+        assert on_disk["ap"] == "agent-fin"
+        assert "acknowledgedConventions" in on_disk
+        assert on_disk["acknowledgedConventions"]["hash"] == cv.hash_conventions(conv)
+        other = {"notes": ["different"]}
+        assert not cv.has_recent_ack(repo, other)
+
+
+# --- CLI: emit/import ---------------------------------------------------
+
+
+def _seed_jira(td, *, conventions=None) -> pathlib.Path:
+    p = pathlib.Path(td) / "kanban.json"
+    cfg = {
+        "boardUrl": "https://acme.atlassian.net/jira/software/projects/AGENT/boards/1",
+        "boardId": 1, "projectKey": "AGENT",
+        "transitions": {
+            "TODO": {"status": "Selected for Development"},
+            "DOING": {"status": "In Progress"},
+            "BLOCKED": {"status": "In Progress", "addLabels": ["kanban:blocked"]},
+            "DONE": {"status": "Done"},
+        },
+        "ap": {"fieldId": "customfield_10042", "fieldName": "Claude Agent",
+               "registered": ["agent-fin"]},
+    }
+    if conventions is not None:
+        cfg["conventions"] = conventions
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": cfg},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _isolated_home(td: pathlib.Path) -> dict[str, str]:
+    home = td / "fakehome"
+    home.mkdir(parents=True, exist_ok=True)
+    return {"HOME": str(home)}
+
+
+def _run(*args, env_extra=None) -> subprocess.CompletedProcess:
+    cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(cmd, capture_output=True, env=env, text=True)
+
+
+def test_emit_default_v2_with_empty_conventions():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td)
+        out = _run("emit-jira-code", "--kanban-path", str(kp),
+                   env_extra=_isolated_home(td))
+        assert out.returncode == 0, out.stderr
+        code = json.loads(out.stdout)["code"]
+        assert code["schema"] == "kanban-jira-code/2"
+        assert code["conventions"] == {"notes": []}
+
+
+def test_emit_preserves_notes_and_toggle():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={
+            "notes": ["use CANCELLED not DELETE",
+                      "Review 一律 assign kirin"],
+            "blockedRequiresLink": True,
+        })
+        out = _run("emit-jira-code", "--kanban-path", str(kp),
+                   env_extra=_isolated_home(td))
+        assert out.returncode == 0
+        code = json.loads(out.stdout)["code"]
+        assert code["conventions"]["notes"] == [
+            "use CANCELLED not DELETE", "Review 一律 assign kirin"
+        ]
+        assert code["conventions"]["blockedRequiresLink"] is True
+
+
+def test_import_v1_back_compat():
+    """Old code with schema=/1 still importable; conventions silently empty."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps({
+            "version": "0.2",
+            "backend": {"driver": "jira", "jira": {"projectKey": "AGENT"}},
+            "meta": {"priorities": ["P0"], "categories": [],
+                     "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                     "created_at": "x", "updated_at": "x"},
+            "tasks": [],
+        }))
+        v1_code = {
+            "schema": "kanban-jira-code/1",
+            "boardUrl": "https://acme.atlassian.net/jira/software/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+        }
+        out = _run("import-jira-code",
+                   "--kanban-path", str(kp),
+                   "--code-json", json.dumps(v1_code),
+                   env_extra=_isolated_home(td))
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        assert j["schema"] == "kanban-jira-code/1"
+        assert j["conventions"] == {"notes": []}
+        assert j["ackRequired"] is False
+
+
+def test_import_v2_with_notes_sets_ack_required():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps({
+            "version": "0.2",
+            "backend": {"driver": "jira", "jira": {"projectKey": "AGENT"}},
+            "meta": {"priorities": ["P0"], "categories": [],
+                     "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                     "created_at": "x", "updated_at": "x"},
+            "tasks": [],
+        }))
+        v2_code = {
+            "schema": "kanban-jira-code/2",
+            "boardUrl": "https://acme.atlassian.net/jira/software/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+            "conventions": {
+                "notes": ["use CANCELLED not DELETE"],
+                "blockedRequiresLink": False,
+            },
+        }
+        out = _run("import-jira-code",
+                   "--kanban-path", str(kp),
+                   "--code-json", json.dumps(v2_code),
+                   env_extra=_isolated_home(td))
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        assert j["schema"] == "kanban-jira-code/2"
+        assert j["conventions"]["notes"] == ["use CANCELLED not DELETE"]
+        assert j["ackRequired"] is True
+
+
+def test_import_rejects_unknown_schema():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps({
+            "version": "0.2",
+            "backend": {"driver": "jira", "jira": {"projectKey": "X"}},
+            "meta": {"priorities": ["P0"], "categories": [],
+                     "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                     "created_at": "x", "updated_at": "x"},
+            "tasks": [],
+        }))
+        out = _run("import-jira-code",
+                   "--kanban-path", str(kp),
+                   "--code-json", json.dumps({"schema": "kanban-jira-code/3"}),
+                   env_extra=_isolated_home(td))
+        assert out.returncode != 0
+        j = json.loads(out.stdout)
+        assert j["ok"] is False
+
+
+# --- CLI: set/read/record-ack ------------------------------------------
+
+
+def test_set_conventions_writes_and_warns():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td)
+        notes = ["a" * 250, "ok note"]
+        out = _run(
+            "set-conventions",
+            "--kanban-path", str(kp),
+            "--conventions-json", json.dumps({"notes": notes}),
+            env_extra=_isolated_home(td),
+        )
+        assert out.returncode == 0, out.stderr
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        assert any("250 chars" in w for w in j["warnings"])
+        cfg = json.loads(kp.read_text())["backend"]["jira"]
+        assert cfg["conventions"]["notes"] == notes
+
+
+def test_read_conventions_returns_ack_state():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["x"]})
+        out = _run("read-conventions", "--kanban-path", str(kp),
+                   env_extra=_isolated_home(td))
+        j = json.loads(out.stdout)
+        assert j["ok"] is True
+        assert j["isEmpty"] is False
+        assert j["alreadyAcked"] is False
+        assert isinstance(j["ackHash"], str) and len(j["ackHash"]) > 0
+
+
+def test_record_ack_then_read_shows_acked():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["x"]})
+        env = _isolated_home(td)
+        out = _run("read-conventions", "--kanban-path", str(kp), env_extra=env)
+        assert json.loads(out.stdout)["alreadyAcked"] is False
+        out = _run("record-conventions-ack", "--kanban-path", str(kp), env_extra=env)
+        assert out.returncode == 0
+        out = _run("read-conventions", "--kanban-path", str(kp), env_extra=env)
+        assert json.loads(out.stdout)["alreadyAcked"] is True
+
+
+# --- blockedRequiresLink enforcement ------------------------------------
+
+
+def test_block_requires_link_when_convention_on():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"blockedRequiresLink": True})
+        out = _run(
+            "transition", "--kanban-path", str(kp),
+            "--key", "AGENT-1", "--to", "BLOCKED", "--reason", "anything",
+            env_extra=_isolated_home(td),
+        )
+        assert out.returncode != 0
+        j = json.loads(out.stdout)
+        assert j["ok"] is False
+        assert j.get("kind") == "convention"
+        assert "blockedRequiresLink" in j["error"]
+
+
+def test_block_allows_when_convention_off():
+    """Convention off → cmd_transition's pre-check passes through; failure
+    downstream is for a different reason (no creds), not the convention."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td)
+        out = _run(
+            "transition", "--kanban-path", str(kp),
+            "--key", "AGENT-1", "--to", "BLOCKED", "--reason", "anything",
+            env_extra=_isolated_home(td),
+        )
+        j = json.loads(out.stdout)
+        assert j["ok"] is False
+        assert j.get("kind") != "convention"
+
+
+def main() -> int:
+    cases = [
+        ("normalize_fills_defaults_drops_unknown", test_normalize_fills_defaults_drops_unknown),
+        ("validate_flags_guardrails", test_validate_flags_guardrails),
+        ("is_empty", test_is_empty),
+        ("hash_stability", test_hash_stability),
+        ("record_ack_preserves_existing_fields", test_record_ack_preserves_existing_fields),
+        ("emit_default_v2_with_empty_conventions", test_emit_default_v2_with_empty_conventions),
+        ("emit_preserves_notes_and_toggle", test_emit_preserves_notes_and_toggle),
+        ("import_v1_back_compat", test_import_v1_back_compat),
+        ("import_v2_with_notes_sets_ack_required", test_import_v2_with_notes_sets_ack_required),
+        ("import_rejects_unknown_schema", test_import_rejects_unknown_schema),
+        ("set_conventions_writes_and_warns", test_set_conventions_writes_and_warns),
+        ("read_conventions_returns_ack_state", test_read_conventions_returns_ack_state),
+        ("record_ack_then_read_shows_acked", test_record_ack_then_read_shows_acked),
+        ("block_requires_link_when_convention_on", test_block_requires_link_when_convention_on),
+        ("block_allows_when_convention_off", test_block_allows_when_convention_off),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase11: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase8.py
+++ b/plugins/kanban/scripts/test_phase8.py
@@ -93,7 +93,8 @@ def test_emit_strips_agent_and_registered():
         j = json.loads(out.stdout)
         assert j["ok"] is True
         code = j["code"]
-        assert code["schema"] == "kanban-jira-code/1"
+        # 0.3.4+ writers emit /2 by default; reader still accepts /1 (forward-compat).
+        assert code["schema"] == "kanban-jira-code/2"
         assert code["projectKey"] == "AGENT"
         assert code["boardId"] == 1
         # Defaults strip these:

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -77,6 +77,22 @@
                   "uniqueItems": true
                 }
               }
+            },
+            "conventions": {
+              "type": "object",
+              "description": "Soft team agreements — narrative notes that travel with the board mapping (kanban-jira-code/2 schema). Length guardrails are advisory; helpers warn but don't reject.",
+              "additionalProperties": false,
+              "properties": {
+                "notes": {
+                  "type": "array",
+                  "description": "Short prose notes shown to anyone importing the board code. Receivers are required to acknowledge before /kanban:initjira-by-code completes.",
+                  "items": { "type": "string" }
+                },
+                "blockedRequiresLink": {
+                  "type": "boolean",
+                  "description": "If true, /kanban:block refuses transitions to BLOCKED that don't pass --blocked-by. Per-team opt-in convention."
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Closes #10.

## Summary

The share code (`/kanban:showjira-code` → `/kanban:initjira-by-code`) now carries a small `conventions` block alongside the existing hard wiring (`transitions`, `ap`, `boardUrl`). Schema bumped `kanban-jira-code/1` → `/2`; receivers still accept v1 for back-compat.

**Scope is narrower than the original issue proposal**, by user agreement after evaluation:

| Field from issue | Status | Reason |
|---|---|---|
| `notes` (≤200 × ≤10) | ✅ shipped | The high-leverage primitive — "just having the slot" causes conventions to get written down |
| `blockedRequiresLink` | ✅ shipped | Genuine 5-line addition, pairs with `--blocked-by` from #8, per-team opt-in |
| Receiver `I have read these` ack | ✅ shipped | Friction-by-design from the issue's UX section |
| `reviewerAccountId` | ❌ rejected | Already encodable via `transitions.REVIEW.assignee` — would be a duplicate slot to keep in sync |
| `requiredLabels.<COL>` | ❌ rejected | Overlaps with `transitions.<COL>.addLabels` |
| `summaryPrefix` | ❌ rejected | Triggers on card-create (rare path); easy to forget |
| `defaultEpic` | ❌ rejected | Needs another field-discovery flow per project |
| `commentTemplates` | ❌ rejected | Variable substitution = mini template language; slippery slope |

The user's framing was the deciding factor: "每個team每個board使用習慣不同, 不應該強制規定" — keep it advisory.

## What changed

| Concern | File |
|---|---|
| `normalize / validate / is_empty / hash_conventions / record_ack / has_recent_ack / blocked_requires_link` | `lib/conventions.py` (new) |
| Schema bump in emit (`kanban-jira-code/2`) + accept v1+v2 in import; response gains `ackRequired` | `scripts/jira_setup.py` (`cmd_emit_jira_code`, `cmd_import_jira_code`) |
| New helper subcommands: `set-conventions`, `read-conventions`, `record-conventions-ack` | `scripts/jira_setup.py` |
| `cmd_transition` refuses `BLOCKED` without `--blocked-by` when team set `blockedRequiresLink: true` | `scripts/jira_setup.py` |
| Schema: `backend.jira.conventions` optional block (additive) | `templates/kanban.schema.json` |
| `/kanban:edit-conventions` — interactive author flow | `commands/edit-conventions.md` (new) |
| `/kanban:show-conventions` — read-only render with ack status | `commands/show-conventions.md` (new) |
| `/kanban:initjira-by-code` — Step 2.5 ack flow with literal phrase | `commands/initjira-by-code.md` |
| `/kanban:showjira-code` — documents `kanban-jira-code/2` + conventions field | `commands/showjira-code.md` |
| 15 mocked tests | `scripts/test_phase11.py` (new) |
| `test_phase8` schema assertion bumped /1 → /2 | `scripts/test_phase8.py` |
| Bump `0.3.3 → 0.3.4`; CHANGELOG entry | versions / CHANGELOG |

## Receiver UX (issue §Receiver UX)

When `/kanban:initjira-by-code` imports a v2 code with non-empty notes:

```
⚠ Team conventions you should know before starting work:

  1. <note 1>
  2. <note 2>
  ...

If `blockedRequiresLink` is true:
  ⚙ This team requires `--blocked-by KEY` on every /kanban:block call.

Type the literal phrase 'I have read these' to acknowledge and continue:
```

`yes`, `Y`, `ok`, `已讀` — all rejected. Two mismatches abort init. Once acknowledged, the (hash, timestamp) pair lands in `.claude/kanban-agent.json` so re-imports of the same set skip the prompt.

## Authoring (issue §Where do conventions get authored)

Two paths from the issue, both implemented:
- **Power user / scripts**: `set-conventions --conventions-json '{...}'` — direct JSON write with advisory length warnings
- **First-time setup**: `/kanban:edit-conventions` — interactive flow with per-note keep/edit/delete + toggle prompt

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 11 phase suites, **114 tests**, all green
- [x] v1 code on v2 plugin: imports cleanly with empty `conventions` (back-compat)
- [x] v2 code with notes: `ackRequired: true` returned to slash command
- [x] v2 code with same notes after ack: `ackRequired: false` (no re-prompt)
- [x] `set-conventions` writes despite warnings (advisory, not blocking)
- [x] `blockedRequiresLink: true` rejects `/kanban:block` without `--blocked-by` upfront (no Jira round-trip needed)
- [x] `blockedRequiresLink: false` / absent → no convention check, behaves exactly as 0.3.3
- [ ] After merge: real `/kanban:edit-conventions` on the DMI repo, add 2-3 notes, run `/kanban:showjira-code`, paste into a test repo, verify the `I have read these` prompt fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
