### PR TITLE
feat(kanban): 0.3.6 — sync surfaces stale DOING + unanswered questions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-01 (sync stale + Q checks)
+
+### Added
+- **kanban 0.3.6** — `/kanban:sync` (and the SessionStart hook that
+  fires it automatically) now surfaces two checks beyond the existing
+  open-cards + mentions blocks:
+
+  - **`[stale DOING — N card(s) idle ≥ 2 day(s)]`** — DOING cards
+    belonging to this AP whose `updated` timestamp is older than 2
+    days. The agent might have forgotten the card sat in DOING; the
+    block prompts them to resume, ask a `/kanban:question`, or close
+    via `/kanban:done`.
+  - **`[unanswered questions — N BLOCKED card(s) waiting on human, ≥24h]`**
+    — BLOCKED cards where this AP posted a Q-prefix comment via
+    `/kanban:question` and no other party has commented since,
+    AND ≥24h have passed (so the human has had time to reply). Helps
+    the agent spot stuck-on-the-human items rather than waiting forever.
+
+  Together with the existing open-cards summary and mentions block,
+  `/kanban:sync` is now the equivalent of "open Jira and look around" —
+  the answer to issue/question #13 ("how does the agent know what to
+  check?"). No new slash command (intentionally — Option A from the
+  thread); both checks are augmentations of the existing primitive.
+
+  Highlights:
+  - `_detect_stale_doing(driver, repo_ap)` reads `Task.updated` from
+    `list_tasks(column=DOING, ap=...)`. No extra network calls beyond
+    the existing list_tasks.
+  - `_detect_unanswered_questions(driver, repo_ap)` does
+    `list_tasks(BLOCKED) + list_comments` per BLOCKED card. The
+    existing prefix-grammar parser (`_parse_comment`) already
+    distinguishes own Q-comments (author == this AP) from anything
+    else; the detector uses that.
+  - Best-effort: detector failures don't block the rest of the sync
+    output.
+  - Thresholds hardcoded for now (2 days / 24 hours) — moved to
+    conventions only when a real use case demands per-team tuning.
+  - `test_phase13.py`: 11 mocked cases covering both detectors,
+    timestamp edge cases, and the cmd_sync_summary integration. All
+    13 phase suites (136 tests) green.
+
 ## 2026-05-01
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1669,6 +1669,142 @@ def cmd_precheck_card(args: argparse.Namespace) -> int:
     return 0
 
 
