### PR TITLE
fix(kanban): 0.3.9 — Accept-Language: en-US for locale-stable Jira responses (#17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,37 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (locale-stable Jira responses)
+
+### Fixed
+- **kanban 0.3.9** — JiraClient now sends `Accept-Language: en-US` on
+  every request. Closes #17. The plugin's DSL stores status / priority /
+  issue-type names in English; without this header, an agent account
+  with non-English UI locale (e.g. zh-TW) caused Jira to return
+  localized names like `進行中` for `In Progress`, and:
+
+  - `transition --to REVIEW` failed with `no Jira workflow transition
+    leads to status 'Resolved'` (because the response had `已解決`)
+  - `import-tasks` priority validation drifted (returned localized
+    priority names that didn't match user input)
+  - any other lookup that string-matched against status/priority/type
+    names was at risk
+
+  The fix is one line in `lib/jira_client.py:_request` — adding the
+  header. Workflows whose underlying status names are non-English
+  (e.g. an actual zh-TW project where the admin defined statuses in
+  Chinese) are unaffected, because Jira only translates English source
+  names; non-English source has no English to translate to.
+
+  This also affects #18's priority validation, which is now reliable
+  across locales as a bonus.
+
+  - `test_phase16.py`: 7 cases covering header presence on GET / POST /
+    PUT, header coexistence with existing Authorization / Accept /
+    Content-Type, header on 429 retry path, end-to-end transition
+    lookup. All 16 phase suites (168 tests) green.
+  - bumps 0.3.8 → 0.3.9
+
 ## 2026-05-02 (import-tasks completeness)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -137,6 +137,15 @@ class JiraClient:
         headers = {
             "Authorization": self._auth_header(),
             "Accept": "application/json",
+            # Force English responses regardless of the agent account's UI
+            # locale. The plugin's DSL stores status / priority / issue-type
+            # names in English; without this, a zh-TW (or any non-English)
+            # account causes Jira to return localized names like `進行中` for
+            # `In Progress`, and transition lookup / priority validation
+            # silently fail. Closes #17. Workflows whose underlying source
+            # names are non-English are unaffected — there's no English
+            # source to translate from in that case.
+            "Accept-Language": "en-US",
         }
         body_bytes: Optional[bytes] = None
         if body is not None:

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do  # 8-15: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import-completeness (#16+#18)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do  # 8-16: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase16.py
+++ b/plugins/kanban/scripts/test_phase16.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Phase 16 regression checks for kanban v0.3.9 — locale-stable Jira responses.
+
+Closes #17. Adding `Accept-Language: en-US` to every Jira API request
+forces English responses regardless of the agent account's UI locale.
+The plugin's DSL stores status / priority / issue-type names in English;
+without this header, a zh-TW (or any non-English) account caused Jira
+to return localized names and transition lookup silently failed.
+
+Cases:
+  (a) Accept-Language: en-US header is present on GET requests
+  (b) Same header on POST requests (with body)
+  (c) Same header on PUT requests
+  (d) Header doesn't displace existing Authorization / Accept / Content-Type
+  (e) Even on retried requests (429), the header rides along on each retry
+  (f) End-to-end: a transition lookup that would have failed with a
+      localized to.name response works because the production server now
+      returns English (we can only verify our request shape; the server
+      behaviour is its responsibility)
+"""
+from __future__ import annotations
+
+import json
+import sys
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+def _mock(queue, calls):
+    def t(method, url, headers, body):
+        # Snapshot the headers dict — caller may mutate it on retry path
+        calls.append({
+            "method": method,
+            "url": url,
+            "body": body,
+            "headers": dict(headers),
+        })
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return t
+
+
+def _client(queue, calls):
+    return JiraClient(
+        "https://x.atlassian.net", "a@b", "tok",
+        transport=_mock(queue, calls), sleep=lambda _: None,
+    )
+
+
+# --- header presence ----------------------------------------------------
+
+
+def test_get_sends_accept_language_en_us():
+    queue = [_Response(200, b'{"accountId":"x"}', {})]
+    calls = []
+    c = _client(queue, calls)
+    c.get_myself()
+    assert calls[0]["headers"].get("Accept-Language") == "en-US"
+
+
+def test_post_sends_accept_language():
+    queue = [_Response(200, b'{"issues":[]}', {})]
+    calls = []
+    c = _client(queue, calls)
+    c.search_jql("project = X")
+    assert calls[0]["method"] == "POST"
+    assert calls[0]["headers"].get("Accept-Language") == "en-US"
+
+
+def test_put_sends_accept_language():
+    queue = [_Response(204, b"", {})]
+    calls = []
+    c = _client(queue, calls)
+    # update_issue uses PUT internally
+    c.update_issue("X-1", {"labels": ["foo"]})
+    assert calls[0]["method"] == "PUT"
+    assert calls[0]["headers"].get("Accept-Language") == "en-US"
+
+
+def test_existing_headers_unchanged():
+    """Adding Accept-Language must not displace Authorization / Accept /
+    Content-Type."""
+    queue = [_Response(200, b"{}", {})]
+    calls = []
+    c = _client(queue, calls)
+    c.search_jql("project = X")
+    h = calls[0]["headers"]
+    assert h["Accept-Language"] == "en-US"
+    assert h["Accept"] == "application/json"
+    assert h["Content-Type"] == "application/json"  # POST has body
+    assert h["Authorization"].startswith("Basic ")
+
+
+def test_get_no_content_type_but_accept_language():
+    """A GET (no body) shouldn't carry Content-Type, but should carry
+    Accept-Language."""
+    queue = [_Response(200, b"{}", {})]
+    calls = []
+    c = _client(queue, calls)
+    c.get_myself()
+    h = calls[0]["headers"]
+    assert h.get("Content-Type") is None or h.get("Content-Type") == "application/json"
+    # Note: the client only sets Content-Type when body is non-None.
+    # When body is None, Content-Type is absent; verify that.
+    assert "Content-Type" not in h
+    assert h["Accept-Language"] == "en-US"
+
+
+# --- header rides along on retry ---------------------------------------
+
+
+def test_accept_language_on_each_retry():
+    """A 429 retry sequence sends the header on every attempt — the
+    locale assumption mustn't break under retry pressure."""
+    queue = [
+        _Response(429, b"", {"retry-after": "0.01"}),
+        _Response(429, b"", {"retry-after": "0.01"}),
+        _Response(200, b'{"accountId":"x"}', {}),
+    ]
+    calls = []
+    c = _client(queue, calls)
+    c.get_myself()
+    assert len(calls) == 3
+    for call in calls:
+        assert call["headers"].get("Accept-Language") == "en-US"
+
+
+# --- end-to-end transition lookup with the header ----------------------
+
+
+def test_transition_lookup_works_with_english_response():
+    """Documents the contract: assuming Jira honours Accept-Language: en-US
+    (which it does on Cloud), `to.name` comes back as `In Progress`
+    rather than `進行中`, and the existing string-match in
+    JiraDriver.transition succeeds. We can't drive a real localized
+    server in a unit test, but we can verify the request carries the
+    header that triggers English behaviour.
+    """
+    queue = [
+        _Response(200, json.dumps({
+            "transitions": [
+                {"id": "21", "to": {"name": "In Progress"}},
+                {"id": "31", "to": {"name": "Done"}},
+            ]
+        }).encode(), {}),
+    ]
+    calls = []
+    c = _client(queue, calls)
+    resp = c.get_transitions("AGENT-1")
+    assert resp["transitions"][0]["to"]["name"] == "In Progress"
+    # Header check: any production zh-TW user would have got 進行中
+    # without the header. The fix is the header.
+    assert calls[0]["headers"].get("Accept-Language") == "en-US"
+
+
+def main() -> int:
+    cases = [
+        ("get_sends_accept_language_en_us", test_get_sends_accept_language_en_us),
+        ("post_sends_accept_language", test_post_sends_accept_language),
+        ("put_sends_accept_language", test_put_sends_accept_language),
+        ("existing_headers_unchanged", test_existing_headers_unchanged),
+        ("get_no_content_type_but_accept_language",
+         test_get_no_content_type_but_accept_language),
+        ("accept_language_on_each_retry", test_accept_language_on_each_retry),
+        ("transition_lookup_works_with_english_response",
+         test_transition_lookup_works_with_english_response),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase16: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #17.

## Symptom

Agent account with non-English Atlassian UI locale (e.g. zh-TW) caused Jira REST to return localized status / priority / issue-type names. The plugin's DSL stores these in English, so:

- `transition --to REVIEW` failed with `no Jira workflow transition leads to status 'Resolved'` (response had `已解決`)
- `import-tasks` priority validation drifted (response had localized priority names)
- any other string-match against status / priority / type was at risk

The reporter saw this on a project whose underlying status names ARE English (`Selected for Development`, `IN PROGRESS`, `RESOLVED`, `DONE`) — but the zh-TW account UI locale caused Jira to translate them on read.

## Fix

One line in `lib/jira_client.py:_request`:

```python
headers = {
    "Authorization": self._auth_header(),
    "Accept": "application/json",
    "Accept-Language": "en-US",   # ← new
}
```

Forces English responses regardless of account locale. The plugin's internal contract has always been "DSL is in English"; this just makes the wire-level assumption explicit.

## Why this is safe

The header tells Jira "give me the English representation". Workflows whose underlying source names are **already English** (the bug case) → server now returns English consistently → DSL match works.

Workflows whose underlying source names are **non-English** (e.g. an actual zh-TW Jira project where the admin defined statuses in Chinese) → there's no English source to translate from → server returns the actual non-English names → continues working as before. The 0.3.0 non-English suggester (which recognizes 進行中 via `statusCategory.key`) handles this case.

## Bonus: also fixes priority validation drift

The same locale issue affected `client.get_priorities()` (added in 0.3.8 for #18). With this header, priority names are now stable across locales — a `kirinchen.atlassian.net` agent on zh-TW will get back `["Highest", "High", "Medium", "Low", "Lowest"]` reliably.

## What changed

| Concern | File |
|---|---|
| Add `Accept-Language: en-US` to every Jira request | `lib/jira_client.py` |
| 7 mocked tests | `scripts/test_phase16.py` (new) |
| Bump `0.3.8 → 0.3.9`; CHANGELOG entry | versions / CHANGELOG |

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 16 phase suites, **168 tests**, all green
- [x] Header present on GET / POST / PUT
- [x] Header coexists with Authorization / Accept / Content-Type (no displacement)
- [x] Header rides along on each 429 retry attempt
- [x] End-to-end transition lookup: contract verified (server-side English assumed)
- [ ] After merge: real `/kanban:initjira` → `transition --to REVIEW` against the BZK project on a zh-TW Atlassian account — verify the transition succeeds without manual workarounds

## Next in queue

- **PR-C** (#19 + #20): anti-self-approve assignee scoping + 200-char guardrail bump
- **PR-D** (#21): `reconcile` command for unmapped-status discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
