### PR TITLE
feat(kanban): 0.3.15 — set-conventions append/remove/set-toggle flags

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,39 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-03 (kanban set-conventions incremental flags)
+
+### Added
+- **kanban 0.3.15** — `set-conventions` accepts three new flags for
+  incremental mutation, mutually exclusive with the existing
+  `--conventions-json` full-replace mode. Closes #36.
+
+  - `--append-note "..."` — append a note to `conventions.notes`.
+    Idempotent: exact-text duplicates of existing notes are silently
+    skipped, so slash-command flows that re-run on the same input
+    won't double up. Repeat the flag to append several notes in one
+    call.
+  - `--remove-note "..."` — drop a note by exact-text match. Notes
+    that don't exist are a no-op.
+  - `--set-toggle KEY=VALUE` — set a single toggle (e.g.
+    `blockedRequiresLink=false`). Booleans are recognised
+    case-insensitively (`true` / `TRUE` / `false` / `FALSE`);
+    everything else is stored as a string.
+
+  Why this matters: the original `--conventions-json` mode required
+  callers to faithfully reproduce the entire block to add a single
+  rule. For LLM-driven slash-command flows that round-trip is risky —
+  an agent that paraphrases an existing note on the way through
+  silently overwrites it ("why did this rule disappear" mysteries).
+  The incremental flags let callers atomically mutate the block
+  without reproducing existing material.
+
+  Phase 22 covers seven cases: append idempotency, remove no-op when
+  absent, toggle bool conversion (case-insensitive), mutual
+  exclusion with `--conventions-json`, "require at least one mode"
+  guard, full-replace back-compat, and a combo call exercising all
+  three incremental flags together.
+
 ## 2026-05-03 (kanban create_task fixup PUT)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -992,28 +992,82 @@ def cmd_import_jira_code(args: argparse.Namespace) -> int:
 def cmd_set_conventions(args: argparse.Namespace) -> int:
     """Persist `backend.jira.conventions` to kanban.json.
 
-    Accepts a full conventions block (notes + per-team toggles) as JSON.
+    Two modes (mutually exclusive):
+
+      Full replace — `--conventions-json '{"notes": [...], ...}'`. The
+      block is replaced wholesale.
+
+      Incremental — `--append-note`, `--remove-note`, `--set-toggle
+      KEY=VAL`. The existing block is loaded, the requested mutations
+      applied (append is idempotent: exact-text dups skipped), then
+      saved. Useful for slash commands that want to add a single rule
+      without faithfully reproducing the rest (which an LLM might
+      paraphrase on round-trip — exactly the kind of subtle drift that
+      causes "why did this rule disappear" mysteries). See #36.
+
     Validation is advisory — guardrails surface as `warnings`, never
     block the write.
     """
     p = Path(args.kanban_path)
     if not p.exists():
         return _fail(f"kanban.json not found at {p}")
-    try:
-        incoming = json.loads(args.conventions_json)
-    except json.JSONDecodeError as e:
-        return _fail(f"--conventions-json is not valid JSON: {e}")
-    if not isinstance(incoming, dict):
-        return _fail("--conventions-json must be a JSON object")
 
-    normalized = _cv.normalize(incoming)
-    warnings = _cv.validate(normalized)
+    incremental = bool(
+        args.append_note or args.remove_note or args.set_toggle
+    )
+    if args.conventions_json and incremental:
+        return _fail(
+            "--conventions-json cannot be combined with --append-note / "
+            "--remove-note / --set-toggle (full replace vs. incremental "
+            "mutate are different modes — pick one)"
+        )
+    if not args.conventions_json and not incremental:
+        return _fail(
+            "set-conventions requires either --conventions-json (full "
+            "replace) or one of --append-note / --remove-note / "
+            "--set-toggle (incremental mutate)"
+        )
 
     data = kanban_io.load(p)
     backend = data.setdefault("backend", {"driver": "jira"})
     if backend.get("driver") != "jira":
         return _fail("backend.driver must be 'jira'")
     jira_cfg = backend.setdefault("jira", {})
