### PR TITLE
fix(mentor): 0.2.3 — agent_behavior.session_end_summary opt-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "mentor",
       "source": "./plugins/mentor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "description": "Onboarding mentor for Claude Code — prescribes bootstrap reading, doc hierarchy (Epic/Sprint/Issue/ADR), and agent workflow. Replaces docsync.",
       "category": "developer-tools",
       "keywords": ["onboarding", "framework", "epic", "sprint", "issue", "adr", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,33 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (mentor session-end summary opt-out)
+
+### Added
+- **mentor 0.2.3** — `agent_behavior.session_end_summary` flag in
+  `mentor.yaml`. Default `true` preserves prior behavior; set to `false`
+  to silence the Stop-hook user-visible summary. Closes #29.
+
+  Stop hooks fire on every turn boundary in Claude Code, not just at
+  true session end, so `mentor-finalcheck.py` was reprinting the same
+  20-line "Documents touched this session" + violations block after
+  every assistant reply — drowning out the actual end-of-turn message
+  for doc-heavy projects (active Sprint planning, ADR drafting).
+  Previously the only way to silence it was to disable the entire
+  `mentor` plugin, losing SessionStart bootstrap, PreToolUse mentor-
+  guard, and all `/mentor:*` skills along with it.
+
+  The flag gates only the user-visible `systemMessage` print. The
+  side effects in the same hook — `_fanout_memory` (Sprint retro / ADR
+  capture into workbench-memory) and `review()` — keep running, since
+  they're governed by separate knobs (`integration.memory_save_*`) and
+  are no-ops when nothing's transitioned. One knob, one job.
+
+  `mentor.example.yaml` carries a commented-out `session_end_summary:
+  true` line so users discover the knob; the schema declares it under
+  `agent_behavior.properties` (the schema is `additionalProperties:
+  false`, so without the declaration the field would be rejected).
+
 ## 2026-05-02 (locale + JQL + ADF fixes)
 
 ### Fixed

--- a/plugins/mentor/.claude-plugin/plugin.json
+++ b/plugins/mentor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mentor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Onboarding mentor for Claude Code — prescribes bootstrap reading, document hierarchy (Epic/Sprint/Issue/ADR), and agent workflow. Replaces the earlier `docsync` plugin with a broader, framework-driven design. Dev profile.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirinchen/claude-workbench",

--- a/plugins/mentor/scripts/framework_engine.py
+++ b/plugins/mentor/scripts/framework_engine.py
@@ -208,6 +208,12 @@ class AgentBehavior:
     require_issue_context: bool = True
     auto_retrospective: bool = True
     require_adr_on_decision: bool = True
+    # When False, mentor-finalcheck.py skips its user-visible summary
+    # (touched docs + violations) on every Stop hook firing. Memory
+    # fan-out and review() still run — those have their own knobs under
+    # `integration.memory_save_*`. Default True preserves prior behavior
+    # (#29).
+    session_end_summary: bool = True
 
 
 @dataclass
@@ -251,6 +257,7 @@ class MentorConfig:
             require_issue_context=bool(ab_raw.get("require_issue_context", True)),
             auto_retrospective=bool(ab_raw.get("auto_retrospective", True)),
             require_adr_on_decision=bool(ab_raw.get("require_adr_on_decision", True)),
+            session_end_summary=bool(ab_raw.get("session_end_summary", True)),
         )
         tpl = raw.get("templates") or {}
         integ_raw = raw.get("integration") or {}
@@ -555,6 +562,7 @@ def config_to_dict(cfg: MentorConfig) -> dict:
             "require_issue_context": cfg.agent_behavior.require_issue_context,
             "auto_retrospective": cfg.agent_behavior.auto_retrospective,
             "require_adr_on_decision": cfg.agent_behavior.require_adr_on_decision,
