### PR TITLE
fix(kanban): 0.3.10 — assignee-aware self-approve + guardrail bump (#19, #20)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,48 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (assignee-aware self-approve + guardrail bump)
+
+### Changed
+- **kanban 0.3.10** — two behaviour-tuning fixes from real BZK board use:
+
+  - **(#19)** Anti-self-approve now considers `assignee` alongside the
+    AP custom field. Previously, refusing DONE only required
+    `card.ap == repo_ap` — too strict when the agent is recording work
+    completed by a human teammate (assignee = the human). The agent
+    isn't approving its own work in that case; it's recording the
+    human's completion.
+
+    The new rule:
+
+    | `card.ap` | `assignee` | DONE allowed? |
+    |---|---|---|
+    | mine | agent's own account | NO (refuse) |
+    | mine | None (unassigned) | NO (refuse, strict default) |
+    | mine | a different account (human teammate) | YES (allow) |
+    | other / nil | anything | YES (allow) |
+
+    Refusal message now hints at the workaround: "assign the card to
+    that human first if you are recording on their behalf."
+
+  - **(#20)** `conventions.notes[]` length guardrail bumped 200 → 300
+    chars. Compound rules like `"REVIEW = ball in user court. (A) ...
+    (B) ... Don't confuse with BLOCKED for ..."` consistently exceeded
+    200 in real use; splitting them across multiple notes lost the
+    connecting logic. 300 covers typical compound clauses; over that,
+    move to an ADR.
+
+  Both are advisory-level tweaks (no API change, no schema change).
+
+  - `test_phase17.py` (5 cases): all four canonical
+    AP/assignee combinations + workaround hint in error message.
+  - phase 7's `test_self_approve_refused_v03` updated: mock issue's
+    assignee changed from `kirin-acct` → `shared-agent` to match the
+    new "refuse only when assignee is the agent itself" rule.
+  - phase 11 guardrail tests updated for 300-char threshold.
+
+  All 17 phase suites (173 tests) green. Bumps 0.3.9 → 0.3.10.
+
 ## 2026-05-02 (locale-stable Jira responses)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -308,11 +308,31 @@ class JiraDriver:
         if to_column == "DONE":
             current_ap = self._current_repo_ap()
             if current_ap and existing_for_status.ap and existing_for_status.ap == current_ap:
-                raise SelfApproveRefused(
-                    f"anti-self-approve: agent {current_ap!r} cannot "
-                    f"transition its own card {key} to DONE — ask another "
-                    "agent or a human reviewer to approve"
+                # Only refuse when the agent itself owns the work.
+                # Per issue #19: if the assignee is a different account
+                # (e.g. a human teammate who actually completed the
+                # work), the agent is recording, not approving — allow.
+                # An unassigned card defaults to "agent's own work" for
+                # safety: without an explicit human owner the strict
+                # original guard still applies.
+                assignee_acct: str | None = None
+                if existing_for_status.assignee is not None:
+                    assignee_acct = getattr(
+                        existing_for_status.assignee, "accountId", None
+                    )
+                recording_for_other = (
+                    assignee_acct is not None
+                    and self.agent_account_id is not None
+                    and assignee_acct != self.agent_account_id
                 )
+                if not recording_for_other:
+                    raise SelfApproveRefused(
+                        f"anti-self-approve: agent {current_ap!r} cannot "
+                        f"transition its own card {key} to DONE — ask "
+                        "another agent or a human reviewer to approve "
+                        "(or assign the card to that human first if you "
+                        "are recording on their behalf)"
+                    )
         client = self._client_or_raise()
 
         # Step 0 — blocked_by issue links (only meaningful when transitioning

--- a/plugins/kanban/lib/conventions.py
+++ b/plugins/kanban/lib/conventions.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 
-DEFAULT_NOTES_MAX_LEN = 200
+DEFAULT_NOTES_MAX_LEN = 300
 DEFAULT_NOTES_MAX_COUNT = 10
 
 

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do  # 8-16: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17; do  # 8-17: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve assignee (#19)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase11.py
+++ b/plugins/kanban/scripts/test_phase11.py
@@ -62,8 +62,13 @@ def test_normalize_fills_defaults_drops_unknown():
 
 
 def test_validate_flags_guardrails():
-    warns = cv.validate({"notes": ["a" * 201, "ok"]})
-    assert any("201 chars" in w for w in warns)
+    # Guardrail bumped 200 → 300 in 0.3.10 (issue #20). 350 chars is
+    # over the new threshold; verify the warning text reflects it.
+    warns = cv.validate({"notes": ["a" * 350, "ok"]})
+    assert any("350 chars" in w for w in warns)
+    # 250 chars is under the new threshold — should NOT warn.
+    warns = cv.validate({"notes": ["a" * 250]})
+    assert all("250 chars" not in w for w in warns)
     warns = cv.validate({"notes": ["x"] * 15})
     assert any("15 entries" in w for w in warns)
     warns = cv.validate({"notes": ["", "   ", "real"]})
@@ -277,7 +282,8 @@ def test_set_conventions_writes_and_warns():
     with tempfile.TemporaryDirectory() as raw:
         td = pathlib.Path(raw)
         kp = _seed_jira(td)
-        notes = ["a" * 250, "ok note"]
+        # 0.3.10 bumped guardrail to 300; use 350 to trigger the warning.
+        notes = ["a" * 350, "ok note"]
         out = _run(
             "set-conventions",
             "--kanban-path", str(kp),
@@ -287,7 +293,7 @@ def test_set_conventions_writes_and_warns():
         assert out.returncode == 0, out.stderr
         j = json.loads(out.stdout)
         assert j["ok"] is True
-        assert any("250 chars" in w for w in j["warnings"])
+        assert any("350 chars" in w for w in j["warnings"])
         cfg = json.loads(kp.read_text())["backend"]["jira"]
         assert cfg["conventions"]["notes"] == notes
 

--- a/plugins/kanban/scripts/test_phase17.py
+++ b/plugins/kanban/scripts/test_phase17.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Phase 17 regression checks for kanban v0.3.10 — assignee-aware
+anti-self-approve (#19).
+
+The original anti-self-approve rule (refuse DONE if `card.ap == repo_ap`)
+was too strict in the common case where the agent records work
+completed by a human teammate (assignee = the human). v0.3.10 loosens
+the rule: refuse only when the card's assignee is the agent itself
+(or null). This phase covers the four canonical cases:
+
+  | card.ap     | assignee                          | DONE allowed?  |
+  |-------------|-----------------------------------|----------------|
+  | mine        | agent's own account               | NO (refuse)    |
+  | mine        | None (unassigned)                 | NO (refuse)    |
+  | mine        | a different account (e.g. human)  | YES (allow)    |
+  | other / nil | anything                          | YES (allow)    |
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+def _seed():
+    return {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    from drivers.jira import JiraDriver
+    from lib import credentials
+
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        return queue.pop(0)
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _seed_repo_ap(repo: pathlib.Path, ap: str = "agent-fin"):
+    (repo / ".claude").mkdir(parents=True, exist_ok=True)
+    (repo / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": ap}) + "\n"
+    )
+
+
+def _issue(key, *, status="In Progress", assignee_acct=None,
+           ap_value="agent-fin", labels=()):
+    f = {
+        "summary": "x",
+        "status": {"name": status},
+        "priority": {"name": "P1"},
+        "assignee": {"accountId": assignee_acct} if assignee_acct else None,
+        "labels": list(labels),
+        "created": "x", "updated": "y",
+        "issuelinks": [],
+    }
+    if ap_value is not None:
+        f["customfield_10042"] = {"value": ap_value}
+    return {"key": key, "fields": f}
+
+
+# --- the four canonical cases -------------------------------------------
+
+
+def test_refuse_when_assignee_is_agent_account():
+    """AP=mine + assignee=agent → still refuse (classic self-approve)."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(_seed(), proj)
+        pre = _issue("AGENT-1", assignee_acct="5e-agent",
+                     ap_value="agent-fin")
+        queue = [_Response(200, json.dumps(pre).encode(), {})]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.jira import SelfApproveRefused
+        try:
+            drv.transition("AGENT-1", "DONE")
+            assert False, "should have refused"
+        except SelfApproveRefused as e:
+            assert "agent-fin" in str(e)
+        # Only the pre-flight read happened — no transition POST attempt
+        assert len(calls) == 1
+
+
+def test_refuse_when_assignee_is_none():
+    """AP=mine + assignee=None → still refuse. Without proof of human
+    ownership we err on the strict side."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(_seed(), proj)
+        pre = _issue("AGENT-2", assignee_acct=None, ap_value="agent-fin")
+        queue = [_Response(200, json.dumps(pre).encode(), {})]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.jira import SelfApproveRefused
+        try:
+            drv.transition("AGENT-2", "DONE")
+            assert False, "should have refused"
+        except SelfApproveRefused:
+            pass
+        assert len(calls) == 1
+
+
+def test_allow_when_assignee_is_different_human():
+    """AP=mine + assignee=different account → allow (recording on
+    behalf of the human who actually did the work — issue #19)."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(_seed(), proj)
+        # Card belongs to my AP but is assigned to Kirin (a different
+        # account from the bot).
+        pre = _issue("AGENT-3", assignee_acct="5e-kirin",
+                     ap_value="agent-fin", status="In Progress")
+        post = _issue("AGENT-3", assignee_acct="5e-kirin",
+                      ap_value="agent-fin", status="Done")
+        # Full transition flow: get_task → get_transitions → POST → final get_task
+        queue = [
+            _Response(200, json.dumps(pre).encode(), {}),
+            _Response(200, json.dumps(
+                {"transitions": [{"id": "31", "to": {"name": "Done"}}]}
+            ).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(post).encode(), {}),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        result = drv.transition("AGENT-3", "DONE")
+        assert result.column == "DONE"
+        # We hit the transition POST — proves the new code allowed it.
+        posts = [c for c in calls if c["method"] == "POST"
+                 and c["url"].endswith("/transitions")]
+        assert len(posts) == 1
+
+
+def test_allow_when_ap_does_not_match():
+    """AP=other (a different agent's card) — never triggered the refuse
+    path under the old rule either; verify still allowed."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)  # repo AP = "agent-fin"
+        drv = _patched_driver(_seed(), proj)
+        # Card's AP is a different agent
+        pre = _issue("AGENT-4", assignee_acct="5e-agent",
+                     ap_value="agent-quant", status="In Progress")
+        post = _issue("AGENT-4", assignee_acct="5e-agent",
+                      ap_value="agent-quant", status="Done")
+        queue = [
+            _Response(200, json.dumps(pre).encode(), {}),
+            _Response(200, json.dumps(
+                {"transitions": [{"id": "31", "to": {"name": "Done"}}]}
+            ).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(post).encode(), {}),
+        ]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        result = drv.transition("AGENT-4", "DONE")
+        assert result.column == "DONE"
+
+
+# --- error message preserved --------------------------------------------
+
+
+def test_refused_error_message_mentions_workaround():
+    """The new refusal message hints at the workaround (assign to human
+    first if recording on their behalf)."""
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(_seed(), proj)
+        pre = _issue("AGENT-5", assignee_acct="5e-agent",
+                     ap_value="agent-fin")
+        queue = [_Response(200, json.dumps(pre).encode(), {})]
+        calls = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.jira import SelfApproveRefused
+        try:
+            drv.transition("AGENT-5", "DONE")
+            assert False, "should have refused"
+        except SelfApproveRefused as e:
+            msg = str(e)
+            assert "anti-self-approve" in msg
+            assert "agent-fin" in msg
+            # New hint about the recording-on-behalf workaround
+            assert "assign" in msg.lower() and "human" in msg.lower()
+
+
+def main() -> int:
+    cases = [
+        ("refuse_when_assignee_is_agent_account",
+         test_refuse_when_assignee_is_agent_account),
+        ("refuse_when_assignee_is_none",
+         test_refuse_when_assignee_is_none),
+        ("allow_when_assignee_is_different_human",
+         test_allow_when_assignee_is_different_human),
+        ("allow_when_ap_does_not_match",
+         test_allow_when_ap_does_not_match),
+        ("refused_error_message_mentions_workaround",
+         test_refused_error_message_mentions_workaround),
+    ]
+    for name, fn in cases:
+        try:
+            fn()
+        except AssertionError as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"ERROR {name}: {type(e).__name__}: {e}", file=sys.stderr)
+            return 2
+        print(f"ok    {name}")
+    print("phase17: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase7.py
+++ b/plugins/kanban/scripts/test_phase7.py
@@ -365,13 +365,18 @@ def test_compound_transition_status_change():
 
 
 def test_self_approve_refused_v03():
+    """Classic anti-self-approve refusal: AP=mine AND assignee is the
+    agent account itself. (#19 in 0.3.10 loosened the rule to allow
+    when assignee differs from agent — see test_phase17 for that
+    branch.)"""
     with tempfile.TemporaryDirectory() as td:
         proj = pathlib.Path(td)
         (proj / ".claude").mkdir()
         (proj / ".claude" / "kanban-agent.json").write_text(json.dumps({"ap": "agent-fin"}))
         drv = _patched_driver(_seed_jira_data(), proj)
         pre = _issue("AGENT-7", "In Progress", labels=["kanban:review"],
-                     assignee="kirin-acct", ap_value="agent-fin")
+                     assignee="shared-agent",  # the agent's own account
+                     ap_value="agent-fin")
         queue = [_Response(200, json.dumps(pre).encode(), {})]
         calls = []
         _attach_mock(drv, queue, calls)


### PR DESCRIPTION
Closes #19 + #20.

Two behaviour-tuning fixes from the same BZK board session. Both small.

## #19 — assignee-aware anti-self-approve

The original rule (refuse DONE if `card.ap == repo_ap`) was too strict when the agent is recording work completed by a human. In the reporter's scenario:

> 22 cards with AP=narrative-fin-agent. Some assigned to Surf Monster (the agent), some to Kirin Chen (the human). When Kirin completed his 10 tasks and asked me to mark them DONE on his behalf, every transition --to DONE failed: "anti-self-approve: agent 'narrative-fin-agent' cannot transition its own card BZK-608 to DONE..." But BZK-608's assignee is Kirin Chen.

New rule:

| `card.ap` | `assignee` | DONE allowed? |
|---|---|---|
| mine | agent's own account | NO (refuse) |
| mine | `None` (unassigned) | NO (refuse, strict default) |
| mine | a different account (human teammate) | **YES (allow)** |
| other / nil | anything | YES (allow) |

The refusal message now hints at the workaround: "assign the card to that human first if you are recording on their behalf."

## #20 — conventions notes guardrail 200 → 300

Real compound rules consistently exceeded 200 chars; splitting them across multiple notes lost the connecting logic. The reporter's example was 246 chars and triggered the warning. 300 is "Twitter-2x", still scannable, fits typical compound clauses without forcing artificial splits. Anything longer still warns (move to an ADR).

Both are advisory-level tweaks — no API change, no schema change, no migration needed.

## What changed

| Concern | File |
|---|---|
| `transition()` self-approve guard reads `existing.assignee.accountId` and allows when it differs from `agent_account_id` | `drivers/jira.py` |
| Refusal message updated with workaround hint | `drivers/jira.py` |
| `DEFAULT_NOTES_MAX_LEN: 200 → 300` | `lib/conventions.py` |
| 5 new mocked tests (all four AP/assignee combos + message hint) | `scripts/test_phase17.py` (new) |
| Phase-7 `test_self_approve_refused_v03` mock assignee updated `kirin-acct` → `shared-agent` to keep the refusal scenario valid under the new rule | `scripts/test_phase7.py` |
| Phase-11 guardrail tests bumped `200/250` → `300/350` boundary assertions | `scripts/test_phase11.py` |
| Bump `0.3.9 → 0.3.10`; CHANGELOG entry | versions / CHANGELOG |

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — 17 phase suites, **173 tests**, all green
- [x] AP=mine + assignee=agent → refuses (classic case still works)
- [x] AP=mine + assignee=None → refuses (strict default)
- [x] AP=mine + assignee=different account → allows + transition POST fires
- [x] AP=other → allows
- [x] Refusal message contains the workaround hint
- [x] 350-char note triggers warning; 250-char note doesn't
- [ ] After merge: real `/kanban:done <CARD assigned to Kirin>` on the BZK project — verify it transitions without the refusal

## Next in queue

- **PR-D** (#21): `reconcile` command for unmapped-status discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