+
+    if args.conventions_json:
+        try:
+            incoming = json.loads(args.conventions_json)
+        except json.JSONDecodeError as e:
+            return _fail(f"--conventions-json is not valid JSON: {e}")
+        if not isinstance(incoming, dict):
+            return _fail("--conventions-json must be a JSON object")
+    else:
+        # Incremental: start from the current normalized block, mutate.
+        incoming = dict(_cv.normalize(jira_cfg.get("conventions")))
+        notes = list(incoming.get("notes") or [])
+        # Append (idempotent — skip exact-text duplicates)
+        for n in args.append_note:
+            if n not in notes:
+                notes.append(n)
+        # Remove (no-op if absent)
+        if args.remove_note:
+            removeset = set(args.remove_note)
+            notes = [n for n in notes if n not in removeset]
+        incoming["notes"] = notes
+        # Toggles (KEY=VAL; boolean detection is case-insensitive)
+        for spec in args.set_toggle:
+            if "=" not in spec:
+                return _fail(
+                    f"--set-toggle expects KEY=VALUE form, got {spec!r}"
+                )
+            k, _, v = spec.partition("=")
+            if v.lower() in ("true", "false"):
+                incoming[k] = (v.lower() == "true")
+            else:
+                incoming[k] = v
+
+    normalized = _cv.normalize(incoming)
+    warnings = _cv.validate(normalized)
     jira_cfg["conventions"] = normalized
     kanban_io.save(p, data)
     _emit({"ok": True, "conventions": normalized, "warnings": warnings})
