### PR TITLE
fix(kanban): 0.3.12 — locale-immune workflow + JQL timestamp + ADF prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,53 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (locale + JQL + ADF fixes)
+
+### Fixed
+- **kanban 0.3.12** — three orthogonal regressions surfaced after the
+  morning's #16–#21 batch shipped. Closes #17 (re-opened), #26, #27.
+
+  - **#17 transition lookup is now locale-immune.** The `Accept-Language:
+    en-US` header added in 0.3.9 fixed JQL paths but does NOT untranslate
+    the `to.name` field on `/transitions` responses — Atlassian still
+    returns localized status names (e.g. `審查` for `REVIEW` on a zh-TW
+    account) even with the header. `transition()` now matches by the
+    transition action name (`t["name"]`, English-canonical regardless of
+    UI locale) first, falling back to `t["to"]["name"]` for English-locale
+    accounts whose action and status names differ. Same root cause hit
+    `/kanban:reconcile`: it compared raw `status.name` against DSL names
+    client-side. The fix moves the filter server-side via JQL `status
+    not in (mapped_statuses)`, which JQL evaluates against canonical
+    English regardless of UI locale. One JQL query instead of two; the
+    localized status name in the response is used only for grouping in
+    the diagnostic output (cosmetic).
+
+  - **#26 `find-mentions` always returned 0.** `_jql_quote_ts()` was a
+    passthrough that handed Jira full ISO-8601 strings with timezone
+    offsets (`2026-05-02T11:44:37+08:00`) — JQL silently rejects this
+    format and returns 0 results with no error. Now normalizes to JQL's
+    canonical `yyyy-MM-dd HH:mm` via `datetime.fromisoformat`. Same
+    `_jql_quote_ts` site is reused by `cmd_sync_summary`'s mentions
+    block, which had the same bug.
+
+  - **#27 agent comment prefix rendered broken in Jira UI.** The SPEC §9
+    prefix was authored as a markdown literal (`**[ap] [kind]**`) and
+    embedded into a single ADF text node; ADF doesn't parse markdown,
+    so Jira's renderer emitted raw `**` plus broken `<span class="error">`
+    around the brackets. The prefix is now an ADF text node with a
+    `strong` mark in its own paragraph, with the body in a second
+    paragraph. `_PREFIX_RE` now accepts both forms (old comments still
+    parse). The same fix applies to `text_to_adf_with_mention` so
+    `/kanban:reply` renders correctly.
+
+  Tests: phase 19 covers transition action-name fallback (with both
+  zh-TW and English locale workflows), reconcile's locale-immune JQL
+  shape, `_jql_quote_ts` normalization (incl. quote-injection refusal),
+  and ADF strong-mark prefix on both no-mention and mention paths.
+  Phase 18 mocks updated to mirror the new server-side filter (mapped
+  cards never reach the client); phase 2's `post_comment_prefixes`
+  asserts the new ADF shape directly. All 19 phases green.
+
 ## 2026-05-02 (drift visibility)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -50,9 +50,13 @@ class SelfApproveRefused(RuntimeError):
     delegating to Jira workflow conditions when admin can configure them.
     """
 
-# SPEC §9 prefix grammar.
+# SPEC §9 prefix grammar. Historically the prefix was authored as markdown
+# `**[ap] [kind]**`; v0.3.12 switched to ADF strong marks (so Jira UI no
+# longer renders literal `**` and broken `<span class="error">` around the
+# brackets — see #27). When parsing, accept both forms so old comments stay
+# readable.
 _PREFIX_RE = re.compile(
-    r"^\*\*\[(?P<ap>[a-z][a-z0-9-]+)\]\s+\[(?P<kind>Q|A|C|S)\]\*\*\s*\n*(?P<rest>.*)$",
+    r"^(?:\*\*)?\[(?P<ap>[a-z][a-z0-9-]+)\]\s+\[(?P<kind>Q|A|C|S)\](?:\*\*)?\s*\n*(?P<rest>.*)$",
     re.DOTALL,
 )
 
@@ -163,14 +167,40 @@ class JiraDriver:
         )
 
     @staticmethod
-    def _agent_prefix(ap: str | None, kind: CommentKind) -> str:
+    def _agent_prefix_text(ap: str | None, kind: CommentKind) -> str:
+        """Plain text of the SPEC §9 prefix (no markdown). The ADF builder
+        wraps this in a strong-marked text node, so Jira UI renders it as
+        bold without the markdown literals leaking through (see #27)."""
         ap_str = ap or "agent"
-        return f"**[{ap_str}] [{kind.value}]**\n\n"
+        return f"[{ap_str}] [{kind.value}]"
 
     def _agent_comment_body(
         self, body: str, kind: CommentKind, ap: str | None
     ) -> dict[str, Any]:
-        return text_to_adf(self._agent_prefix(ap, kind) + body)
+        # Two paragraphs: bold prefix on its own line, then the body. ADF
+        # doesn't parse markdown — emitting the prefix as a strong-marked
+        # text node is the only way to get bold rendering without the raw
+        # `**` showing up in the Jira UI (#27).
+        return {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": self._agent_prefix_text(ap, kind),
+                            "marks": [{"type": "strong"}],
+                        }
+                    ],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": body}],
+                },
+            ],
+        }
 
     def _parse_comment(self, raw: dict[str, Any]) -> Comment:
         author = ((raw.get("author") or {}).get("displayName")) or ""
@@ -349,11 +379,19 @@ class JiraDriver:
         existing_status = existing_for_status.custom.get("raw_status")
         if existing_status != target_status:
             transitions = (client.get_transitions(key) or {}).get("transitions", [])
+            # Match by transition action name first, then destination status
+            # name. Jira's `to.name` is locale-translated (e.g. zh-TW shows
+            # "審查" for canonical "REVIEW") even with Accept-Language: en-US,
+            # but `name` (the workflow action label) stays English. Falling
+            # back to `to.name` keeps English-locale users working when their
+            # action name differs from their status name (e.g. action="Resolve
+            # Issue", status="Resolved", DSL="Resolved"). See #17.
             tid = next(
                 (
                     t["id"]
                     for t in transitions
-                    if (t.get("to") or {}).get("name") == target_status
+                    if t.get("name") == target_status
+                    or (t.get("to") or {}).get("name") == target_status
                 ),
                 None,
             )
@@ -430,11 +468,8 @@ class JiraDriver:
         client = self._client_or_raise()
         ap = self._current_repo_ap()
         if mention_account_id:
-            # Strip trailing newlines from the agent prefix so the prefix
-            # paragraph reads cleanly above the mention paragraph.
-            prefix = self._agent_prefix(ap, kind).strip()
             adf = text_to_adf_with_mention(
-                prefix,
+                self._agent_prefix_text(ap, kind),
                 mention_account_id,
                 mention_display or "user",
                 body,

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -482,20 +482,26 @@ def text_to_adf_with_mention(
     mention_display: str,
     body_text: str,
 ) -> dict[str, Any]:
-    """Build an ADF doc that prepends `prefix_text` (as its own paragraph)
-    then a paragraph that begins with an @-mention node followed by
-    ` body_text`.
+    """Build an ADF doc that prepends `prefix_text` (as its own paragraph,
+    rendered bold) then a paragraph that begins with an @-mention node
+    followed by ` body_text`.
 
-    Used by /kanban:reply so the bot's reply notifies the human via
-    Jira's native mention plumbing. Empty `prefix_text` collapses the
-    prefix paragraph (used when caller already wrapped the prefix
-    elsewhere).
+    Used by /kanban:reply so the bot's reply notifies the human via Jira's
+    native mention plumbing. Empty `prefix_text` collapses the prefix
+    paragraph (used when caller already wrapped the prefix elsewhere). The
+    prefix renders as bold via an ADF `strong` mark — ADF doesn't parse
+    markdown, so emitting `**...**` literals would render verbatim (#27).
     """
     content: list[dict[str, Any]] = []
     if prefix_text:
-        content.append(
-            {"type": "paragraph", "content": [{"type": "text", "text": prefix_text}]}
-        )
+        content.append({
+            "type": "paragraph",
+            "content": [{
+                "type": "text",
+                "text": prefix_text,
+                "marks": [{"type": "strong"}],
+            }],
+        })
     body_para: dict[str, Any] = {
         "type": "paragraph",
         "content": [

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1215,14 +1215,22 @@ def cmd_find_mentions(args: argparse.Namespace) -> int:
 def _jql_quote_ts(ts: str) -> str:
     """Format a timestamp for safe inclusion in a JQL string literal.
 
-    Jira's JQL `updated >= "..."` accepts both yyyy/MM/dd HH:mm and ISO-8601.
-    We pass through ISO if it looks safe; anything with a `"` is rejected
-    (callers should never produce such input — `since` is either a stored
-    timestamp or a freshly-generated ISO string).
+    Jira JQL accepts `yyyy-MM-dd HH:mm`, `yyyy/MM/dd HH:mm`, and the
+    date-only forms. It silently rejects full ISO-8601 with a timezone
+    offset (e.g. `2026-05-02T11:44:37+08:00`) — query returns 0 results
+    with no error (#26). When the input parses as ISO-8601, normalize to
+    `yyyy-MM-dd HH:mm` (Jira interprets the bare timestamp in the project's
+    configured zone, which is what callers want for "recent activity"
+    queries). Otherwise pass through (already canonical short form).
     """
     if '"' in ts:
         raise ValueError(f"invalid timestamp {ts!r}")
-    return ts
+    from datetime import datetime
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return ts  # already canonical (yyyy-MM-dd or yyyy/MM/dd HH:mm)
+    return dt.strftime("%Y-%m-%d %H:%M")
 
 
 def cmd_mark_mentions_read(args: argparse.Namespace) -> int:
@@ -2149,8 +2157,15 @@ def _detect_reconcile(
 
     Two read-only JQL queries:
       1. project=X AND cf[ap]=repo_ap AND statusCategory!=Done
-         → cards belonging to my AP; group by status; flag those
-         whose status name isn't in transitions[*].status set.
+                  AND status not in (mapped_statuses)
+         → my-AP cards whose Jira status isn't covered by the DSL.
+         Filtering server-side via `status not in (...)` is locale-immune:
+         JQL accepts canonical English status names regardless of the
+         account's UI locale, so a zh-TW account whose API responses
+         translate "REVIEW" to "審查" still won't false-flag mapped cards
+         (#17). The status name in the response is used only for grouping
+         in the diagnostic output (cosmetic — matches what the user sees
+         in their Jira UI).
       2. project=X AND cf[ap] is EMPTY AND statusCategory!=Done
          → cards in the project with no AP set (invisible to
          /kanban:next which always filters by AP).
@@ -2162,20 +2177,27 @@ def _detect_reconcile(
     missing_ap: list[str] = []
     errors: list[str] = []
 
-    mapped_status_names: set[str] = set()
+    # Distinct mapped status names for the JQL `status not in (...)` filter.
+    # Skip any name containing `"` (would break the JQL string literal —
+    # Jira status names never contain quotes in normal configurations).
+    mapped_statuses: list[str] = []
+    seen: set[str] = set()
     for spec in (transitions or {}).values():
         st = (spec or {}).get("status")
-        if isinstance(st, str) and st:
-            mapped_status_names.add(st)
+        if isinstance(st, str) and st and '"' not in st and st not in seen:
+            mapped_statuses.append(st)
+            seen.add(st)
 
     cf_id = _ap_cf_jql_id(ap_field_id)
 
-    # 1. My-AP cards in unmapped statuses
-    if repo_ap and cf_id:
+    # 1. My-AP cards in unmapped statuses (server-side filter — locale immune)
+    if repo_ap and cf_id and mapped_statuses:
+        in_clause = ", ".join(f'"{s}"' for s in mapped_statuses)
         jql = (
             f'project = "{project_key}" '
             f'AND cf[{cf_id}] = "{repo_ap}" '
-            f'AND statusCategory != Done'
+            f'AND statusCategory != Done '
+            f'AND status not in ({in_clause})'
         )
         try:
             resp = client.search_jql(
@@ -2188,12 +2210,9 @@ def _detect_reconcile(
                 key = issue.get("key", "")
                 status_name = (
                     ((issue.get("fields") or {}).get("status") or {}).get("name")
-                )
-                if not isinstance(status_name, str) or not status_name:
-                    continue
-                if status_name in mapped_status_names:
-                    continue  # mapped, no problem
-                unmapped.setdefault(status_name, []).append(key)
+                ) or "(unknown)"
+                if key:
+                    unmapped.setdefault(status_name, []).append(key)
 
     # 2. Missing-AP cards (regardless of which AP would have owned them)
     if cf_id:

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18; do  # 8-18: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; do  # 8-19: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase18.py
+++ b/plugins/kanban/scripts/test_phase18.py
@@ -91,20 +91,20 @@ _TRANSITIONS = {
 
 
 def test_detect_reconcile_groups_unmapped():
-    """My-AP cards with status outside the mapped set are flagged."""
+    """My-AP cards with status outside the mapped set are flagged.
+
+    v0.3.12: filtering moved server-side via JQL `status not in (...)`
+    (locale-immune — see #17), so the mock only returns the unmapped
+    cards. Mapped cards never reach the client.
+    """
     queue = [
-        # Query 1: my-AP, statusCategory != Done
+        # Query 1: my-AP cards in unmapped statuses (server-side filter)
         _Response(200, json.dumps({
             "issues": [
-                # Mapped — not flagged
-                {"key": "AGENT-100",
-                 "fields": {"status": {"name": "In Progress"}}},
-                # Unmapped — flagged under "TO PROGRESS"
                 {"key": "AGENT-201",
                  "fields": {"status": {"name": "TO PROGRESS"}}},
                 {"key": "AGENT-202",
                  "fields": {"status": {"name": "TO PROGRESS"}}},
-                # Unmapped — flagged under "Backlog"
                 {"key": "AGENT-300",
                  "fields": {"status": {"name": "Backlog"}}},
             ],
@@ -127,6 +127,13 @@ def test_detect_reconcile_groups_unmapped():
     assert unmapped["TO PROGRESS"] == ["AGENT-201", "AGENT-202"]
     assert unmapped["Backlog"] == ["AGENT-300"]
     assert missing == ["AGENT-401", "AGENT-402"]
+    # Query 1 must include the locale-immune `status not in (...)` filter
+    # listing every DSL-mapped status name (the heart of #17 fix).
+    q1_payload = json.loads((calls[0]["body"] or b"{}").decode())
+    q1_jql = q1_payload.get("jql", "")
+    assert "status not in (" in q1_jql, q1_jql
+    for st in ("Selected for Development", "In Progress", "Done"):
+        assert f'"{st}"' in q1_jql, q1_jql
 
 
 def test_detect_reconcile_skips_when_no_repo_ap():
@@ -240,13 +247,11 @@ def _restore_client_or_none(orig):
 
 
 def test_reconcile_clean():
-    """When no drift, hint is positive."""
+    """When no drift, hint is positive. (v0.3.12: server-side JQL filter
+    means a clean state returns empty in query 1.)"""
     queue = [
-        # Query 1 — only mapped statuses
-        _Response(200, json.dumps({"issues": [
-            {"key": "A-1", "fields": {"status": {"name": "In Progress"}}},
-            {"key": "A-2", "fields": {"status": {"name": "Selected for Development"}}},
-        ]}).encode(), {}),
+        # Query 1 — server filter `status not in (mapped)` excludes everything
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
         # Query 2 — empty
         _Response(200, json.dumps({"issues": []}).encode(), {}),
     ]

--- a/plugins/kanban/scripts/test_phase19.py
+++ b/plugins/kanban/scripts/test_phase19.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Phase 19 regression checks for kanban v0.3.12 — locale-immune workflow,
+JQL timestamp normalization, ADF strong-mark prefix.
+
+Closes #17 (re-opened), #26, #27.
+
+Cases:
+  (a) transition() falls back to matching by transition action name when
+      the destination status name is locale-translated (#17).
+  (b) transition() still works when only the destination status name
+      matches (English locale, action name differs).
+  (c) _detect_reconcile builds locale-immune `status not in (...)` JQL
+      and, when no DSL transitions are configured, skips query 1 entirely
+      (#17 — server-side filter cannot be expressed without a mapped set).
+  (d) _jql_quote_ts converts ISO-8601 with offset to JQL canonical
+      `yyyy-MM-dd HH:mm` (#26).
+  (e) _jql_quote_ts passes through already-canonical short forms (#26).
+  (f) cmd_find_mentions sends the rewritten timestamp in its JQL (#26).
+  (g) post_comment with @-mention emits a strong-marked prefix paragraph
+      (no markdown literals) followed by the mention paragraph (#27).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _mock_client(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return JiraClient(
+        "https://x", "a@b", "tok",
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+# --- (a) (b) transition lookup OR-fallback ------------------------------
+
+
+def _seed_jira_data():
+    return {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "REVIEW": {"status": "REVIEW"},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    from drivers.jira import JiraDriver
+    from lib import credentials
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        return queue.pop(0)
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _seed_repo_ap(repo: pathlib.Path, ap: str = "agent-fin"):
+    (repo / ".claude").mkdir(parents=True, exist_ok=True)
+    (repo / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": ap}) + "\n"
+    )
+
+
+def _issue_response(key, *, status_name="In Progress", labels=(),
+                    assignee_acct="some-human", ap_value="agent-fin"):
+    """Minimal `get_issue` response used by transition()'s pre-flight read."""
+    return _Response(200, json.dumps({
+        "key": key,
+        "fields": {
+            "summary": "x",
+            "status": {"name": status_name},
+            "priority": {"name": "P1"},
+            "assignee": {"accountId": assignee_acct} if assignee_acct else None,
+            "labels": list(labels),
+            "created": "x", "updated": "y",
+            "issuelinks": [],
+            "customfield_10042": {"value": ap_value},
+        },
+    }).encode(), {})
+
+
+def test_transition_matches_by_action_name_when_status_localized():
+    """zh-TW workflow: action.name='REVIEW' (English), to.name='審查'
+    (locale-translated). DSL says status='REVIEW'. Old code matched only
+    on to.name and failed; new code matches on the action name."""
+    data = _seed_jira_data()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            # Pre-flight read for status check (TODO → REVIEW transition)
+            _issue_response("AGENT-1", status_name="To Do"),
+            # get_transitions: only zh-TW localized to.name available;
+            # action name stays canonical English.
+            _Response(200, json.dumps({"transitions": [
+                {"id": "11", "name": "Start Progress",
+                 "to": {"id": "10001", "name": "進行中"}},
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "審查"}},
+                {"id": "31", "name": "Done",
+                 "to": {"id": "10004", "name": "完成"}},
+            ]}).encode(), {}),
+            # transition_issue acceptance (no body)
+            _Response(204, b"", {}),
+            # Post-transition refresh read (driver.get_task)
+            _issue_response("AGENT-1", status_name="REVIEW"),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("AGENT-1", "REVIEW")
+        # The accepted transition must have id=21 (matched via action name)
+        transition_call = next(
+            c for c in calls
+            if c["url"].endswith("/transitions") and c["method"] == "POST"
+        )
+        sent = json.loads(transition_call["body"])
+        assert sent["transition"]["id"] == "21", sent
+
+
+def test_transition_still_matches_by_destination_status_name():
+    """English locale: action.name='Resolve Issue', to.name='Done',
+    DSL='Done'. Match falls through to the to.name branch."""
+    data = _seed_jira_data()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _issue_response("AGENT-1", status_name="In Progress"),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "11", "name": "Send Back",
+                 "to": {"id": "10000", "name": "To Do"}},
+                {"id": "31", "name": "Resolve Issue",
+                 "to": {"id": "10004", "name": "Done"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _issue_response("AGENT-1", status_name="Done"),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("AGENT-1", "DONE")
+        transition_call = next(
+            c for c in calls
+            if c["url"].endswith("/transitions") and c["method"] == "POST"
+        )
+        sent = json.loads(transition_call["body"])
+        # Must match id=31 (via to.name="Done"), NOT id=11 (which would
+        # match neither field). Old behavior is preserved.
+        assert sent["transition"]["id"] == "31", sent
+
+
+# --- (c) reconcile skips query 1 when no DSL transitions ----------------
+
+
+def test_detect_reconcile_skips_when_no_transitions():
+    """No DSL → no mapped_statuses → no `status not in (...)` filter to
+    construct → query 1 must not fire (we'd otherwise build invalid JQL
+    or return every open card as 'unmapped'). Only missing-AP runs."""
+    queue = [
+        # Only the missing-AP query
+        _Response(200, json.dumps({"issues": [
+            {"key": "A-9", "fields": {"status": {"name": "x"}}},
+        ]}).encode(), {}),
+    ]
+    calls: list[dict] = []
+    c = _mock_client(queue, calls)
+    unmapped, missing, errs = _jira_setup._detect_reconcile(
+        c, "AGENT", transitions={},
+        ap_field_id="customfield_10042", repo_ap="agent-fin",
+    )
+    assert unmapped == {}
+    assert missing == ["A-9"]
+    assert errs == []
+    assert len(calls) == 1, calls
+    # Single call must be the missing-AP query
+    payload = json.loads((calls[0]["body"] or b"{}").decode())
+    assert "is EMPTY" in payload.get("jql", "")
+
+
+# --- (d) (e) _jql_quote_ts ----------------------------------------------
+
+
+def test_jql_quote_ts_normalizes_iso_with_offset():
+    """ISO-8601 with timezone offset is what `cmd_find_mentions` produces
+    by default. Jira JQL silently rejects this format (#26) — must be
+    converted to canonical `yyyy-MM-dd HH:mm`."""
+    fn = _jira_setup._jql_quote_ts
+    # The exact input that broke production (per #26)
+    assert fn("2026-05-02T11:44:37+08:00") == "2026-05-02 11:44"
+    # UTC offset
+    assert fn("2026-05-02T00:00:00+00:00") == "2026-05-02 00:00"
+    # No-offset ISO (still a `T` separator) → also normalized
+    assert fn("2026-05-02T11:44:37") == "2026-05-02 11:44"
+
+
+def test_jql_quote_ts_handles_canonical_short_forms():
+    """Already-canonical formats produce JQL-friendly output: ISO date-only
+    parses and gets normalized to `yyyy-MM-dd 00:00` (still JQL-canonical);
+    slash-form (which fromisoformat can't parse) passes through unchanged.
+    Either way the result is something JQL accepts."""
+    fn = _jira_setup._jql_quote_ts
+    # Date-only ISO parses; emerges as yyyy-MM-dd 00:00 (JQL accepts this).
+    assert fn("2026-05-02") == "2026-05-02 00:00"
+    # Slash-form is not ISO — fromisoformat raises, falls through unchanged.
+    assert fn("2026/05/02 00:00") == "2026/05/02 00:00"
+
+
+def test_jql_quote_ts_rejects_quote_injection():
+    """Defensive — protects against any caller-side `since` containing
+    a `"` that would break the JQL string literal."""
+    try:
+        _jira_setup._jql_quote_ts('2026-05-02"; OR 1=1 --')
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError on quoted timestamp")
+
+
+# --- (f) cmd_find_mentions sends rewritten timestamp --------------------
+
+
+def test_find_mentions_sends_normalized_timestamp_in_jql():
+    """The default-since ISO-with-offset path is the regression that
+    masked production mentions. Verify the resulting JQL uses the
+    canonical short form."""
+    queue = [
+        # search_jql response — empty issues, but we only care about the
+        # outgoing JQL.
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+    ]
+    calls: list[dict] = []
+    c = _mock_client(queue, calls)
+
+    with tempfile.TemporaryDirectory() as td:
+        kp = pathlib.Path(td) / "kanban.json"
+        kp.write_text(json.dumps({
+            "version": "0.2",
+            "backend": {"driver": "jira", "jira": {
+                "projectKey": "AGENT",
+                "agentAccountId": "5e-agent",
+                "ap": {"fieldId": "customfield_10042"},
+            }},
+            "meta": {"priorities": ["P0"], "categories": [],
+                     "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                                 "DONE", "CANCELLED"],
+                     "created_at": "x", "updated_at": "x"},
+            "tasks": [],
+        }))
+        orig_client = _jira_setup._client_from_env
+        _jira_setup._client_from_env = lambda: c
+        try:
+            class A:
+                kanban_path = str(kp)
+                since = "2026-05-02T11:44:37+08:00"
+            rc, out = _capture(_jira_setup.cmd_find_mentions, A())
+        finally:
+            _jira_setup._client_from_env = orig_client
+
+    assert rc == 0, out
+    payload = json.loads((calls[0]["body"] or b"{}").decode())
+    jql = payload.get("jql", "")
+    # Canonical form embedded in the JQL string
+    assert '"2026-05-02 11:44"' in jql, jql
+    # The broken ISO+offset form must NOT appear
+    assert "+08:00" not in jql, jql
+
+
+# --- (g) ADF strong-mark prefix in @-mention path -----------------------
+
+
+def test_post_comment_with_mention_uses_adf_strong_prefix():
+    """The mention path used to embed `**[ap] [C]**` as a literal text
+    node in the prefix paragraph — Jira UI rendered raw `**` plus broken
+    `<span class="error">` around the brackets (#27). Verify the prefix
+    paragraph now carries an ADF `strong` mark and contains no `*`."""
+    data = _seed_jira_data()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj, ap="narrative-fin-agent")
+        drv = _patched_driver(data, proj)
+        queue = [_Response(201, b'{"created":"2026-05-02T00:00:00+08:00"}', {})]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.base import CommentKind
+        drv.post_comment(
+            "AGENT-1", "hello",
+            CommentKind.COMMENT,
+            mention_account_id="kirin-account-id",
+            mention_display="Kirin Chen",
+        )
+        sent = json.loads(calls[0]["body"])
+        adf = sent["body"]
+        paras = adf["content"]
+        # Prefix paragraph: bold, no markdown asterisks
+        prefix_para = paras[0]
+        assert prefix_para["type"] == "paragraph"
+        prefix_node = prefix_para["content"][0]
+        assert prefix_node["type"] == "text"
+        assert prefix_node["text"] == "[narrative-fin-agent] [C]"
+        assert "*" not in prefix_node["text"]
+        assert {"type": "strong"} in prefix_node["marks"]
+        # Mention paragraph: starts with the @-mention node
+        mention_para = paras[1]
+        first = mention_para["content"][0]
+        assert first["type"] == "mention"
+        assert first["attrs"]["id"] == "kirin-account-id"
+
+
+# --- driver -------------------------------------------------------------
+
+
+def main() -> int:
+    cases = [
+        ("transition_matches_by_action_name_when_status_localized",
+         test_transition_matches_by_action_name_when_status_localized),
+        ("transition_still_matches_by_destination_status_name",
+         test_transition_still_matches_by_destination_status_name),
+        ("detect_reconcile_skips_when_no_transitions",
+         test_detect_reconcile_skips_when_no_transitions),
+        ("jql_quote_ts_normalizes_iso_with_offset",
+         test_jql_quote_ts_normalizes_iso_with_offset),
+        ("jql_quote_ts_handles_canonical_short_forms",
+         test_jql_quote_ts_handles_canonical_short_forms),
+        ("jql_quote_ts_rejects_quote_injection",
+         test_jql_quote_ts_rejects_quote_injection),
+        ("find_mentions_sends_normalized_timestamp_in_jql",
+         test_find_mentions_sends_normalized_timestamp_in_jql),
+        ("post_comment_with_mention_uses_adf_strong_prefix",
+         test_post_comment_with_mention_uses_adf_strong_prefix),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase19: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase19: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase2.py
+++ b/plugins/kanban/scripts/test_phase2.py
@@ -310,10 +310,23 @@ def test_post_comment_prefixes():
 
     drv.post_comment("AGENT-1", "Body of question?", CommentKind.QUESTION)
     sent = json.loads(calls[0]["body"])
+    # v0.3.12 (#27): prefix is now an ADF strong-marked text node in its
+    # own paragraph — emitting `**...**` markdown literals broke Jira UI
+    # rendering. adf_to_text drops the marks and returns canonical text.
     body_text = adf_to_text(sent["body"])
-    assert body_text.startswith("**[")
-    assert "[Q]" in body_text
+    # No repo_ap configured in the temp project → fallback "agent" is used.
+    assert body_text.startswith("[agent] [Q]"), body_text
     assert "Body of question?" in body_text
+    # Verify the actual ADF shape so a regression to markdown-string mode
+    # is caught loudly: first paragraph has the prefix as a strong text
+    # node, second paragraph is the body as plain text.
+    paras = sent["body"]["content"]
+    assert paras[0]["type"] == "paragraph"
+    p0 = paras[0]["content"][0]
+    assert p0["type"] == "text"
+    assert p0["text"] == "[agent] [Q]"
+    assert {"type": "strong"} in p0["marks"]
+    assert paras[1]["content"][0]["text"] == "Body of question?"
 
 
 def test_list_comments_parses_prefix():


### PR DESCRIPTION
## Summary

Three orthogonal regressions surfaced after the morning's #16–#21 batch shipped. All three are tightly scoped — one PR is cheaper than three rounds of test/merge/verify.

- **#17 (re-opened) — transition lookup + reconcile are now locale-immune.** `Accept-Language: en-US` (added in 0.3.9) fixed JQL paths but does NOT untranslate the `to.name` field on `/transitions` responses; Atlassian still returns `審查` for canonical `REVIEW` on a zh-TW account. `transition()` now matches by the transition action name (`t["name"]`, English-canonical) first, with the destination-status-name match kept as a fallback for English-locale workflows whose action and status names differ. `/kanban:reconcile` had the same root cause — it compared raw `status.name` against DSL names client-side; the fix moves the filter server-side via JQL `status not in (...)`, which JQL evaluates canonically regardless of UI locale.
- **#26 — `find-mentions` silently returned 0.** `_jql_quote_ts()` was a passthrough that handed Jira full ISO-8601 with timezone offsets (`2026-05-02T11:44:37+08:00`) — JQL silently rejects this format. Now normalizes to canonical `yyyy-MM-dd HH:mm`. Same fix flows through `cmd_sync_summary`'s mentions block (shared call site).
- **#27 — agent comment prefix rendered broken in Jira UI.** SPEC §9 prefix was authored as markdown literal `**[ap] [kind]**` inside a single ADF text node; ADF doesn't parse markdown so Jira emitted raw `**` plus broken `<span class=\"error\">`. The prefix is now an ADF strong-marked text node in its own paragraph, body in a second paragraph. `_PREFIX_RE` accepts both forms so old comments still parse.

Closes #17
Closes #26
Closes #27

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 19 phases green (108 checks)
- [x] Phase 19 (8 new cases): action-name fallback for zh-TW workflow, destination-status-name fallback for English locale, reconcile skips query 1 when no DSL transitions, `_jql_quote_ts` ISO-with-offset normalization + canonical-form passthrough + quote-injection refusal, `cmd_find_mentions` sends rewritten timestamp in JQL, `post_comment` mention path emits ADF strong-mark prefix
- [x] Phase 18 mocks updated to mirror new server-side filter (mapped cards never reach the client)
- [x] Phase 2 `post_comment_prefixes` asserts new ADF shape directly so any regression to markdown-literal mode fails loudly
- [ ] Manual verify on zh-TW Jira account: `/kanban:transition --to REVIEW` succeeds; `/kanban:reconcile` doesn't false-flag localized REVIEW cards; `/kanban:mentions` returns expected count; agent comment renders bold-prefix in Jira UI (no raw `**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)