### PR TITLE
feat(kanban): 0.3.7 — resolve-doc-link helper for clickable Jira refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,50 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-01 (clickable doc links)
+
+### Added
+- **kanban 0.3.7** — `resolve-doc-link` helper turns a repo-relative
+  doc path into a clickable GitHub URL for Jira comments. First piece
+  of the `kanban × mentor` integration line from SPEC §13.
+
+  Motivation: when the agent posts `please see epic/AGENT-001-foo.md`
+  to Jira, the human reading the comment can't click — they have to
+  navigate GitHub manually. With this helper, the agent posts
+  `https://github.com/<owner>/<repo>/blob/main/epic/AGENT-001-foo.md`
+  instead. The skill (`kanban-jira-agent`) carries the rule.
+
+  Highlights:
+  - New CLI subcommand:
+    ```
+    resolve-doc-link --kanban-path P --doc-path 'epic/X.md' [--branch B]
+    ```
+    Returns `{ok, url, exists, branch, host, owner, repo, docPath}`.
+  - Reads `git remote get-url origin`, parses both HTTPS and SSH GitHub
+    forms (`https://github.com/owner/repo` and
+    `git@github.com:owner/repo.git`).
+  - Branch resolution: explicit `--branch` > current git branch > `main`.
+  - Doc-path strips leading `/` and `./`; refuses `..` traversal even
+    though GitHub itself would 404.
+  - `exists` flag reflects whether the file is present locally — the
+    URL is still returned for uncommitted files (skill explains how
+    to handle).
+  - **Non-GitHub origins** (GitLab, Bitbucket, internal): returns
+    `ok=false` with `host: "other"` so the LLM can fall back to a
+    relative path with a one-line explanation. Other hosts can land
+    later when the URL formats stabilise.
+  - `kanban-jira-agent` SKILL.md gains a "Linking to repo docs"
+    section with the four response branches (exists / not-exists /
+    other-host / no-origin).
+  - **No automatic comment rewriting** — the LLM decides when to use
+    a URL vs a relative path. Plugin provides primitive, LLM decides;
+    same philosophy as the mention-reply work in 0.3.5.
+  - `test_phase14.py`: 12 cases covering origin parsers (HTTPS / SSH /
+    non-GitHub / malformed), happy-path resolution, leading-slash
+    handling, traversal rejection, exists flag, branch override, no
+    origin, non-GitHub host, empty doc-path. All 14 phase suites
+    (148 tests) green.
+
 ## 2026-05-01 (sync stale + Q checks)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -767,6 +767,118 @@ def cmd_live_list_aps(args: argparse.Namespace) -> int:
     return 0
 
 
