### PR TITLE
fix(kanban): 0.3.13 — health oracle for by-code init + notes guardrail 300→1024

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.12",
+      "version": "0.3.13",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-02 (kanban health oracle + notes guardrail)
+
+### Fixed
+- **kanban 0.3.13** — `/kanban:initjira-by-code` step 1 was using
+  `health` as the oracle for "are Jira credentials present?", but at
+  that point `kanban.json#backend.driver` is still `"local"` (nothing has
+  switched it to `"jira"` yet) so health runs against `LocalDriver` —
+  which has nothing Jira-related to check and unconditionally returns
+  `ok=true`. Callers silently bypassed credential capture; the failure
+  was masked further by `import-jira-code` succeeding offline (it only
+  writes config), surfacing only at `live-list-aps` several steps later
+  with an empty roster. Closes #31.
+
+  - `commands/initjira-by-code.md` step 1 now uses `read-credentials`
+    + checks `tokenPresent` (the same pattern `initjira.md` was already
+    using). Documents the trap explicitly so future readers don't repeat
+    it: "Do **not** use the `health` helper as the oracle here".
+  - `cmd_health` (`scripts/jira_setup.py`) appends a self-documenting
+    hint to `detail` when the active driver is local: `"local driver —
+    Jira credentials not checked; use read-credentials"`. `ok` stays
+    `true` because the local driver IS healthy in its own right —
+    flipping it would break `/kanban:init`'s legitimate post-init
+    health check. The hint surfaces the misuse to anyone who prints
+    `detail`.
+  - Phase 20 covers the new behavior: `cmd_health` on a local-backend
+    `kanban.json` returns `ok=true` with `local driver` + `read-creden\
+tials` in `detail`; on a `jira` backend the local-driver hint is NOT
+    appended (so it can't pollute real auth-failure messages).
+
+### Changed
+- **kanban 0.3.13** — `conventions.notes[*]` guardrail bumped 300 → 1024
+  chars per note. Notes are increasingly carrying richer narrative
+  (multi-sentence team-pattern descriptions, links to ADRs / SOPs);
+  300 was too tight in practice. The guardrail is still a warning, not
+  an error — reasonable long-form material stays in ADRs, but a single
+  paragraph of context now fits without tripping the linter. Phase 11
+  test thresholds adjusted (1100 chars → over, 900 → under).
+
 ## 2026-05-02 (mentor session-end summary opt-out)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/edit-conventions.md
+++ b/plugins/kanban/commands/edit-conventions.md
@@ -30,7 +30,7 @@ For each existing note (in order), ask via `AskUserQuestion`:
 > Note <N>: "<existing text>"
 >   [k]eep / [e]dit / [d]elete
 
-On `e`: capture the new text. Validate length ≤ 200 chars. If longer,
+On `e`: capture the new text. Validate length ≤ 1024 chars. If longer,
 warn and ask whether to truncate or re-enter.
 
 After cycling through existing notes, ask:

--- a/plugins/kanban/commands/initjira-by-code.md
+++ b/plugins/kanban/commands/initjira-by-code.md
@@ -29,11 +29,22 @@ You still need:
 
 ## Step 1/3 — Credentials
 
-If `~/.claude-workbench/.env` already has valid Jira credentials (run
-`/kanban:whoami` or the `health` helper to check), skip. Otherwise run
-the same Step 1 flow as `/kanban:initjira` (capture base URL, agent
-email, API token; validate via `validate-credentials`; persist via
-`store-credentials`).
+If `~/.claude-workbench/.env` already has valid Jira credentials, skip.
+To check, call `read-credentials` and verify `tokenPresent` is true:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
+# expect: {"baseUrl": "...", "email": "...", "tokenPresent": true}
+```
+
+Do **not** use the `health` helper as the oracle here — at this point
+`kanban.json#backend.driver` is still `"local"` (nothing has switched it
+to `"jira"` yet), so `health` runs against the local driver and returns
+`ok=true` regardless of whether Jira credentials exist. See #31.
+
+If credentials are missing, run the same Step 1 flow as `/kanban:initjira`
+(capture base URL, agent email, API token; validate via
+`validate-credentials`; persist via `store-credentials`).
 
 ## Step 2/3 — Paste and import the code
 

--- a/plugins/kanban/lib/conventions.py
+++ b/plugins/kanban/lib/conventions.py
@@ -13,7 +13,7 @@ This module owns the conventions block: validation, hashing for ack, and
 the small public surface needed by the slash commands and helper CLI.
 
 Public surface:
