### PR TITLE
fix(kanban): 0.3.8 — import-tasks fully populates AP/assignee/status (#16, #18)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,57 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (import-tasks completeness)
+
+### Fixed
+- **kanban 0.3.8** — `import-tasks` now produces fully-functional Jira
+  cards instead of orphaned ghosts. Closes #16 + #18. Two related bugs
+  surfaced together while migrating 22 local tasks to a real Jira board:
+
+  - **(#16)** Imported issues had `customfield_<APFieldId> = null`,
+    `assignee = null`, and stayed in the project's default initial
+    status (e.g. `Backlog`) — so `/kanban:status` and `/kanban:next`
+    couldn't see them. The migration looked successful but the cards
+    were invisible to the plugin.
+  - **(#18)** Local `P0..P3` priorities were passed verbatim, but
+    Jira's default priority scheme uses `Highest/High/Medium/Low/Lowest`.
+    Every issue failed individually with HTTP 400 before the user saw
+    any signal that the whole batch would fail.
+
+  Fix:
+
+  - **Pre-flight priority validation** via `client.get_priorities()`
+    (`GET /rest/api/3/priority`). Auto-map `P0..P4 → Highest..Lowest`
+    when both ends are valid in the project's scheme. Fail-fast with
+    one actionable error listing unmappable values + valid scheme,
+    BEFORE any issue gets created.
+  - **Post-create AP + assignee** via `driver.assign(AgentRef(ap=repo_ap))`
+    — sets the AP custom field AND the agent assignee account in one
+    API call (existing helper, already does both).
+  - **Post-create transition to TODO** via
+    `driver.transition(key, "TODO")` — moves the new card out of the
+    project default status into the canonical TODO mapped by DSL.
+  - **BLOCKED-origin audit comment** — when a local task was BLOCKED,
+    the imported card lands in TODO (unified target) but a system
+    comment preserves the original `blocked_reason` so context isn't
+    lost.
+  - **Per-task best-effort** — assign / transition failures don't
+    abort the whole batch. Each result entry surfaces `apSet` /
+    `apError` / `transitioned` / `transitionError` flags so the user
+    knows exactly which post-create steps succeeded.
+  - **Dry-run** still skips all writes; pre-flight still runs and
+    surfaces resolved priorities so the user can preview the mapping.
+  - **Pass-through** when credentials are missing — the priority
+    pre-flight is skipped silently and the existing create-time-error
+    path is preserved (so cli use without `~/.claude-workbench/.env`
+    behaves as before).
+  - `test_phase15.py`: 13 new mocked cases covering `_resolve_priority`
+    in all 5 modes, pre-flight rejection (no creates), auto-map
+    P1→High end-to-end, post-create assign + transition, BLOCKED
+    audit comment, per-task best-effort on failures, dry-run, skip
+    logic, no-credentials pass-through. All 15 phase suites
+    (161 tests) green.
+
 ## 2026-05-01 (clickable doc links)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -292,6 +292,16 @@ class JiraClient:
             body={"options": [{"value": value}]},
         )
 
+    def get_priorities(self) -> list[dict[str, Any]]:
+        """GET /rest/api/3/priority — list of `{id, name, description}` rows.
+
+        Used by import-tasks pre-flight: validate local priority strings
+        against the actual project / scheme before creating any issues.
+        Different Atlassian sites may have customised priority schemes,
+        so we don't bake a fixed list into the plugin.
+        """
+        return self._request("GET", "/rest/api/3/priority")
+
     def update_issue(self, key: str, fields: dict[str, Any]) -> None:
         """PUT /issue/{key} with `fields` payload. Used by AgentRef assign
         to write the AP custom field directly.

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -2108,12 +2108,65 @@ def cmd_mcp_conflict_scan(args: argparse.Namespace) -> int:
     return 0
 
 
+# P0..P4 → Atlassian default-scheme names. Closes #18: most local-mode
+# users use the industry-standard P0..P3 convention, while Jira's default
+# priority scheme is named Highest/High/Medium/Low/Lowest.
+_PRIORITY_AUTOMAP: dict[str, str] = {
+    "P0": "Highest",
+    "P1": "High",
+    "P2": "Medium",
+    "P3": "Low",
+    "P4": "Lowest",
+}
+
+
+def _resolve_priority(
+    p: str | None, valid_names: set[str]
+) -> str | None | bool:
+    """Resolve a local priority string against a set of valid Jira names.
+
+    Returns:
+        - the priority name to use (str)
+        - None if `p` was None (no priority set on the task)
+        - False if `p` could not be mapped to a valid Jira name
+          (caller should treat as unmappable and fail-fast)
+
+    When `valid_names` is empty (e.g., no credentials), the input
+    passes through unchanged — the caller has no way to validate, so
+    the error surfaces at create time as before.
+    """
+    if p is None:
+        return None
+    if not valid_names:
+        return p  # pre-flight unavailable; pass through
+    if p in valid_names:
+        return p
+    mapped = _PRIORITY_AUTOMAP.get(p)
+    if mapped and mapped in valid_names:
+        return mapped
+    return False
+
+
 def cmd_import_tasks(args: argparse.Namespace) -> int:
     """Migrate local kanban.json#tasks into Jira issues. Idempotent.
 
     Skip strategy:
       - tasks already in `.claude/.migration-map.json` → skip (mapped)
       - column in {DONE, CANCELLED} and not --include-done → skip
+
+    Per-task work (when not --dry-run):
+      1. driver.create_task(TaskInput) — base issue
+      2. driver.assign(AgentRef(ap=repo_ap)) — sets AP custom field
+         + agent assignee so /kanban:next can see the imported card
+      3. driver.transition(key, "TODO") — moves out of project default
+         status (typically Backlog) into the canonical TODO status
+      4. For BLOCKED-origin tasks, post audit comment preserving the
+         original `blocked_reason` (the imported card lands in TODO
+         per the unified target; the blocked context isn't lost)
+
+    Steps 2-4 are best-effort — failure is recorded per-task in
+    skippedDetail/imported entries (apSet, transitioned flags) but
+    doesn't abort the whole batch. Closes #16.
     """
     p = Path(args.kanban_path)
     if not p.exists():
@@ -2138,10 +2191,49 @@ def cmd_import_tasks(args: argparse.Namespace) -> int:
     else:
         mapping = {}
 
+    # --- Pre-flight: priority validation (closes #18) -----------------
+    # Fetch live priority list once, fail-fast if any task has an
+    # unmappable priority — better than 22 individual create-time 400s.
+    valid_priority_names: set[str] = set()
+    pre_flight_client = _client_from_env_or_none()
+    if pre_flight_client is not None:
+        try:
+            ps = pre_flight_client.get_priorities() or []
+            valid_priority_names = {
+                str(x.get("name")) for x in ps if isinstance(x, dict) and x.get("name")
+            }
+        except (JiraError, Exception):  # noqa: BLE001
+            valid_priority_names = set()
+
+    unmappable: list[dict[str, Any]] = []
+    resolved: dict[str, str | None] = {}
+    for t in legacy_tasks:
+        local_id = t.get("id")
+        if not local_id or local_id in mapping:
+            continue
+        col = t.get("column")
+        if col in {"DONE", "CANCELLED"} and not args.include_done:
+            continue
+        result = _resolve_priority(t.get("priority"), valid_priority_names)
+        if result is False:
+            unmappable.append({"id": local_id, "priority": t.get("priority")})
+        else:
+            resolved[local_id] = result
+
+    if unmappable and valid_priority_names:
+        return _fail(
+            f"unmappable priorities (auto-map covers P0..P4 → Highest/High/Medium/Low/Lowest): "
+            f"{[u['priority'] for u in unmappable[:5]]}{' …' if len(unmappable) > 5 else ''}; "
+            f"valid Jira priorities = {sorted(valid_priority_names)}",
+            unmappable=unmappable,
+            validPriorities=sorted(valid_priority_names),
+        )
+
     from drivers import get_driver
-    from drivers.base import TaskInput
+    from drivers.base import AgentRef, CommentKind, TaskInput
 
     driver = get_driver(data, p.parent)
+    repo_ap = _read_repo_ap(p)
 
     imported: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
@@ -2150,30 +2242,82 @@ def cmd_import_tasks(args: argparse.Namespace) -> int:
         if not local_id:
             continue
         if local_id in mapping:
-            skipped.append({"id": local_id, "reason": "already-mapped", "key": mapping[local_id]})
+            skipped.append({"id": local_id, "reason": "already-mapped",
+                            "key": mapping[local_id]})
             continue
         col = t.get("column")
         if col in {"DONE", "CANCELLED"} and not args.include_done:
             skipped.append({"id": local_id, "reason": f"closed-{col.lower()}"})
             continue
         if args.dry_run:
-            imported.append({"id": local_id, "would_create": True})
+            imported.append({
+                "id": local_id, "would_create": True,
+                "resolvedPriority": resolved.get(local_id),
+                "originalColumn": col,
+            })
             continue
+
+        # 1. Create the base issue (resolved priority).
         try:
             new_task = driver.create_task(
                 TaskInput(
                     title=t.get("title") or local_id,
                     description=t.get("description") or "",
-                    priority=t.get("priority"),
+                    priority=resolved.get(local_id),
                     tags=list(t.get("tags") or []) + ["migrated-from-local"],
                     category=t.get("category"),
                 )
             )
         except Exception as e:  # noqa: BLE001
-            skipped.append({"id": local_id, "reason": f"error: {type(e).__name__}: {e}"})
+            skipped.append({"id": local_id,
+                            "reason": f"create failed: {type(e).__name__}: {e}"})
             continue
+
+        # 2. Set AP custom field + agent assignee (best-effort).
+        ap_set = False
+        ap_error: str | None = None
+        if repo_ap:
+            try:
+                driver.assign(new_task.id, AgentRef(ap=repo_ap))
+                ap_set = True
+            except Exception as e:  # noqa: BLE001
+                ap_error = f"{type(e).__name__}: {e}"
+
+        # 3. Transition out of project-default status into canonical TODO
+        # (best-effort).
+        transitioned = False
+        transition_error: str | None = None
+        try:
+            driver.transition(new_task.id, "TODO")
+            transitioned = True
+        except Exception as e:  # noqa: BLE001
+            transition_error = f"{type(e).__name__}: {e}"
+
+        # 4. BLOCKED-origin: preserve the reason via audit comment so the
+        # imported card (now in TODO) doesn't lose context.
+        if col == "BLOCKED":
+            reason = (t.get("custom") or {}).get("blocked_reason") or "(no reason recorded)"
+            try:
+                driver.post_comment(
+                    new_task.id,
+                    f"Originally BLOCKED in local kanban: {reason}",
+                    kind=CommentKind.SYSTEM,
+                )
+            except Exception:
+                pass  # audit-only; non-fatal
+
         mapping[local_id] = new_task.id
-        imported.append({"id": local_id, "key": new_task.id, "title": new_task.title})
+        imported.append({
+            "id": local_id,
+            "key": new_task.id,
+            "title": new_task.title,
+            "resolvedPriority": resolved.get(local_id),
+            "originalColumn": col,
+            "apSet": ap_set,
+            "apError": ap_error,
+            "transitioned": transitioned,
+            "transitionError": transition_error,
+        })
 
     if not args.dry_run:
         tmp = map_path.with_suffix(".json.tmp")
@@ -2189,6 +2333,7 @@ def cmd_import_tasks(args: argparse.Namespace) -> int:
             "tasks": imported,
             "skippedDetail": skipped,
             "mapPath": str(map_path),
+            "preFlightPriorities": sorted(valid_priority_names),
         }
     )
     return 0

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do  # 8-14: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do  # 8-15: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import-completeness (#16+#18)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase15.py
+++ b/plugins/kanban/scripts/test_phase15.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Phase 15 regression checks for kanban v0.3.8 — import-tasks completeness.
+
+Closes #16 (AP/assignee/status not populated) and #18 (priority pre-flight
++ auto-map).
+
+Cases:
+  (a) _resolve_priority: identity for already-valid; auto-map P0..P4 to
+      Highest..Lowest when both are in valid set; False for unmappable;
+      None for None input; passthrough when valid set is empty
+  (b) cmd_import_tasks pre-flight: rejects BEFORE create when any task
+      has unmappable priority (no driver.create_task calls)
+  (c) cmd_import_tasks: auto-map P0..P4 reaches driver.create_task
+      with the correct Atlassian-default priority name
+  (d) cmd_import_tasks: post-create — driver.assign(AgentRef(ap=repo_ap))
+      is called for each created issue
+  (e) cmd_import_tasks: post-create — driver.transition(key, "TODO") is
+      called for each created issue
+  (f) cmd_import_tasks: BLOCKED-origin tasks get an audit comment with
+      the original blocked_reason
+  (g) cmd_import_tasks: per-task best-effort — assign failure surfaces
+      apSet=false but doesn't abort; transition failure surfaces
+      transitioned=false but doesn't abort
+  (h) cmd_import_tasks: dry-run skips ALL post-create steps + writes no
+      mapping file
+  (i) cmd_import_tasks: existing skip logic preserved (already-mapped,
+      DONE/CANCELLED without --include-done)
+  (j) cmd_import_tasks: pass-through priority when no credentials
+      (valid_priority_names empty)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from drivers.base import AgentRef, Comment, CommentKind, Task, TaskInput  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+# --- _resolve_priority --------------------------------------------------
+
+
+def test_resolve_priority_already_valid():
+    fn = _jira_setup._resolve_priority
+    valid = {"High", "Medium", "Low"}
+    assert fn("High", valid) == "High"
+    assert fn("Medium", valid) == "Medium"
+
+
+def test_resolve_priority_automap():
+    fn = _jira_setup._resolve_priority
+    valid = {"Highest", "High", "Medium", "Low", "Lowest"}
+    assert fn("P0", valid) == "Highest"
+    assert fn("P1", valid) == "High"
+    assert fn("P2", valid) == "Medium"
+    assert fn("P3", valid) == "Low"
+    assert fn("P4", valid) == "Lowest"
+
+
+def test_resolve_priority_unmappable_returns_false():
+    fn = _jira_setup._resolve_priority
+    valid = {"Highest", "High", "Medium", "Low", "Lowest"}
+    assert fn("Critical", valid) is False
+    assert fn("P99", valid) is False
+
+
+def test_resolve_priority_none_input():
+    fn = _jira_setup._resolve_priority
+    valid = {"High", "Medium", "Low"}
+    assert fn(None, valid) is None
+
+
+def test_resolve_priority_empty_valid_passes_through():
+    """When pre-flight is unavailable, the helper passes the input
+    through unchanged so the existing create-time-error path still works.
+    """
+    fn = _jira_setup._resolve_priority
+    assert fn("P1", set()) == "P1"
+    assert fn("Anything", set()) == "Anything"
+    assert fn(None, set()) is None
+
+
+# --- cmd_import_tasks integration --------------------------------------
+
+
+def _seed_kanban(td, tasks=()):
+    p = pathlib.Path(td) / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-bot",
+            "transitions": {
+                "TODO": {"status": "Selected for Development"},
+                "DOING": {"status": "In Progress"},
+                "BLOCKED": {"status": "In Progress",
+                            "addLabels": ["kanban:blocked"]},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0", "P1", "P2", "P3"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": list(tasks),
+    }))
+    (p.parent / ".claude").mkdir()
+    (p.parent / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": "agent-fin"}) + "\n"
+    )
+    return p
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+class _StubDriver:
+    """Records every call so tests can assert on order + arguments."""
+    name = "jira"
+
+    def __init__(self, *, fail_assign_for=None, fail_transition_for=None):
+        self.created: list[TaskInput] = []
+        self.assigned: list[tuple[str, AgentRef]] = []
+        self.transitions: list[tuple[str, str]] = []
+        self.comments: list[tuple[str, str, CommentKind]] = []
+        self._key_counter = 100
+        self._fail_assign_for = set(fail_assign_for or [])
+        self._fail_transition_for = set(fail_transition_for or [])
+
+    def _next_key(self) -> str:
+        self._key_counter += 1
+        return f"AGENT-{self._key_counter}"
+
+    def create_task(self, task: TaskInput) -> Task:
+        self.created.append(task)
+        key = self._next_key()
+        return Task(
+            id=key, title=task.title, column="TODO",
+            priority=task.priority or "P2", created="x", updated="y",
+        )
+
+    def assign(self, key: str, member) -> Task:
+        if key in self._fail_assign_for:
+            raise RuntimeError(f"assign failed for {key}")
+        self.assigned.append((key, member))
+        return Task(id=key, title="x", column="TODO", priority="P1",
+                    created="x", updated="y")
+
+    def transition(self, key: str, to_column: str, **kwargs) -> Task:
+        if key in self._fail_transition_for:
+            raise RuntimeError(f"transition failed for {key}")
+        self.transitions.append((key, to_column))
+        return Task(id=key, title="x", column=to_column, priority="P1",
+                    created="x", updated="y")
+
+    def post_comment(self, key: str, body: str, kind: CommentKind = CommentKind.COMMENT,
+                     **kwargs) -> Comment:
+        self.comments.append((key, body, kind))
+        return Comment(author="agent", ts="x", text=body, kind=kind)
+
+
+def _patch_priority_client(valid_names: set[str] | None):
+    """Replace _client_from_env_or_none so the pre-flight uses our fake."""
+    if valid_names is None:
+        # Simulate "no credentials" — pre-flight returns None client
+        client = None
+    else:
+        class _C:
+            def get_priorities(self):
+                return [{"id": str(i), "name": n} for i, n in enumerate(valid_names)]
+        client = _C()
+    orig = _jira_setup._client_from_env_or_none
+    _jira_setup._client_from_env_or_none = lambda: client
+    return orig
+
+
+def _restore_priority_client(orig):
+    _jira_setup._client_from_env_or_none = orig
+
+
+def _patch_driver(stub):
+    import drivers as _drv_mod
+    orig = _drv_mod.get_driver
+    _drv_mod.get_driver = lambda data, root: stub
+    return orig
+
+
+def _restore_driver(orig):
+    import drivers as _drv_mod
+    _drv_mod.get_driver = orig
+
+
+def test_pre_flight_rejects_unmappable_before_creating_anything():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "ok", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+            {"id": "task-002", "title": "bad", "column": "TODO",
+             "priority": "Critical", "created": "x", "updated": "y"},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client({"Highest", "High", "Medium", "Low", "Lowest"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc != 0, out
+        j = json.loads(out)
+        assert j["ok"] is False
+        assert "unmappable priorities" in j["error"]
+        # Critically: NO driver.create_task calls should have happened
+        assert stub.created == []
+        # Map file should NOT exist (no successful creates)
+        assert not (kp.parent / ".claude" / ".migration-map.json").exists()
+
+
+def test_priority_automap_p1_to_high():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "todo", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+            {"id": "task-002", "title": "doing", "column": "DOING",
+             "priority": "P0", "created": "x", "updated": "y",
+             "started": "x"},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client({"Highest", "High", "Medium", "Low", "Lowest"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0, out
+        j = json.loads(out)
+        assert j["imported"] == 2
+        # Verify resolved priorities reached create_task
+        priorities_used = [t.priority for t in stub.created]
+        assert "High" in priorities_used   # P1 → High
+        assert "Highest" in priorities_used  # P0 → Highest
+
+
+def test_post_create_assigns_ap_and_transitions_to_todo():
+    """The big one for #16: every imported card gets AP + transition."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "alpha", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+            {"id": "task-002", "title": "beta", "column": "DOING",
+             "priority": "P2", "created": "x", "updated": "y",
+             "started": "x"},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client({"High", "Medium"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0, out
+        j = json.loads(out)
+        assert j["imported"] == 2
+
+        # Both created cards got assign(AgentRef) called
+        assert len(stub.assigned) == 2
+        for key, member in stub.assigned:
+            assert member.kind == "agent"
+            assert member.ap == "agent-fin"
+
+        # Both created cards got transition(key, "TODO")
+        assert len(stub.transitions) == 2
+        for key, to in stub.transitions:
+            assert to == "TODO"
+
+        # All entries in tasks[] report apSet=true and transitioned=true
+        for entry in j["tasks"]:
+            assert entry["apSet"] is True
+            assert entry["transitioned"] is True
+            assert entry["apError"] is None
+            assert entry["transitionError"] is None
+
+
+def test_blocked_origin_gets_audit_comment():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "stuck", "column": "BLOCKED",
+             "priority": "P2", "created": "x", "updated": "y",
+             "custom": {"blocked_reason": "waiting on infra team"}},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client({"Medium"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0
+        # An audit comment should have been posted
+        assert len(stub.comments) == 1
+        key, body, kind = stub.comments[0]
+        assert "Originally BLOCKED" in body
+        assert "waiting on infra team" in body
+        assert kind == CommentKind.SYSTEM
+
+
+def test_per_task_best_effort_on_assign_failure():
+    """If assign fails for one card, the rest of the import continues
+    and the failed card has apSet=false in the result."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "a", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+            {"id": "task-002", "title": "b", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+        ])
+        # First created issue's assign fails. Stub's first key will be AGENT-101.
+        stub = _StubDriver(fail_assign_for={"AGENT-101"})
+        po = _patch_priority_client({"High"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0
+        j = json.loads(out)
+        assert j["imported"] == 2  # both still imported (best-effort)
+        # First entry shows apSet=false; second shows true
+        first, second = j["tasks"][0], j["tasks"][1]
+        assert first["apSet"] is False and first["apError"] is not None
+        assert second["apSet"] is True
+        # Both still got transition attempts
+        assert len(stub.transitions) == 2
+
+
+def test_dry_run_skips_all_writes():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "a", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client({"High"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = True; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0
+        # Zero side-effects on driver
+        assert stub.created == []
+        assert stub.assigned == []
+        assert stub.transitions == []
+        # No mapping file written
+        assert not (kp.parent / ".claude" / ".migration-map.json").exists()
+        # Result still surfaces the planned resolution
+        j = json.loads(out)
+        assert j["dryRun"] is True
+        assert j["tasks"][0]["resolvedPriority"] == "High"
+
+
+def test_skip_logic_preserved():
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "open", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+            {"id": "task-002", "title": "old", "column": "DONE",
+             "priority": "P1", "created": "x", "updated": "y",
+             "started": "x", "completed": "x"},
+        ])
+        # Pre-existing mapping for task-001 simulates a re-run
+        (kp.parent / ".claude" / ".migration-map.json").write_text(
+            json.dumps({"task-001": "AGENT-99"})
+        )
+        stub = _StubDriver()
+        po = _patch_priority_client({"High"})
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        assert rc == 0
+        j = json.loads(out)
+        # task-001 already-mapped, task-002 DONE-skipped → 0 created
+        assert j["imported"] == 0
+        assert j["skipped"] == 2
+        reasons = {s["reason"] for s in j["skippedDetail"]}
+        assert "already-mapped" in reasons
+        assert "closed-done" in reasons
+
+
+def test_passthrough_priority_when_no_credentials():
+    """No credentials = no pre-flight = passthrough. The legacy code-path
+    (create-time error if Jira rejects) is preserved."""
+    with tempfile.TemporaryDirectory() as td:
+        kp = _seed_kanban(td, tasks=[
+            {"id": "task-001", "title": "x", "column": "TODO",
+             "priority": "P1", "created": "x", "updated": "y"},
+        ])
+        stub = _StubDriver()
+        po = _patch_priority_client(None)  # no client
+        do = _patch_driver(stub)
+        try:
+            class A:
+                kanban_path = str(kp); dry_run = False; include_done = False
+            rc, out = _capture(_jira_setup.cmd_import_tasks, A())
+        finally:
+            _restore_priority_client(po)
+            _restore_driver(do)
+        # Stub doesn't reject — would succeed; verify P1 was passed through
+        assert rc == 0
+        assert stub.created[0].priority == "P1"
+
+
+def main() -> int:
+    cases = [
+        ("resolve_priority_already_valid", test_resolve_priority_already_valid),
+        ("resolve_priority_automap", test_resolve_priority_automap),
+        ("resolve_priority_unmappable_returns_false",
+         test_resolve_priority_unmappable_returns_false),
+        ("resolve_priority_none_input", test_resolve_priority_none_input),
+        ("resolve_priority_empty_valid_passes_through",
+         test_resolve_priority_empty_valid_passes_through),
+        ("pre_flight_rejects_unmappable_before_creating_anything",
+         test_pre_flight_rejects_unmappable_before_creating_anything),
+        ("priority_automap_p1_to_high", test_priority_automap_p1_to_high),
+        ("post_create_assigns_ap_and_transitions_to_todo",
+         test_post_create_assigns_ap_and_transitions_to_todo),
+        ("blocked_origin_gets_audit_comment",
+         test_blocked_origin_gets_audit_comment),
+        ("per_task_best_effort_on_assign_failure",
+         test_per_task_best_effort_on_assign_failure),
+        ("dry_run_skips_all_writes", test_dry_run_skips_all_writes),
+        ("skip_logic_preserved", test_skip_logic_preserved),
+        ("passthrough_priority_when_no_credentials",
+         test_passthrough_priority_when_no_credentials),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase15: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #16 + #18.

Two bugs surfaced together while migrating 22 local tasks to a real Jira board (BZK on `kirinchen.atlassian.net`). They're both about `import-tasks`, hence batched into one PR.

## Symptoms

**#16** — Imported Jira issues had `customfield_<APFieldId> = null`, `assignee = null`, and stayed in the project's default initial status (e.g. `Backlog`). The migration looked successful (`imported: 22, skipped: 0`) but the cards were invisible to `/kanban:status` and `/kanban:next` because the JQL filter `cf[<APFieldId>] = "<ap>"` excluded them.

**#18** — Local `P0..P3` priorities were passed verbatim to Jira, which uses `Highest/High/Medium/Low/Lowest` in the default scheme. Every issue failed individually with HTTP 400 — 22 identical errors before the user saw any signal that the whole batch would fail.

## Fix

| Change | File |
|---|---|
| `client.get_priorities()` (`GET /rest/api/3/priority`) | `lib/jira_client.py` |
| `_resolve_priority(p, valid_names)` — auto-maps `P0..P4 → Highest..Lowest` when the original isn't already valid; returns `False` for unmappable; passthrough for empty `valid_names` (no credentials) | `scripts/jira_setup.py` |
| `cmd_import_tasks` pre-flight: fetch valid priorities once, resolve every task, fail-fast with actionable error if any unmappable | `scripts/jira_setup.py` |
| `cmd_import_tasks` post-create per task: `driver.assign(AgentRef(ap=repo_ap))` sets AP custom field + agent assignee; `driver.transition(key, "TODO")` moves out of project default | `scripts/jira_setup.py` |
| BLOCKED-origin tasks: audit comment preserves `blocked_reason` since the card lands in TODO (unified target) | `scripts/jira_setup.py` |
| Per-task best-effort: assign / transition failures surface as `apSet=false` / `transitioned=false` flags in result entries; batch continues | `scripts/jira_setup.py` |
| 13 new mocked tests | `scripts/test_phase15.py` (new) |
| Bump `0.3.7 → 0.3.8`; CHANGELOG entry | versions / CHANGELOG |

## What survives unchanged

- Dry-run still skips all writes (and now surfaces `resolvedPriority` so the user can preview the auto-map).
- Existing skip logic preserved: already-mapped tasks (`.claude/.migration-map.json`), DONE/CANCELLED without `--include-done`.
- Passthrough when credentials missing — pre-flight is silently skipped, the create-time-error path is unchanged for `set-conventions`-only callers.

## Why TODO and not preserve column

Imported cards always land in TODO (canonical), regardless of original local column. Reasoning:
- DOING locally → after import, the human reviews and can `/kanban:next` to re-claim the cards they were actually working on
- BLOCKED locally → blocked_reason preserved via audit comment; if still blocked, user re-blocks via `/kanban:block <KEY> --reason "..." --blocked-by <KEY>`

This matches the user's stated expectation in #16: "be transitioned from default project status to the canonical TODO status defined by DSL". Loss of "I was actively doing this" state is recovered explicitly via `/kanban:next` post-import.

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 15 phase suites, **161 tests**, all green
- [x] `_resolve_priority`: 5 modes (already-valid / automap / unmappable / None / empty-valid)
- [x] Pre-flight rejects unmappable WITHOUT creating any issues (zero `driver.create_task` calls)
- [x] Auto-map P1→High end-to-end with verifiable `priority` field reaching create_task
- [x] Post-create AP + transition: every imported card gets both calls
- [x] BLOCKED-origin: audit comment with original reason
- [x] Per-task best-effort: assign failure on one card, the other still imports + transitions
- [x] Dry-run: zero side effects on driver, no map file written
- [x] Skip logic: already-mapped + DONE-skipped both reported in skippedDetail
- [x] No-credentials passthrough: P1 reaches create_task unchanged
- [ ] After merge: real `/kanban:initjira` import on the BZK project — verify cards land in `Selected for Development` with AP populated

## Next in queue

Per the plan we agreed:
- **PR-B** (#17): locale-translated status name handling
- **PR-C** (#19 + #20): anti-self-approve assignee scoping + 200-char guardrail bump
- **PR-D** (#21): `reconcile` command for unmapped-status discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