+# --- doc-link resolution (kanban × mentor integration, SPEC §13) -------
+
+
+_GITHUB_HTTPS_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?/?$"
+)
+_GITHUB_SSH_RE = re.compile(
+    r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/.]+?)(?:\.git)?$"
+)
+
+
+def _parse_github_origin(origin: str) -> tuple[str, str] | None:
+    """Return (owner, repo) when `origin` is a GitHub URL, else None."""
+    if not origin:
+        return None
+    for rx in (_GITHUB_HTTPS_RE, _GITHUB_SSH_RE):
+        m = rx.match(origin.strip())
+        if m:
+            return m.group("owner"), m.group("repo")
+    return None
+
+
+def _git_origin(repo_root: Path) -> str:
+    """Return `git remote get-url origin` from repo_root, or '' on error."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return ""
+    if out.returncode != 0:
+        return ""
+    return (out.stdout or "").strip()
+
+
+def _git_current_branch(repo_root: Path) -> str:
+    """Return current git branch from repo_root, or '' on error."""
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "branch", "--show-current"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return ""
+    if out.returncode != 0:
+        return ""
+    return (out.stdout or "").strip()
+
+
+def cmd_resolve_doc_link(args: argparse.Namespace) -> int:
+    """Resolve a repo-relative doc path to a clickable GitHub URL.
+
+    Used when posting Jira comments that reference repo docs (mentor's
+    Epic / Sprint / Issue / ADR docs in particular). Without this, the
+    agent would write "see epic/AGENT-001-foo.md" — not clickable in
+    Jira; the human has to navigate to GitHub manually.
+
+    Detects host from `git remote get-url origin`. Only GitHub
+    (`github.com`) is supported in this version; other hosts return
+    `ok=false` so the LLM can fall back to a relative path with an
+    explanation.
+    """
+    repo_root = Path(args.kanban_path).parent.resolve()
+    origin = _git_origin(repo_root)
+    if not origin:
+        return _fail(
+            "no git origin — repo must be cloned from a remote for "
+            "links to resolve"
+        )
+
+    parsed = _parse_github_origin(origin)
+    if parsed is None:
+        return _fail(
+            f"only github.com origins are supported (got origin={origin!r}); "
+            "fall back to a relative path or paste the URL manually",
+            host="other",
+            origin=origin,
+        )
+    owner, repo = parsed
+
+    # Strip any leading `/` or `./`; reject `..` to avoid traversal-style
+    # URLs even though GitHub itself would 404 them.
+    doc = (args.doc_path or "").strip().lstrip("./").lstrip("/")
+    if not doc:
+        return _fail("--doc-path is required and must be non-empty")
+    if ".." in doc.split("/"):
+        return _fail("--doc-path cannot contain '..' segments")
+
+    # Branch resolution: explicit > current > "main"
+    branch = (args.branch or _git_current_branch(repo_root) or "main").strip()
+    # /blob/ renders markdown nicely in browser; /raw/ would serve plain text.
+    url = f"https://github.com/{owner}/{repo}/blob/{branch}/{doc}"
+
+    file_path = repo_root / doc
+    exists = file_path.is_file()
+
+    _emit({
+        "ok": True,
+        "url": url,
+        "exists": exists,
+        "branch": branch,
+        "host": "github",
+        "owner": owner,
+        "repo": repo,
+        "docPath": doc,
+    })
+    return 0
+
+
 def cmd_emit_jira_code(args: argparse.Namespace) -> int:
     """Print the shareable backend.jira block as compact JSON.
 
@@ -2247,6 +2359,14 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--no-user-lookup", action="store_true",
                    help="skip /user/search resolution for non-'me' assignees")
     s.set_defaults(func=cmd_parse_transitions_dsl)