-    DEFAULT_NOTES_MAX_LEN          # 200 chars per note
+    DEFAULT_NOTES_MAX_LEN          # 1024 chars per note
     DEFAULT_NOTES_MAX_COUNT        # 10 notes total
     validate(conventions) -> list[str]            # warnings, never errors
     hash_conventions(conventions) -> str          # stable for ack tracking
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 
-DEFAULT_NOTES_MAX_LEN = 300
+DEFAULT_NOTES_MAX_LEN = 1024
 DEFAULT_NOTES_MAX_COUNT = 10
 
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -2561,7 +2561,19 @@ def cmd_health(args: argparse.Namespace) -> int:
 
     driver = get_driver(data, p.parent)
     h = driver.health()
-    _emit({"ok": h.status.value == "ok", "status": h.status.value, "detail": h.detail})
+    detail = h.detail
+    # `LocalDriver.health()` is unconditionally ok — it has nothing
+    # Jira-related to check. Callers that use `health` to gate "are Jira
+    # credentials set up?" silently bypass credential capture when the
+    # backend is still local (the by-code init flow before #31 fix).
+    # Append a hint so any caller who prints `detail` self-diagnoses.
+    # `ok` stays true because the local driver IS healthy in its own
+    # right — flipping it would break /kanban:init's legitimate
+    # post-init health check.
+    if driver.name == "local":
+        hint = "local driver — Jira credentials not checked; use read-credentials"
+        detail = f"{detail}; {hint}" if detail else hint
+    _emit({"ok": h.status.value == "ok", "status": h.status.value, "detail": detail})
     return 0
 
 

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; do  # 8-19: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do  # 8-20: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase11.py
+++ b/plugins/kanban/scripts/test_phase11.py
@@ -62,13 +62,14 @@ def test_normalize_fills_defaults_drops_unknown():
 
 
 def test_validate_flags_guardrails():
-    # Guardrail bumped 200 → 300 in 0.3.10 (issue #20). 350 chars is
-    # over the new threshold; verify the warning text reflects it.
-    warns = cv.validate({"notes": ["a" * 350, "ok"]})
-    assert any("350 chars" in w for w in warns)
-    # 250 chars is under the new threshold — should NOT warn.
-    warns = cv.validate({"notes": ["a" * 250]})
-    assert all("250 chars" not in w for w in warns)
+    # Guardrail bumped 200 → 300 in 0.3.10 (issue #20), then 300 → 1024
+    # in 0.3.13 (notes carry richer narrative now). 1100 chars is over
+    # the threshold; verify the warning text reflects it.
+    warns = cv.validate({"notes": ["a" * 1100, "ok"]})
+    assert any("1100 chars" in w for w in warns)
+    # 900 chars is under the new threshold — should NOT warn.
+    warns = cv.validate({"notes": ["a" * 900]})
+    assert all("900 chars" not in w for w in warns)
     warns = cv.validate({"notes": ["x"] * 15})
     assert any("15 entries" in w for w in warns)
     warns = cv.validate({"notes": ["", "   ", "real"]})
@@ -282,8 +283,8 @@ def test_set_conventions_writes_and_warns():
     with tempfile.TemporaryDirectory() as raw:
         td = pathlib.Path(raw)
         kp = _seed_jira(td)