@@ -2798,8 +2852,39 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("set-conventions")
     s.add_argument("--kanban-path", required=True)
     s.add_argument(
-        "--conventions-json", required=True,
-        help='JSON object: {"notes": ["..."], "blockedRequiresLink": bool}',
+        "--conventions-json",
+        help=(
+            'Full replace mode. JSON object: {"notes": ["..."], '
+            '"blockedRequiresLink": bool}. Mutually exclusive with the '
+            'incremental flags below.'
+        ),
+    )
+    s.add_argument(
+        "--append-note", action="append", default=[],
+        help=(
+            "Incremental mode: append a note to conventions.notes. "
+            "Idempotent — exact-text duplicates of existing notes are "
+            "silently skipped. Repeat the flag to append several notes "
+            "in one call. May not be combined with --conventions-json."
+        ),
+    )
+    s.add_argument(
+        "--remove-note", action="append", default=[],
+        help=(
+            "Incremental mode: remove a note from conventions.notes by "
+            "exact-text match. Notes that don't exist are a no-op. May "
+            "not be combined with --conventions-json."
+        ),
+    )
+    s.add_argument(
+        "--set-toggle", action="append", default=[],
+        help=(
+            "Incremental mode: set a single toggle as KEY=VALUE (e.g. "
+            "blockedRequiresLink=false). Booleans are recognised "
+            "case-insensitively; everything else is stored as a string. "
+            "Repeat the flag to set several toggles. May not be combined "
+            "with --conventions-json."
+        ),
     )
     s.set_defaults(func=cmd_set_conventions)
 

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21; do  # 8-21: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22; do  # 8-22: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase22.py
+++ b/plugins/kanban/scripts/test_phase22.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Phase 22 regression checks for kanban v0.3.15 — `set-conventions`
+incremental flags.
+
+Closes #36. The original `set-conventions` required `--conventions-json`
+carrying the entire block, so adding a single note required a
+read → parse → append → re-serialize round-trip. For LLM-driven slash
+command flows the round-trip is risky: an agent that paraphrases an
+existing note on the way through silently overwrites it. The new
+`--append-note`, `--remove-note`, `--set-toggle` flags let callers
+mutate the block atomically without reproducing existing material.
+
+Cases:
+  (a) `--append-note "X"` adds X to existing notes; subsequent
+      identical append is a no-op (idempotent for slash-command re-run
+      safety).
+  (b) `--remove-note "X"` drops X if present; absent is a no-op.
+  (c) `--set-toggle blockedRequiresLink=false` flips the bool;
+      string values pass through unchanged.
+  (d) `--conventions-json` and the incremental flags are mutually
+      exclusive — caller cannot accidentally combine modes.
+  (e) Calling `set-conventions` with neither mode fails clearly.
+  (f) Full-replace `--conventions-json` path still works (back-compat).
+  (g) Several incremental flags in one call apply correctly together.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+
+
+def _seed_jira(td, *, conventions=None) -> pathlib.Path:
+    p = pathlib.Path(td) / "kanban.json"
+    cfg = {
+        "boardUrl": "https://x.atlassian.net/jira/software/projects/AGENT/boards/1",
+        "boardId": 1, "projectKey": "AGENT",
+        "transitions": {
+            "TODO": {"status": "Selected for Development"},
+            "DOING": {"status": "In Progress"},
+            "DONE": {"status": "Done"},
+        },
+        "ap": {"fieldId": "customfield_10042", "fieldName": "Claude Agent",
+               "registered": ["agent-fin"]},
+    }
+    if conventions is not None:
+        cfg["conventions"] = conventions
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": cfg},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _isolated_home(td: pathlib.Path) -> dict[str, str]:
+    home = td / "fakehome"
+    home.mkdir(parents=True, exist_ok=True)
+    return {"HOME": str(home)}
+
+
+def _run(*args, env_extra=None) -> subprocess.CompletedProcess:
+    cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(cmd, capture_output=True, env=env, text=True)
+
+
+def _read_conventions(kp: pathlib.Path) -> dict:
+    return json.loads(kp.read_text())["backend"]["jira"]["conventions"]
+
+
+def test_append_note_adds_then_idempotent():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["existing"],
+                                         "blockedRequiresLink": True})
+        env = _isolated_home(td)
+
+        # First append — added
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--append-note", "new rule", env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["existing", "new rule"]
+
+        # Second append (same text) — no-op (idempotent)
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--append-note", "new rule", env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["existing", "new rule"], cv["notes"]
+
+
+def test_remove_note_drops_present_no_op_when_absent():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["a", "b", "c"],
+                                         "blockedRequiresLink": True})
+        env = _isolated_home(td)
+
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--remove-note", "b", env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["a", "c"]
+
+        # Removing something not there — no-op
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--remove-note", "ghost", env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["a", "c"]
+
+
+def test_set_toggle_flips_bool_and_preserves_notes():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["x"],
+                                         "blockedRequiresLink": True})
+        env = _isolated_home(td)
+
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--set-toggle", "blockedRequiresLink=false",
+                   env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["blockedRequiresLink"] is False
+        # Notes preserved
+        assert cv["notes"] == ["x"]
+
+        # Case-insensitive bool: TRUE works too
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   "--set-toggle", "blockedRequiresLink=TRUE",
+                   env_extra=env)
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["blockedRequiresLink"] is True
+
+
+def test_conventions_json_and_incremental_are_mutually_exclusive():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td)
+        env = _isolated_home(td)
+
+        out = _run(
+            "set-conventions", "--kanban-path", str(kp),
+            "--conventions-json", json.dumps({"notes": ["x"]}),
+            "--append-note", "y",
+            env_extra=env,
+        )
+        assert out.returncode != 0, out.stdout
+        # The error surfaces in stdout (via _emit/_fail JSON) or stderr
+        combined = (out.stdout + out.stderr).lower()
+        assert "mutually exclusive" in combined \
+            or "cannot be combined" in combined \
+            or "different modes" in combined, combined
+
+
+def test_set_conventions_requires_at_least_one_mode():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td)
+        env = _isolated_home(td)
+
+        out = _run("set-conventions", "--kanban-path", str(kp),
+                   env_extra=env)
+        assert out.returncode != 0, out.stdout
+        combined = (out.stdout + out.stderr).lower()
+        assert "requires either" in combined or "incremental" in combined, combined
+
+
+def test_full_replace_path_still_works():
+    """Back-compat: existing slash-command invocations using
+    --conventions-json must keep working."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["old"],
+                                         "blockedRequiresLink": True})
+        env = _isolated_home(td)
+
+        out = _run(
+            "set-conventions", "--kanban-path", str(kp),
+            "--conventions-json", json.dumps({
+                "notes": ["new1", "new2"],
+                "blockedRequiresLink": False,
+            }),
+            env_extra=env,
+        )
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["new1", "new2"]
+        assert cv["blockedRequiresLink"] is False
+
+
+def test_combo_append_remove_toggle_in_one_call():
+    """All three incremental flags in one call apply consistently."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira(td, conventions={"notes": ["keep", "drop"],
+                                         "blockedRequiresLink": True})
+        env = _isolated_home(td)
+
+        out = _run(
+            "set-conventions", "--kanban-path", str(kp),
+            "--append-note", "added",
+            "--append-note", "added2",
+            "--remove-note", "drop",
+            "--set-toggle", "blockedRequiresLink=false",
+            env_extra=env,
+        )
+        assert out.returncode == 0, out.stderr
+        cv = _read_conventions(kp)
+        assert cv["notes"] == ["keep", "added", "added2"]
+        assert cv["blockedRequiresLink"] is False
+
+
+def main() -> int:
+    cases = [
+        ("append_note_adds_then_idempotent", test_append_note_adds_then_idempotent),
+        ("remove_note_drops_present_no_op_when_absent",
+         test_remove_note_drops_present_no_op_when_absent),
+        ("set_toggle_flips_bool_and_preserves_notes",
+         test_set_toggle_flips_bool_and_preserves_notes),
+        ("conventions_json_and_incremental_are_mutually_exclusive",
+         test_conventions_json_and_incremental_are_mutually_exclusive),
+        ("set_conventions_requires_at_least_one_mode",
+         test_set_conventions_requires_at_least_one_mode),
+        ("full_replace_path_still_works",
+         test_full_replace_path_still_works),
+        ("combo_append_remove_toggle_in_one_call",
+         test_combo_append_remove_toggle_in_one_call),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase22: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase22: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`set-conventions` previously required `--conventions-json` carrying the entire block, so adding a single note required a read → parse → append → re-serialize round-trip. For LLM-driven slash-command flows that round-trip is risky — an agent that paraphrases an existing note on the way through silently overwrites it (the "why did this rule disappear" mystery).

Three new flags let callers mutate the block atomically without reproducing existing material:

- `--append-note "..."` — append a note to `conventions.notes`. **Idempotent**: exact-text duplicates of existing notes are silently skipped, so slash-command flows that re-run on the same input won't double up.
- `--remove-note "..."` — drop a note by exact-text match. No-op if absent.
- `--set-toggle KEY=VALUE` — set a single toggle (e.g. `blockedRequiresLink=false`). Booleans are recognised case-insensitively; everything else is stored as a string.

All three are repeatable in one invocation. Mutually exclusive with `--conventions-json` (different modes — pick one). Calling with neither mode fails clearly.

Closes #36

## Files

- `plugins/kanban/scripts/jira_setup.py` — argparse + `cmd_set_conventions` two-mode dispatch
- `plugins/kanban/scripts/test_phase22.py` — new (7 cases)
- `plugins/kanban/scripts/test_all.sh` — wire phase 22
- Version bump 0.3.14 → 0.3.15, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 22 phases green
- [x] Phase 22 (7 new cases): append idempotency; remove no-op when absent; toggle bool conversion (case-insensitive); mutual exclusion with `--conventions-json`; "require at least one mode" guard; full-replace back-compat; combo call (append × 2 + remove + set-toggle in one invocation)
- [x] Existing phase 11 `set_conventions_writes_and_warns` still passes (back-compat for full-replace mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)