+
+    s = sub.add_parser("resolve-doc-link")
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument("--doc-path", required=True,
+                   help="repo-relative path, e.g. 'epic/AGENT-001-foo.md'")
+    s.add_argument("--branch",
+                   help="git branch for the URL; defaults to current branch then 'main'")
+    s.set_defaults(func=cmd_resolve_doc_link)
 
     s = sub.add_parser("emit-jira-code")
     s.add_argument("--kanban-path", required=True)

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13; do  # phase 8-13: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do  # 8-14: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase14.py
+++ b/plugins/kanban/scripts/test_phase14.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Phase 14 regression checks for kanban v0.3.7 — resolve-doc-link.
+
+The cross-plugin (kanban × mentor) helper that turns a repo-relative
+doc path into a clickable GitHub URL for Jira comments.
+
+Cases:
+  (a) _parse_github_origin: HTTPS form (with / without .git suffix)
+  (b) _parse_github_origin: SSH form (git@github.com:owner/repo.git)
+  (c) _parse_github_origin: non-GitHub returns None
+  (d) _parse_github_origin: malformed returns None
+  (e) cmd_resolve_doc_link: real git repo with GitHub origin → returns
+       /blob/<branch>/<path> URL
+  (f) cmd_resolve_doc_link: doc-path leading slashes / ./ stripped
+  (g) cmd_resolve_doc_link: doc-path with `..` rejected
+  (h) cmd_resolve_doc_link: file existence reflected in `exists` flag
+  (i) cmd_resolve_doc_link: --branch override beats current branch
+  (j) cmd_resolve_doc_link: missing origin → ok=false with clear error
+  (k) cmd_resolve_doc_link: non-GitHub origin → ok=false, host=other
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+# --- _parse_github_origin ----------------------------------------------
+
+
+def test_parse_origin_https_variants():
+    fn = _jira_setup._parse_github_origin
+    assert fn("https://github.com/owner/repo") == ("owner", "repo")
+    assert fn("https://github.com/owner/repo.git") == ("owner", "repo")
+    assert fn("https://github.com/owner/repo/") == ("owner", "repo")
+    assert fn("http://github.com/owner/repo.git") == ("owner", "repo")
+
+
+def test_parse_origin_ssh_variants():
+    fn = _jira_setup._parse_github_origin
+    assert fn("git@github.com:owner/repo.git") == ("owner", "repo")
+    assert fn("git@github.com:owner/repo") == ("owner", "repo")
+
+
+def test_parse_origin_non_github():
+    fn = _jira_setup._parse_github_origin
+    assert fn("https://gitlab.com/owner/repo.git") is None
+    assert fn("git@bitbucket.org:owner/repo.git") is None
+    assert fn("https://internal.dev/owner/repo") is None
+
+
+def test_parse_origin_malformed():
+    fn = _jira_setup._parse_github_origin
+    assert fn("") is None
+    assert fn("not-a-url") is None
+    assert fn("https://github.com") is None
+    assert fn(None) is None  # type: ignore[arg-type]
+
+
+# --- cmd_resolve_doc_link integration ----------------------------------
+
+
+def _init_repo_with_origin(td: pathlib.Path, origin: str) -> pathlib.Path:
+    """Create an empty git repo at `td` and set its origin URL."""
+    subprocess.run(["git", "init", "-q", "-b", "main", str(td)], check=True)
+    subprocess.run(
+        ["git", "-C", str(td), "remote", "add", "origin", origin], check=True
+    )
+    # Configure user so commits work (we only test pre-commit branches but
+    # branch detection needs at least one commit on some git versions)
+    subprocess.run(
+        ["git", "-C", str(td), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(td), "config", "user.name", "test"], check=True
+    )
+    # Empty initial commit so `branch --show-current` returns 'main'
+    subprocess.run(
+        ["git", "-C", str(td), "commit", "--allow-empty", "-m", "init", "-q"],
+        check=True,
+    )
+    return td
+
+
+def _seed_kanban(repo: pathlib.Path) -> pathlib.Path:
+    p = repo / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {"projectKey": "AGENT"}},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+def test_resolve_happy_path():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://github.com/kirinchen/claude-workbench.git")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/AGENT-001-foo.md"
+            branch = None
+
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc == 0
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["host"] == "github"
+        assert j["owner"] == "kirinchen"
+        assert j["repo"] == "claude-workbench"
+        assert j["branch"] == "main"
+        assert j["url"] == (
+            "https://github.com/kirinchen/claude-workbench/blob/main/"
+            "epic/AGENT-001-foo.md"
+        )
+        assert j["exists"] is False  # we didn't create the file
+
+
+def test_resolve_strips_leading_slashes():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "git@github.com:owner/repo.git")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "/epic/X.md"  # leading slash stripped
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc == 0
+        j = json.loads(out)
+        assert j["url"].endswith("/blob/main/epic/X.md")
+
+        class B(A):
+            doc_path = "./epic/X.md"  # ./ also stripped
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, B())
+        j = json.loads(out)
+        assert j["url"].endswith("/blob/main/epic/X.md")
+
+
+def test_resolve_rejects_traversal():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://github.com/owner/repo")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/../../../etc/passwd"
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc != 0
+        j = json.loads(out)
+        assert j["ok"] is False
+
+
+def test_resolve_exists_flag_reflects_filesystem():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://github.com/owner/repo.git")
+        kp = _seed_kanban(repo)
+        # Create the doc file
+        (repo / "epic").mkdir()
+        (repo / "epic" / "real.md").write_text("# real")
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/real.md"
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        j = json.loads(out)
+        assert j["exists"] is True
+
+        class B(A):
+            doc_path = "epic/missing.md"
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, B())
+        j = json.loads(out)
+        assert j["exists"] is False
+
+
+def test_resolve_branch_override():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://github.com/owner/repo")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/X.md"
+            branch = "release/v2"
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        j = json.loads(out)
+        assert j["branch"] == "release/v2"
+        assert "/blob/release/v2/epic/X.md" in j["url"]
+
+
+def test_resolve_no_origin():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        # Initialise but don't add an origin
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/X.md"
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc != 0
+        j = json.loads(out)
+        assert j["ok"] is False
+        assert "git origin" in j["error"].lower()
+
+
+def test_resolve_non_github():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://gitlab.com/owner/repo.git")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = "epic/X.md"
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc != 0
+        j = json.loads(out)
+        assert j["ok"] is False
+        assert j["host"] == "other"
+        assert "github.com" in j["error"]
+
+
+def test_resolve_empty_doc_path():
+    with tempfile.TemporaryDirectory() as td:
+        repo = pathlib.Path(td)
+        _init_repo_with_origin(repo, "https://github.com/owner/repo")
+        kp = _seed_kanban(repo)
+
+        class A:
+            kanban_path = str(kp)
+            doc_path = ""
+            branch = None
+        rc, out = _capture(_jira_setup.cmd_resolve_doc_link, A())
+        assert rc != 0
+
+
+def main() -> int:
+    cases = [
+        ("parse_origin_https_variants", test_parse_origin_https_variants),
+        ("parse_origin_ssh_variants", test_parse_origin_ssh_variants),
+        ("parse_origin_non_github", test_parse_origin_non_github),
+        ("parse_origin_malformed", test_parse_origin_malformed),
+        ("resolve_happy_path", test_resolve_happy_path),
+        ("resolve_strips_leading_slashes", test_resolve_strips_leading_slashes),
+        ("resolve_rejects_traversal", test_resolve_rejects_traversal),
+        ("resolve_exists_flag_reflects_filesystem",
+         test_resolve_exists_flag_reflects_filesystem),
+        ("resolve_branch_override", test_resolve_branch_override),
+        ("resolve_no_origin", test_resolve_no_origin),
+        ("resolve_non_github", test_resolve_non_github),
+        ("resolve_empty_doc_path", test_resolve_empty_doc_path),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase14: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/skills/kanban-jira-agent/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-agent/SKILL.md
@@ -96,6 +96,39 @@ Treat each mention as a directive. Process:
 - DO NOT push your own card to Done. The plugin refuses (anti-self-approve);
   the Jira workflow may also reject it. This is intentional.
 
+## Linking to repo docs
+
+When a Jira comment references a file in this repo (mentor's Epic /
+Sprint / Issue / ADR docs in particular, but also any source file the
+human might want to read), **always resolve to a clickable GitHub URL
+before posting**. Don't write `see epic/AGENT-001-foo.md` — Kirin
+can't click that and has to navigate GitHub manually.
+
+Resolve via:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py resolve-doc-link \
+  --kanban-path '<kanban.json>' \
+  --doc-path 'epic/AGENT-001-foo.md'
+```
+
+Returns `{ok, url, exists, branch, host, ...}`. Use the `url` field
+verbatim in the comment body.
+
+Behaviour:
+
+| Response | What to do |
+|---|---|
+| `{ok: true, url, exists: true}` | use the URL in your comment |
+| `{ok: true, url, exists: false}` | use the URL anyway (file may be uncommitted); add a parenthetical "(uncommitted on `<branch>`)" so the reader knows |
+| `{ok: false, host: "other", ...}` | non-GitHub origin (GitLab / Bitbucket). Fall back to the relative path and add a one-line explanation: "see `epic/AGENT-001-foo.md` (clickable link not supported on this repo's host)" |
+| `{ok: false, error: "no git origin", ...}` | repo isn't cloned from a remote. Fall back to relative path; mention the constraint once. |
+
+**Branch handling**: the helper defaults to the current git branch.
+For comments destined to outlive a feature branch (e.g. on long-lived
+parent cards), pass `--branch main` explicitly so the link still works
+after the branch is deleted.
+
 ## Forbidden
 
 - Direct Jira API calls (curl, fetch, any HTTP client)


### PR DESCRIPTION
First piece of the kanban × mentor integration line from SPEC §13.

## Problem

When the agent posts `please see epic/AGENT-001-foo.md` to a Jira card, the human reading the comment can't click anywhere — they have to switch to GitHub, find the file, navigate. Friction adds up across many cards.

## What this PR does

New helper `resolve-doc-link` turns a repo-relative path into a clickable GitHub `/blob/` URL.

```bash
python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py resolve-doc-link \
  --kanban-path '<kanban.json>' \
  --doc-path 'epic/AGENT-001-foo.md'
```

Returns:

```json
{
  "ok": true,
  "url": "https://github.com/kirinchen/claude-workbench/blob/main/epic/AGENT-001-foo.md",
  "exists": true,
  "branch": "main",
  "host": "github",
  "owner": "kirinchen", "repo": "claude-workbench",
  "docPath": "epic/AGENT-001-foo.md"
}
```

The skill (`kanban-jira-agent`) instructs the LLM to call this before posting any comment that references a repo file.

## What this PR does NOT do

**Automatic comment-body rewriting** — the LLM decides when to use a URL vs a relative path. Plugin provides primitive, LLM decides. Same philosophy as 0.3.5's mention-reply work. Auto-rewriting would make debugging hard ("why is my comment different from what I wrote?") and would lose the LLM's contextual judgement (sometimes you genuinely want a relative path, e.g. inline in a code review).

## Behaviour matrix

| Scenario | Response | LLM action |
|---|---|---|
| GitHub origin + file exists locally | `{ok: true, url, exists: true}` | Use URL in comment |
| GitHub origin + file uncommitted | `{ok: true, url, exists: false}` | Use URL anyway, add "(uncommitted on `<branch>`)" annotation |
| GitLab / Bitbucket / internal | `{ok: false, host: "other"}` | Fall back to relative path with one-line explanation |
| No git origin | `{ok: false, error: "no git origin"}` | Fall back to relative path |
| `..` in doc path | `{ok: false}` | Refuse — path must be repo-relative |

## Implementation details

- **Origin parsers** support both HTTPS (`https://github.com/owner/repo[.git]`) and SSH (`git@github.com:owner/repo[.git]`) forms.
- **Branch resolution**: explicit `--branch` > current git branch > `main` fallback.
- **Path sanitisation**: leading `/` and `./` stripped; `..` segments rejected (defence-in-depth — GitHub itself would 404 those).
- **Local file check**: `exists` flag is informational. The URL is still returned even when the file is missing locally so the agent can reference uncommitted-but-soon-to-land files.

## Why GitHub-only in v1

GitLab and Bitbucket use different `/blob/` URL formats:
- GitHub: `https://github.com/<owner>/<repo>/blob/<branch>/<path>`
- GitLab: `https://gitlab.com/<owner>/<repo>/-/blob/<branch>/<path>` (extra `/-/`)
- Bitbucket: `https://bitbucket.org/<owner>/<repo>/src/<branch>/<path>` (`src` not `blob`)

Adding them all upfront is fine, but each has its own edge cases (self-hosted GitLab on custom hosts, BitBucket Server vs Cloud, etc.). The `host: "other"` fallback gives clean degradation today; new hosts can land when there's a real user request.

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 14 phase suites, **148 tests**, all green
- [x] `_parse_github_origin`: HTTPS + `.git` suffix variants, SSH form, non-GitHub origins, malformed input
- [x] Real `git init` + `git remote add origin <url>` integration tests for happy path / no origin / non-GitHub
- [x] Doc-path leading slash + `./` stripped; `..` rejected
- [x] Branch override beats current branch
- [x] `exists` reflects filesystem state
- [ ] After merge: real `/kanban:reply` on a DMI card with a `resolve-doc-link`-constructed URL — verify Jira renders it as a clickable link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