-        # 0.3.10 bumped guardrail to 300; use 350 to trigger the warning.
-        notes = ["a" * 350, "ok note"]
+        # 0.3.13 bumped guardrail to 1024; use 1100 to trigger the warning.
+        notes = ["a" * 1100, "ok note"]
         out = _run(
             "set-conventions",
             "--kanban-path", str(kp),
@@ -293,7 +294,7 @@ def test_set_conventions_writes_and_warns():
         assert out.returncode == 0, out.stderr
         j = json.loads(out.stdout)
         assert j["ok"] is True
-        assert any("350 chars" in w for w in j["warnings"])
+        assert any("1100 chars" in w for w in j["warnings"])
         cfg = json.loads(kp.read_text())["backend"]["jira"]
         assert cfg["conventions"]["notes"] == notes
 

--- a/plugins/kanban/scripts/test_phase20.py
+++ b/plugins/kanban/scripts/test_phase20.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Phase 20 regression checks for kanban v0.3.13 — `cmd_health` hint
+when the active driver is local.
+
+Closes #31. The `health` helper was being used as the oracle for "are
+Jira credentials present?" in `/kanban:initjira-by-code` step 1 — but at
+that point `kanban.json#backend.driver` is still `"local"`, so health
+runs against `LocalDriver` (which has nothing Jira-related to check)
+and unconditionally returns ok. Callers silently bypassed credential
+capture and only failed multiple steps later.
+
+The fix on the slash-command side is a doc change (use `read-credentials`
++ `tokenPresent`). On the helper side we can't safely flip `ok` to false
+for the local driver — `/kanban:init`'s legitimate post-init health
+check would break. Instead we append a hint to the `detail` field so
+any caller that prints it self-diagnoses the misuse.
+
+Cases:
+  (a) `cmd_health` with `backend.driver == "local"` keeps `ok=true` but
+      `detail` mentions `local driver` and `read-credentials`.
+  (b) `cmd_health` with `backend.driver == "jira"` (and missing creds —
+      i.e. unauthenticated) returns the underlying driver detail
+      unchanged — the local-driver hint is NOT appended.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+def _seed_local_kanban(td: pathlib.Path) -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "local"},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _seed_jira_kanban(td: pathlib.Path) -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "transitions": {"TODO": {"status": "To Do"}},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def test_health_local_driver_appends_hint():
+    """LocalDriver is fine on its own (ok=true) but health is the wrong
+    oracle for 'are Jira creds set up?' — detail must self-document so
+    any caller that prints it spots the misuse."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_local_kanban(td)
+
+        class A:
+            kanban_path = str(kp)
+
+        rc, out = _capture(_jira_setup.cmd_health, A())
+        assert rc == 0
+        j = json.loads(out)
+        assert j["ok"] is True
+        # Status from LocalDriver is still "ok"
+        assert j["status"] == "ok"
+        # Hint surfaces in detail
+        detail = j["detail"] or ""
+        assert "local driver" in detail.lower()
+        assert "read-credentials" in detail
+
+
+def test_health_jira_driver_no_local_hint():
+    """When backend is `jira`, the local-driver hint must NOT contaminate
+    the detail field — that would mislead users on real auth failures."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        # Force unauthenticated state by clearing credential env vars
+        # AND pointing credentials.read at an empty payload.
+        from lib import credentials
+        orig = credentials.read
+        credentials.read = lambda prefix=None: {}
+        try:
+            class A:
+                kanban_path = str(kp)
+            rc, out = _capture(_jira_setup.cmd_health, A())
+        finally:
+            credentials.read = orig
+        assert rc == 0
+        j = json.loads(out)
+        # Whatever the underlying status is, the local-driver hint must
+        # not appear here.
+        detail = j["detail"] or ""
+        assert "local driver" not in detail.lower(), detail
+
+
+def main() -> int:
+    cases = [
+        ("health_local_driver_appends_hint",
+         test_health_local_driver_appends_hint),
+        ("health_jira_driver_no_local_hint",
+         test_health_jira_driver_no_local_hint),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase20: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase20: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two unrelated changes batched into one PR.

### #31 — `health` was the wrong oracle in `/kanban:initjira-by-code` step 1

At step 1 of the by-code flow, `kanban.json#backend.driver` is still `"local"` (nothing has switched it to `"jira"` yet). The slash-command spec told the agent to use the `health` helper to check whether Jira credentials are present — but `health` runs against `LocalDriver` in this state, which has nothing Jira-related to check and unconditionally returns `ok=true`. The agent silently bypassed credential capture; `import-jira-code` succeeded offline (it only writes config), so the real failure surfaced multiple steps later at `live-list-aps` with an empty roster.

Two-pronged fix:

- `commands/initjira-by-code.md` step 1 now uses `read-credentials` + `tokenPresent` (the same pattern `initjira.md` was already using). Explicit "Do **not** use the `health` helper as the oracle here" so future readers don't repeat the trap.
- `cmd_health` appends a self-documenting hint to `detail` when the active driver is local: `"local driver — Jira credentials not checked; use read-credentials"`. `ok` stays `true` because `LocalDriver` IS healthy in its own right — flipping it would break `/kanban:init`'s legitimate post-init health check. The hint surfaces the misuse to anyone who prints `detail`.

### Notes guardrail bumped 300 → 1024

`conventions.notes[*]` was capped at 300 chars in 0.3.10. In practice notes carry richer narrative now (multi-sentence team-pattern descriptions, links to ADRs / SOPs); 300 was too tight. Still a warning, not an error. `edit-conventions.md` prompt updated; phase 11 test thresholds adjusted.

Closes #31

## Files

- `plugins/kanban/scripts/jira_setup.py` — `cmd_health` local-driver hint
- `plugins/kanban/commands/initjira-by-code.md` — step 1 rewrite (~10 LOC)
- `plugins/kanban/lib/conventions.py` — `DEFAULT_NOTES_MAX_LEN` 300→1024 + docstring
- `plugins/kanban/commands/edit-conventions.md` — prompt updated
- `plugins/kanban/scripts/test_phase11.py` — thresholds 350/250 → 1100/900
- `plugins/kanban/scripts/test_phase20.py` — new (2 cases)
- `plugins/kanban/scripts/test_all.sh` — wire phase 20
- Version bump 0.3.12 → 0.3.13, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 20 phases green
- [x] Phase 20 (2 new cases): `cmd_health` on local backend → `ok=true` + detail mentions `local driver` and `read-credentials`; on jira backend → local-driver hint NOT appended (no contamination of real auth-failure messages)
- [x] Phase 11 covers new threshold (1100 over, 900 under)
- [ ] Manual: fresh machine, no `JIRA_API_TOKEN` in `.env`, run `/kanban:initjira-by-code` → step 1 now correctly detects missing creds and runs capture flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)