+            "session_end_summary": cfg.agent_behavior.session_end_summary,
         },
         "templates": {
             "source": cfg.templates_source,

--- a/plugins/mentor/scripts/mentor-finalcheck.py
+++ b/plugins/mentor/scripts/mentor-finalcheck.py
@@ -116,6 +116,22 @@ def main() -> int:
     touched = _categorise(changed, cfg)
     violations = review(proj, cfg)
 
+    # Memory fan-out runs regardless of the summary flag — it's gated by
+    # its own `integration.memory_save_*` knobs, and the per-doc status
+    # check inside _fanout_memory means a no-op when nothing's transitioned.
+    try:
+        _fanout_memory(proj, cfg, touched)
+    except Exception:
+        pass
+
+    # Stop hooks fire on every turn boundary in Claude Code, not just at
+    # true session end. Doc-heavy projects see the same summary repeated
+    # many times per session, drowning out the assistant's actual reply.
+    # `agent_behavior.session_end_summary: false` opts out of the user-
+    # visible print while keeping review/memory side effects above (#29).
+    if not cfg.agent_behavior.session_end_summary:
+        return 0
+
     lines: list[str] = []
     lines.append(f"mentor: session-end summary (mode: {cfg.mode}).")
 
@@ -136,12 +152,6 @@ def main() -> int:
             lines.append(f"  - [{v.kind}] {v.path}: {v.detail}")
         if len(violations) > 10:
             lines.append(f"  … {len(violations) - 10} more; run `workbench-mentor review` to see all.")
-
-    # Memory fan-out (best-effort, never fatal)
-    try:
-        _fanout_memory(proj, cfg, touched)
-    except Exception:
-        pass
 
     if len(lines) == 1:  # only the header — nothing interesting
         return 0

--- a/plugins/mentor/templates/mentor.example.yaml
+++ b/plugins/mentor/templates/mentor.example.yaml
@@ -30,6 +30,11 @@ agent_behavior:
   auto_retrospective: true
   # Write an ADR when a non-trivial decision is made (development mode)
   require_adr_on_decision: true
+  # Set false to silence the Stop-hook "session-end summary" block that
+  # otherwise prints after every turn boundary (Claude Code fires Stop
+  # per turn, not per process exit). Memory fan-out + review() still
+  # run — those have their own knobs under integration.memory_save_*.
+  # session_end_summary: true
 
 # Template source
 templates:

--- a/plugins/mentor/templates/mentor.schema.json
+++ b/plugins/mentor/templates/mentor.schema.json
@@ -42,7 +42,11 @@
         },
         "require_issue_context": { "type": "boolean" },
         "auto_retrospective": { "type": "boolean" },
-        "require_adr_on_decision": { "type": "boolean" }
+        "require_adr_on_decision": { "type": "boolean" },
+        "session_end_summary": {
+          "type": "boolean",
+          "description": "When false, the Stop-hook user-visible summary (touched docs + violations) is suppressed. Memory fan-out and review still run. Default true."
+        }
       }
     },
     "templates": {


### PR DESCRIPTION
## Summary

Stop hooks fire on every turn boundary in Claude Code, not just at true session end — so `mentor-finalcheck.py` was reprinting its "Documents touched this session" + violations block after every assistant reply. For doc-heavy projects (active Sprint planning, ADR drafting) this drowns out the actual end-of-turn message. Disabling the whole `mentor` plugin was the only workaround, but that loses SessionStart bootstrap, PreToolUse mentor-guard, and all `/mentor:*` skills along with it.

This PR adds `agent_behavior.session_end_summary` to `mentor.yaml`. **Default `true`** preserves prior behavior; set to `false` to silence the user-visible summary print.

The flag gates *only* the `systemMessage` print. `_fanout_memory` (Sprint retro / ADR capture into `workbench-memory`) and `review()` keep running regardless — they have separate knobs under `integration.memory_save_*` and are no-ops when nothing's transitioned. One knob, one job.

Closes #29

## Files

- `plugins/mentor/scripts/framework_engine.py` — `AgentBehavior` dataclass field + `from_dict` parse + dump dict
- `plugins/mentor/scripts/mentor-finalcheck.py` — restructured: memory fan-out runs unconditionally, then early-return if flag is false
- `plugins/mentor/templates/mentor.schema.json` — declare `session_end_summary` (schema is `additionalProperties: false`, so without this the field would be rejected)
- `plugins/mentor/templates/mentor.example.yaml` — commented-out `session_end_summary: true` so users discover the knob
- Version bump 0.2.2 → 0.2.3, CHANGELOG entry

## Test plan

- [x] Manual: default config (no `session_end_summary` key) → full summary block printed (mode header + 4 compliance issues)
- [x] Manual: same config with `session_end_summary: false` → empty stdout, exit 0
- [x] Memory fan-out runs in both cases (verified by code path — no `git diff` to the order it executes in)
- [ ] Manual: in a real doc-heavy session, set `false` and confirm Stop hook is silent across multiple turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)