### PR TITLE
docs(kanban): multi-machine / multi-repo setup cheatsheet

### DIFF
--- a/kanban_quickstart.md
+++ b/kanban_quickstart.md
@@ -196,6 +196,53 @@ full v0.2 design.
 
 ---
 
+## 8b. Multi-machine / multi-repo setup (kanban v0.3+)
+
+The biggest source of friction is "I set this up on machine A — does
+machine B / repo B / teammate C have to redo all five steps?"
+
+Setup splits into three layers, each with a different lifecycle:
+
+| Layer | What | When you redo it |
+|---|---|---|
+| **Per-board** (shareable) | `transitions`, AP custom-field id, board metadata, `conventions` notes | Once. Then `/kanban:showjira-code` and any teammate / repo can `/kanban:initjira-by-code` paste the JSON to inherit it. |
+| **Per-machine** | Jira credentials in `~/.claude-workbench/.env` (base URL, agent email, API token) | Once per machine. After that all repos on that machine share the credentials. |
+| **Per-repo** | This repo's AP in `.claude/kanban-agent.json` | Once per repo. Each repo picks its own AP from the live Jira options list. |
+
+### Cheatsheet
+
+| Scenario | What you run on the new side |
+|---|---|
+| **All-new machine + all-new repo** | `/kanban:init` → `/kanban:initjira-by-code` (does credentials + paste code + assign AP in one flow) |
+| **Same machine, new repo** | `/kanban:init` → `/kanban:initjira-by-code` (credentials auto-skipped — already on this machine; only paste code + assign AP run interactively) |
+| **Existing repo already in Jira mode** | Nothing — already set up. `/kanban:whoami` to verify. |
+
+### How it works
+
+On the source machine:
+
+```
+> /kanban:showjira-code
+```
+
+prints a JSON code (`kanban-jira-code/2`) containing the per-board config — `transitions`, `ap.fieldId`, `boardId`, `projectKey`, `conventions`. Tokens are NOT in the code; they stay per-machine in `~/.claude-workbench/.env`.
+
+On any other machine / repo:
+
+```
+> /kanban:init                  # scaffold kanban.json (local mode)
+> /kanban:initjira-by-code      # paste the JSON; runs credentials (if needed) + assign AP
+```
+
+The receiver asks for Jira credentials only the first time on a given machine. If `conventions.notes` is non-empty, the receiver also has to type `I have read these` to acknowledge before init completes (the friction is intentional — see issue #10).
+
+Versions to be aware of:
+- `kanban-jira-code/1` (v0.3.0+) — transitions + AP field
+- `kanban-jira-code/2` (v0.3.4+) — adds `conventions` (notes + `blockedRequiresLink`)
+- v0.3.4+ receivers accept both schemas; v0.3.4 senders default to /2
+
+---
+
 ## 9. Uninstall
 
 Inside Claude:

--- a/kanban_quickstart_zhtw.md
+++ b/kanban_quickstart_zhtw.md
@@ -187,6 +187,52 @@ init 完之後：
 
 ---
 
+## 8b. 多機器 / 多 repo setup（kanban v0.3+）
+
+最常見的卡關：「我在 A 機器設好了——B 機器 / B repo / 同事 C 是不是要把五步 init 全跑一次？」
+
+Setup 拆成**三層**，每層有自己的生命週期：
+
+| 層級 | 內容 | 何時要重跑 |
+|---|---|---|
+| **Per-board（可分享）** | `transitions`、AP custom field id、board metadata、`conventions` 規則 | **一次**。然後 `/kanban:showjira-code`，任何同事 / repo 用 `/kanban:initjira-by-code` 貼 JSON 就繼承 |
+| **Per-machine（每台必做）** | Jira 憑證（`~/.claude-workbench/.env`：base URL、agent email、API token） | 每台機器一次。之後該台所有 repo 共用 |
+| **Per-repo（每個 repo 必做）** | 這個 repo 用哪個 AP（`.claude/kanban-agent.json`） | 每個 repo 一次。各自從 Jira live options 挑 |
+
+### Cheatsheet
+
+| 情境 | 新 receiver 端要跑的 |
+|---|---|
+| **全新機器 + 全新 repo** | `/kanban:init` → `/kanban:initjira-by-code`（一個指令做完憑證 + 貼 code + 選 AP） |
+| **同機器 + 新 repo** | `/kanban:init` → `/kanban:initjira-by-code`（憑證自動跳過——本機已有；只剩貼 code + 選 AP 互動） |
+| **既有 repo 已是 jira mode** | 啥都不用——已 setup。`/kanban:whoami` 可驗證 |
+
+### 運作原理
+
+來源端：
+
+```
+> /kanban:showjira-code
+```
+
+印出 `kanban-jira-code/2` 格式 JSON，含 per-board 設定——`transitions`、`ap.fieldId`、`boardId`、`projectKey`、`conventions`。**Token 不在 code 內**——憑證永遠 per-machine 留在 `~/.claude-workbench/.env`。
+
+接收端（任何另一台機器 / 另一個 repo）：
+
+```
+> /kanban:init                  # scaffold kanban.json (local mode)
+> /kanban:initjira-by-code      # 貼 JSON；視情況跑憑證 + 選 AP
+```
+
+第一次在某台機器跑時會問憑證；同台第二個 repo 時自動跳過。如果 code 帶 `conventions.notes` 非空，接收端必須輸入 `I have read these` 才能完成 init（這個 friction 是刻意的——詳見 issue #10）。
+
+版本相容性：
+- `kanban-jira-code/1`（v0.3.0+）—— transitions + AP field
+- `kanban-jira-code/2`（v0.3.4+）—— 加上 `conventions`（notes + `blockedRequiresLink`）
+- v0.3.4+ 接收端兩種都收；v0.3.4 來源端預設輸出 /2
+
+---
+
 ## 9. 解除安裝
 
 在 Claude 裡：


### PR DESCRIPTION
Doc-only PR. No version bump, no plugin code change.

## Why

You've asked the same question across multiple PRs (#5, #11, etc.):

> 如果我某台環境已經 setup kanban jira done, 另一台機器還要再 init jira 一次還是不用?

The answer was scattered across feature commit messages but never landed in the canonical onboarding docs. This adds it as **§8b** in both quickstart files.

## What's added

A three-layer model + cheatsheet showing what's shareable across machines / repos and what each side redoes:

| Layer | What | When you redo |
|---|---|---|
| **Per-board** (shareable) | `transitions`, AP field id, board metadata, `conventions` | Once → `/kanban:showjira-code` → teammates `/kanban:initjira-by-code` |
| **Per-machine** | Jira credentials in `~/.claude-workbench/.env` | Once per machine |
| **Per-repo** | This repo's AP in `.claude/kanban-agent.json` | Once per repo |

Plus a 3-row scenario cheatsheet, a "how it works" walkthrough, and a schema-version compat note (`kanban-jira-code/1` vs `/2`).

## Files

- `kanban_quickstart.md` — English
- `kanban_quickstart_zhtw.md` — Traditional Chinese

Both root-level (not under `plugins/`), so the pre-commit version-bump hook doesn't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