+_STALE_DOING_THRESHOLD_DAYS = 2
+_UNANSWERED_Q_THRESHOLD_HOURS = 24
+
+
+def _parse_iso(ts: str | None):
+    """Tolerant ISO-8601 parse. Returns datetime or None."""
+    if not ts or not isinstance(ts, str):
+        return None
+    from datetime import datetime
+    try:
+        # fromisoformat handles "2026-04-30T10:00:00+08:00" + offset variants
+        return datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        # Jira sometimes emits trailing "Z" or millis with weird offsets
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            return None
+
+
+def _detect_stale_doing(
+    driver, repo_ap: str | None, *, threshold_days: int = _STALE_DOING_THRESHOLD_DAYS
+) -> list[dict[str, Any]]:
+    """Return DOING cards belonging to repo_ap whose `updated` is older
+    than `threshold_days`. Each entry: {key, title, updated, days_idle}.
+
+    The agent might have forgotten the card sat in DOING; surfacing it
+    on /kanban:sync nudges them to either resume, BLOCKED + question, or
+    transition to REVIEW.
+    """
+    from datetime import datetime, timedelta, timezone
+    from drivers.base import TaskFilter
+
+    try:
+        tasks = driver.list_tasks(
+            TaskFilter(column="DOING", ap=repo_ap, limit=20)
+            if repo_ap
+            else TaskFilter(column="DOING", limit=20)
+        )
+    except Exception:
+        return []
+    now = datetime.now(timezone.utc).astimezone()
+    cutoff = now - timedelta(days=threshold_days)
+    out: list[dict[str, Any]] = []
+    for t in tasks:
+        ts = _parse_iso(t.updated)
+        if ts is None:
+            continue
+        if ts >= cutoff:
+            continue
+        idle_days = (now - ts).days
+        out.append(
+            {
+                "key": t.id,
+                "title": t.title,
+                "updated": t.updated,
+                "days_idle": idle_days,
+                "priority": t.priority,
+            }
+        )
+    return out
+
+
+def _detect_unanswered_questions(
+    driver,
+    repo_ap: str | None,
+    *,
+    threshold_hours: int = _UNANSWERED_Q_THRESHOLD_HOURS,
+) -> list[dict[str, Any]]:
+    """For BLOCKED cards belonging to repo_ap, find ones where this AP
+    posted a Q-prefix comment and no other party has commented since,
+    older than `threshold_hours` (so the human has had time to reply).
+
+    Each entry: {key, title, asked_at, hours_idle, question}.
+
+    Implementation reads comments via driver.list_comments which already
+    parses the SPEC §9 prefix grammar. A Q-comment authored by repo_ap
+    is "ours"; any later comment from a different author counts as a
+    reply (whether human or another agent).
+    """
+    from datetime import datetime, timezone
+    from drivers.base import TaskFilter
+
+    if not repo_ap:
+        return []
+    try:
+        tasks = driver.list_tasks(
+            TaskFilter(column="BLOCKED", ap=repo_ap, limit=20)
+        )
+    except Exception:
+        return []
+
+    now = datetime.now(timezone.utc).astimezone()
+    out: list[dict[str, Any]] = []
+    for t in tasks:
+        try:
+            comments = driver.list_comments(t.id)
+        except Exception:
+            continue
+        latest_q_ts: str | None = None
+        latest_q_text: str | None = None
+        latest_other_ts: str | None = None
+        for c in comments:
+            ts = c.ts or ""
+            if not ts:
+                continue
+            kind = getattr(c.kind, "value", None)
+            if c.author == repo_ap and kind == "Q":
+                if latest_q_ts is None or ts > latest_q_ts:
+                    latest_q_ts = ts
+                    latest_q_text = c.text
+            elif c.author != repo_ap:
+                if latest_other_ts is None or ts > latest_other_ts:
+                    latest_other_ts = ts
+        if latest_q_ts is None:
+            continue  # no own questions
+        if latest_other_ts is not None and latest_other_ts > latest_q_ts:
+            continue  # someone replied
+        q_dt = _parse_iso(latest_q_ts)
+        if q_dt is None:
+            continue
+        idle_hours = (now - q_dt).total_seconds() / 3600.0
+        if idle_hours < threshold_hours:
+            continue  # too recent — give the human time
+        out.append(
+            {
+                "key": t.id,
+                "title": t.title,
+                "asked_at": latest_q_ts,
+                "hours_idle": int(idle_hours),
+                "question": (latest_q_text or "")[:200],
+            }
+        )
+    return out
+
+
 def cmd_sync_summary(args: argparse.Namespace) -> int:
     """Render an open-cards summary for the current repo's AP."""
     p = Path(args.kanban_path)
@@ -1792,6 +1928,44 @@ def cmd_sync_summary(args: argparse.Namespace) -> int:
             + "\n  (run /kanban:mentions to mark these read)"
         )
 
+    # Stale DOING + unanswered questions — the "things a human checks
+    # when they open Jira" beyond just open-card counts. Best-effort:
+    # detector failures don't block the rest of the sync.
+    stale_rows: list[dict[str, Any]] = []
+    unanswered_rows: list[dict[str, Any]] = []
+    try:
+        stale_rows = _detect_stale_doing(driver, repo_ap)
+    except Exception:
+        stale_rows = []
+    try:
+        unanswered_rows = _detect_unanswered_questions(driver, repo_ap)
+    except Exception:
+        unanswered_rows = []
+
+    if stale_rows:
+        summary += (
+            f"\n\n[stale DOING — {len(stale_rows)} card(s) idle ≥ "
+            f"{_STALE_DOING_THRESHOLD_DAYS} day(s)]\n"
+            + "\n".join(
+                f"  {r['key']:<14}{r['days_idle']}d idle    "
+                f"{r['title']}"
+                for r in stale_rows
+            )
+            + "\n  (resume, /kanban:question, or /kanban:done to clear)"
+        )
+
+    if unanswered_rows:
+        summary += (
+            f"\n\n[unanswered questions — {len(unanswered_rows)} BLOCKED "
+            f"card(s) waiting on human, ≥{_UNANSWERED_Q_THRESHOLD_HOURS}h]\n"
+            + "\n".join(
+                f"  {r['key']:<14}{r['hours_idle']}h waiting    "
+                f"{r['question'][:60]}"
+                for r in unanswered_rows
+            )
+            + "\n  (consider nudging the owner or escalating)"
+        )
+
     _emit({
         "summary": summary,
         "counts": counts,
@@ -1799,6 +1973,8 @@ def cmd_sync_summary(args: argparse.Namespace) -> int:
         "projectKey": project_key,
         "mentions": mentions_count,
         "latestSeen": new_latest_seen,
+        "staleDoing": stale_rows,
+        "unansweredQuestions": unanswered_rows,
     })
     return 0
 

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12; do  # phase 8-12: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13; do  # phase 8-13: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase13.py
+++ b/plugins/kanban/scripts/test_phase13.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Phase 13 regression checks for kanban v0.3.6 — sync stale + unanswered detectors.
+
+`/kanban:sync` (and the SessionStart hook) gain two checks beyond the
+existing open-cards + mentions blocks:
+
+  - Stale DOING: cards in DOING for ≥ 2 days haven't moved
+  - Unanswered questions: this AP posted a Q-comment on a BLOCKED card,
+    no other party has commented since, and ≥24h have passed
+
+These are the "things a human checks when they open Jira" — surfaced so
+the agent doesn't forget cards that have been quietly aging.
+
+Cases:
+  (a) _parse_iso handles +08:00, Z, and bad input
+  (b) _detect_stale_doing flags cards updated > 2d ago
+  (c) _detect_stale_doing skips cards updated recently
+  (d) _detect_stale_doing returns [] when no DOING cards
+  (e) _detect_unanswered_questions: own Q + later non-self comment → not flagged
+  (f) _detect_unanswered_questions: own Q + no reply + > 24h → flagged
+  (g) _detect_unanswered_questions: own Q + no reply but recent → not flagged
+  (h) _detect_unanswered_questions: only counts BLOCKED cards
+  (i) _detect_unanswered_questions: skips cards with no own Q
+  (j) cmd_sync_summary integration: returns staleDoing[] + unansweredQuestions[]
+       in JSON; summary text contains the blocks when non-empty
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from drivers.base import Comment, CommentKind, Task, TaskFilter  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).astimezone()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat(timespec="seconds")
+
+
+# --- _parse_iso --------------------------------------------------------
+
+
+def test_parse_iso_variants():
+    fn = _jira_setup._parse_iso
+    assert fn("2026-04-30T10:00:00+08:00") is not None
+    assert fn("2026-04-30T10:00:00Z") is not None
+    assert fn(None) is None
+    assert fn("") is None
+    assert fn("garbage") is None
+
+
+# --- _detect_stale_doing -----------------------------------------------
+
+
+class _StubDriver:
+    """Minimal driver stub for the detectors. Lets tests inject task and
+    comment lists per call."""
+
+    def __init__(self, *, doing=(), blocked=(), comments=None):
+        self._doing = list(doing)
+        self._blocked = list(blocked)
+        self._comments_by_key = comments or {}
+
+    def list_tasks(self, filter: TaskFilter | None = None) -> list[Task]:
+        if filter and filter.column == "DOING":
+            return list(self._doing)
+        if filter and filter.column == "BLOCKED":
+            return list(self._blocked)
+        return []
+
+    def list_comments(self, key: str) -> list[Comment]:
+        return list(self._comments_by_key.get(key, []))
+
+
+def _mk_task(key: str, *, column: str = "DOING", updated_iso: str = "",
+             title: str = "x", priority: str = "P1") -> Task:
+    return Task(
+        id=key, title=title, column=column, priority=priority,
+        created="x", updated=updated_iso,
+    )
+
+
+def test_stale_doing_flags_old_cards():
+    old = _now() - timedelta(days=3)
+    fresh = _now() - timedelta(hours=4)
+    drv = _StubDriver(doing=[
+        _mk_task("AGENT-1", updated_iso=_iso(old), title="dusty"),
+        _mk_task("AGENT-2", updated_iso=_iso(fresh), title="fresh"),
+    ])
+    out = _jira_setup._detect_stale_doing(drv, repo_ap="agent-fin")
+    assert len(out) == 1
+    assert out[0]["key"] == "AGENT-1"
+    assert out[0]["days_idle"] >= 2
+    assert "fresh" not in (out[0].get("title") or "")
+
+
+def test_stale_doing_empty_when_no_cards():
+    drv = _StubDriver(doing=[])
+    assert _jira_setup._detect_stale_doing(drv, repo_ap="agent-fin") == []
+
+
+def test_stale_doing_handles_bad_timestamps():
+    drv = _StubDriver(doing=[
+        _mk_task("AGENT-3", updated_iso="not-a-date", title="bad ts"),
+    ])
+    # Doesn't crash, just skips
+    assert _jira_setup._detect_stale_doing(drv, repo_ap="agent-fin") == []
+
+
+# --- _detect_unanswered_questions --------------------------------------
+
+
+def _mk_comment(author: str, kind: CommentKind, ts_iso: str,
+                text: str = "") -> Comment:
+    return Comment(author=author, ts=ts_iso, text=text, kind=kind)
+
+
+def test_unanswered_q_replied_skipped():
+    """Own Q at T1, human reply at T2 > T1 → not flagged."""
+    long_ago = _now() - timedelta(days=2)
+    after = _now() - timedelta(days=2, hours=-1)  # later
+    drv = _StubDriver(
+        blocked=[_mk_task("AGENT-99", column="BLOCKED",
+                          updated_iso=_iso(_now() - timedelta(days=2)))],
+        comments={
+            "AGENT-99": [
+                _mk_comment("agent-fin", CommentKind.QUESTION, _iso(long_ago),
+                            text="should I use library X?"),
+                _mk_comment("Kirin", CommentKind.COMMENT, _iso(after),
+                            text="use Y."),
+            ],
+        },
+    )
+    out = _jira_setup._detect_unanswered_questions(drv, repo_ap="agent-fin")
+    assert out == []
+
+
+def test_unanswered_q_old_no_reply_flagged():
+    """Own Q from 2d ago, no later comment → flagged."""
+    long_ago = _now() - timedelta(days=2)
+    drv = _StubDriver(
+        blocked=[_mk_task("AGENT-99", column="BLOCKED",
+                          updated_iso=_iso(long_ago))],
+        comments={
+            "AGENT-99": [
+                _mk_comment("agent-fin", CommentKind.QUESTION, _iso(long_ago),
+                            text="should I use library X?"),
+            ],
+        },
+    )
+    out = _jira_setup._detect_unanswered_questions(drv, repo_ap="agent-fin")
+    assert len(out) == 1
+    assert out[0]["key"] == "AGENT-99"
+    assert "should I use library X?" in out[0]["question"]
+    assert out[0]["hours_idle"] >= 24
+
+
+def test_unanswered_q_recent_not_flagged():
+    """Own Q from 2h ago — too recent, give the human time."""
+    recent = _now() - timedelta(hours=2)
+    drv = _StubDriver(
+        blocked=[_mk_task("AGENT-99", column="BLOCKED",
+                          updated_iso=_iso(recent))],
+        comments={
+            "AGENT-99": [
+                _mk_comment("agent-fin", CommentKind.QUESTION, _iso(recent),
+                            text="thoughts?"),
+            ],
+        },
+    )
+    out = _jira_setup._detect_unanswered_questions(drv, repo_ap="agent-fin")
+    assert out == []
+
+
+def test_unanswered_q_skips_cards_with_no_own_q():
+    """BLOCKED card with only human / other-AP comments — skip."""
+    long_ago = _now() - timedelta(days=2)
+    drv = _StubDriver(
+        blocked=[_mk_task("AGENT-99", column="BLOCKED",
+                          updated_iso=_iso(long_ago))],
+        comments={
+            "AGENT-99": [
+                _mk_comment("Kirin", CommentKind.COMMENT, _iso(long_ago),
+                            text="please block on infra"),
+                _mk_comment("agent-other", CommentKind.QUESTION, _iso(long_ago),
+                            text="from a different agent"),
+            ],
+        },
+    )
+    out = _jira_setup._detect_unanswered_questions(drv, repo_ap="agent-fin")
+    assert out == []
+
+
+def test_unanswered_q_no_repo_ap_returns_empty():
+    drv = _StubDriver()
+    assert _jira_setup._detect_unanswered_questions(drv, repo_ap=None) == []
+
+
+# --- cmd_sync_summary integration --------------------------------------
+
+
+def _seed_kanban(td) -> pathlib.Path:
+    p = pathlib.Path(td) / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-bot",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "BLOCKED": {"status": "In Progress",
+                            "addLabels": ["kanban:blocked"]},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    (p.parent / ".claude").mkdir()
+    (p.parent / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": "agent-fin"}) + "\n"
+    )
+    return p
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        rc = fn(args)
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+def test_sync_summary_includes_stale_and_unanswered():
+    long_ago = _now() - timedelta(days=3)
+    older_q = _now() - timedelta(days=2)
+
+    class _SyncStub:
+        name = "jira"
+        def list_tasks(self, filter=None):
+            if filter and filter.column == "DOING":
+                return [_mk_task("AGENT-1", column="DOING",
+                                 updated_iso=_iso(long_ago),
+                                 title="grid pricing")]
+            if filter and filter.column == "BLOCKED":
+                return [_mk_task("AGENT-9", column="BLOCKED",
+                                 updated_iso=_iso(older_q),
+                                 title="blocked thing")]
+            return []
+        def list_comments(self, key):
+            if key == "AGENT-9":
+                return [_mk_comment("agent-fin", CommentKind.QUESTION,
+                                    _iso(older_q),
+                                    text="library X or Y?")]
+            return []
+
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td)
+        # No credentials => mentions block fails silently. We only care
+        # about the stale + unanswered blocks for this test.
+        import drivers as _drv_mod
+        orig = _drv_mod.get_driver
+        _drv_mod.get_driver = lambda data, root: _SyncStub()
+        try:
+            class A:
+                kanban_path = str(kp)
+            rc, out = _capture(_jira_setup.cmd_sync_summary, A())
+        finally:
+            _drv_mod.get_driver = orig
+        assert rc == 0, out
+        j = json.loads(out)
+        assert len(j["staleDoing"]) == 1
+        assert j["staleDoing"][0]["key"] == "AGENT-1"
+        assert len(j["unansweredQuestions"]) == 1
+        assert j["unansweredQuestions"][0]["key"] == "AGENT-9"
+        # The summary text contains both blocks
+        assert "[stale DOING" in j["summary"]
+        assert "[unanswered questions" in j["summary"]
+        assert "AGENT-1" in j["summary"]
+        assert "AGENT-9" in j["summary"]
+
+
+def test_sync_summary_omits_blocks_when_clean():
+    """When nothing is stale / unanswered, the blocks don't appear."""
+    class _CleanStub:
+        name = "jira"
+        def list_tasks(self, filter=None): return []
+        def list_comments(self, key): return []
+
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td)
+        import drivers as _drv_mod
+        orig = _drv_mod.get_driver
+        _drv_mod.get_driver = lambda data, root: _CleanStub()
+        try:
+            class A:
+                kanban_path = str(kp)
+            rc, out = _capture(_jira_setup.cmd_sync_summary, A())
+        finally:
+            _drv_mod.get_driver = orig
+        assert rc == 0
+        j = json.loads(out)
+        assert j["staleDoing"] == []
+        assert j["unansweredQuestions"] == []
+        assert "[stale DOING" not in j["summary"]
+        assert "[unanswered questions" not in j["summary"]
+
+
+def main() -> int:
+    cases = [
+        ("parse_iso_variants", test_parse_iso_variants),
+        ("stale_doing_flags_old_cards", test_stale_doing_flags_old_cards),
+        ("stale_doing_empty_when_no_cards", test_stale_doing_empty_when_no_cards),
+        ("stale_doing_handles_bad_timestamps", test_stale_doing_handles_bad_timestamps),
+        ("unanswered_q_replied_skipped", test_unanswered_q_replied_skipped),
+        ("unanswered_q_old_no_reply_flagged", test_unanswered_q_old_no_reply_flagged),
+        ("unanswered_q_recent_not_flagged", test_unanswered_q_recent_not_flagged),
+        ("unanswered_q_skips_cards_with_no_own_q",
+         test_unanswered_q_skips_cards_with_no_own_q),
+        ("unanswered_q_no_repo_ap_returns_empty", test_unanswered_q_no_repo_ap_returns_empty),
+        ("sync_summary_includes_stale_and_unanswered",
+         test_sync_summary_includes_stale_and_unanswered),
+        ("sync_summary_omits_blocks_when_clean", test_sync_summary_omits_blocks_when_clean),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase13: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Augments `/kanban:sync` (and the `SessionStart` hook that auto-fires it) with the two missing pieces from the "open Jira and look around" question.

> **Background**: when you asked "如何 trigger AI agent to check 這些該做的事", I recommended **Option A** (augment `/kanban:sync` rather than add a new `/kanban:checkall`). This PR ships that.

## What `/kanban:sync` shows now

Existing blocks (already on main):
- `[kanban Jira sync — DMI · ap=mt-core-backend]` open-cards count + per-column list
- `[mentions — N since X]` unread @-mentions of the bot

**New** in 0.3.6:
- `[stale DOING — N card(s) idle ≥ 2 day(s)]` — DOING cards belonging to this AP whose `updated` is older than 2 days. The agent might have forgotten about them.
- `[unanswered questions — N BLOCKED card(s) waiting on human, ≥24h]` — BLOCKED cards where this AP posted a `/kanban:question` and no other party has commented since (24h+). Helps the agent spot stuck-on-human items.

Together: equivalent of "open Jira inbox + my-cards view + assigned-to-me filter".

## What changed

| Concern | File |
|---|---|
| `_detect_stale_doing(driver, repo_ap)` — reads `Task.updated`, no extra calls | `scripts/jira_setup.py` |
| `_detect_unanswered_questions(driver, repo_ap)` — list_comments per BLOCKED card; uses existing prefix-grammar parser to distinguish own Q-comments | `scripts/jira_setup.py` |
| `_parse_iso(ts)` tolerant timestamp parser (handles `+offset`, `Z`, garbage) | `scripts/jira_setup.py` |
| `cmd_sync_summary` calls both detectors after the existing blocks; output JSON gains `staleDoing[]` + `unansweredQuestions[]`; summary text appends `[stale DOING ...]` / `[unanswered questions ...]` blocks when non-empty | `scripts/jira_setup.py` |
| 11 new mocked tests | `scripts/test_phase13.py` (new) |
| Bump `0.3.5 → 0.3.6`; CHANGELOG entry | versions / CHANGELOG |

## Why no new slash command

You already have `/kanban:sync`. Adding `/kanban:checkall` would just be a second name for the same thing — adoption confusion ("which do I run?"). Augmenting the existing primitive keeps the surface flat.

## Why hardcoded thresholds (2 days / 24 hours)

Could go into `backend.jira.conventions` per-team, but:
- The thresholds are **informational** (just decides whether to surface the row)
- Missing a couple of cards on the edge isn't a correctness problem
- One more knob to maintain

Moved to convention only if a real use case asks ("our team works on weekends, the 2-day threshold rolls every Friday but we're in DOING all weekend"). Until then, simple defaults.

## Why best-effort

Detection failures (Jira API blips, malformed comment data) shouldn't kill the sync. Both detectors are wrapped in `try/except` — if either fails the existing open-cards + mentions blocks still print.

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 13 phase suites, **136 tests**, all green
- [x] `_parse_iso` handles `+offset`, `Z`, and bad input (no crashes)
- [x] Stale DOING flags 3-day-old cards, skips fresh ones, returns [] for empty list
- [x] Unanswered Q: own Q + later non-self comment → not flagged
- [x] Unanswered Q: own Q + no reply + >24h → flagged
- [x] Unanswered Q: own Q from 2h ago → not flagged (give human time)
- [x] Unanswered Q: human-only comments on a BLOCKED card → not flagged (no own Q to be answered)
- [x] cmd_sync_summary integration: when stub driver returns stale + unanswered, summary text includes both blocks; when clean, blocks omitted
- [ ] After merge: real `/kanban:sync` against the DMI project to see "open Jira" feel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
