### PR TITLE
feat(kanban): 0.3.16 — rename /kanban:next→/kanban:doing (Jira), /kanban:initjira-by-code→/kanban:import-jira-code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,65 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-03 (kanban command renames + scope narrowing)
+
+### Changed
+- **kanban 0.3.16** — two slash command renames; the helper subcommands
+  and overall framing now match what the commands actually do. Closes
+  #33 and #34.
+
+  **`/kanban:next` → `/kanban:doing` (Jira mode only).** The old name
+  implied a single-step "pick the next task" model, but the actual
+  workflow on a multi-card AP is "agent works through every card the
+  owner has placed in DOING, reasoning across them." The new command
+  reads only `status=DOING AND assignee=this-AP` cards (helper:
+  `list-doing`) and never pulls from TODO. The state machine the plugin
+  enforces:
+
+  ```
+  TODO  ──(owner moves)──▶  DOING  ──(/kanban:doing executes)──▶  DONE
+  ```
+
+  - **TODO → DOING is the owner's call** (Jira UI, or the owner's own
+    `/kanban:transition`). The agent must never pull from TODO unless
+    an explicit @-mention from the owner names a card with start intent.
+  - The token-cost win is real: 11 open TODOs were being scanned by
+    the old auto-pick to choose one card; the new command only reads
+    the (small) DOING set.
+  - Local mode keeps its `/kanban:next` semantics — local has no AP
+    routing, the pick-one model is still right there.
+  - `/kanban:next` becomes a deprecation shim for one release cycle:
+    in Jira mode it prints a notice and stops; in local mode it forwards
+    to the existing helper.
+
+  **`/kanban:initjira-by-code` → `/kanban:import-jira-code`.** The
+  helper has always been called `import-jira-code` — the slash command
+  now matches. The new name also makes obvious that the command is
+  not just first-run init: it works for re-sync too. To smooth the
+  re-sync path:
+
+  - Step 3 (AP) is now idempotent: when `.claude/kanban-agent.json#ap`
+    is set AND the AP still appears in `live-list-aps`, the prompt is
+    skipped and a one-line confirmation is printed. Re-import after a
+    `/kanban:edit-conventions` change becomes friction-free.
+  - The conventions ack-hash mechanism (forces re-ack when notes
+    drift) is preserved — that's the team-drift safety net.
+  - `/kanban:initjira-by-code` becomes a deprecation shim that prints
+    a notice and forwards.
+
+  Cross-references throughout the repo were updated:
+  README/quickstart, `kanban-jira-agent` SKILL, and Jira-flavored
+  commands (`initjira`, `create-sub`, `mentions`, `reconcile`,
+  `fix-ap-screen`) now point at `/kanban:doing` and
+  `/kanban:import-jira-code`. Generic / local-mode docs keep
+  `/kanban:next` (still correct in local mode).
+
+  New phase 23 covers the helper: list-doing returns DOING-only cards
+  filtered by AP; empty-DOING is `ok=true` with empty list (slash
+  command then says "owner needs to move a TODO into DOING"); missing
+  repo AP fails with the assign-ap nudge; local backend is refused.
+  All 23 phases green.
+
 ## 2026-05-03 (kanban set-conventions incremental flags)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Produces a unified diff (no auto-merge — by design, since your repo may have i
 ```bash
 > /kanban:init --with-examples      # seed kanban.json + schema
 > /kanban:status                    # read-only summary
-> /kanban:next                      # pick a TODO and move it to DOING
+> /kanban:next                      # local mode: pick a TODO and move it to DOING
+> /kanban:doing                     # jira mode: work the cards already in DOING
 > /kanban:done --note="deployed"    # close the DOING task
 ```
 
@@ -133,7 +134,7 @@ Capability detection (SPEC §8.7): each plugin checks for sibling CLIs (`workben
 | Pair | Effect | Status |
 |---|---|---|
 | `kanban × notify` | State transitions trigger push notifications (BLOCKED → high priority). | wired, not E2E tested |
-| `kanban × memory` | `/kanban:next` queries past sessions; `/kanban:done` saves completion notes. | awaits memory |
+| `kanban × memory` | `/kanban:next` (local) / `/kanban:doing` (jira) queries past sessions; `/kanban:done` saves completion notes. | awaits memory |
 | `kanban × mentor` | New Issue can spawn kanban task; optional DONE gate on Issue Acceptance Criteria. | wired, awaits E2E test |
 | `notify × memory` | Decision prompts carry "last time you chose X". | awaits memory |
 | `mentor × memory` | Sprint retros + accepted ADRs persisted to memory. | wired, awaits memory |

--- a/README_zhtw.md
+++ b/README_zhtw.md
@@ -110,7 +110,8 @@ claude
 ```bash
 > /kanban:init --with-examples      # 建立 kanban.json + schema
 > /kanban:status                    # 唯讀的狀態總覽
-> /kanban:next                      # 挑一個 TODO 移到 DOING
+> /kanban:next                      # local mode：挑一個 TODO 移到 DOING
+> /kanban:doing                     # jira mode：執行已經在 DOING 的卡片
 > /kanban:done --note="deployed"    # 關掉當前 DOING 任務
 ```
 
@@ -133,7 +134,7 @@ Claude 對 `kanban.json` **會做的**：
 | 組合 | 效果 | 狀態 |
 |---|---|---|
 | `kanban × notify` | 狀態轉換觸發推播（BLOCKED → 高優先度）。 | 線路已接，E2E 未測 |
-| `kanban × memory` | `/kanban:next` 查詢過去 session；`/kanban:done` 存完工筆記。 | 等 memory |
+| `kanban × memory` | `/kanban:next`（local）/ `/kanban:doing`（jira）查詢過去 session；`/kanban:done` 存完工筆記。 | 等 memory |
 | `kanban × mentor` | 新 Issue 可自動產生 kanban task；可選的 Issue Acceptance Criteria DONE gate。 | 線路已接，等 E2E |
 | `notify × memory` | 決策提示會附帶「上次你選了 X」。 | 等 memory |
 | `mentor × memory` | Sprint retro + accepted ADR 持久化到 memory。 | 線路已接，等 memory |

--- a/kanban_quickstart.md
+++ b/kanban_quickstart.md
@@ -178,7 +178,7 @@ After init:
 
 ```
 > /kanban:status     # live state from Jira
-> /kanban:next       # claim the top TODO for this AP
+> /kanban:doing      # work the cards already in DOING (owner curates TODO → DOING; agent executes)
 > /kanban:done       # transition DOING → In Review (a human approves to Done)
 > /kanban:question AGENT-42 "should v1 stay backward-compatible?"
 > /kanban:whoami     # show driver, AP, token validity, MCP scan
@@ -205,7 +205,7 @@ Setup splits into three layers, each with a different lifecycle:
 
 | Layer | What | When you redo it |
 |---|---|---|
-| **Per-board** (shareable) | `transitions`, AP custom-field id, board metadata, `conventions` notes | Once. Then `/kanban:showjira-code` and any teammate / repo can `/kanban:initjira-by-code` paste the JSON to inherit it. |
+| **Per-board** (shareable) | `transitions`, AP custom-field id, board metadata, `conventions` notes | Once. Then `/kanban:showjira-code` and any teammate / repo can `/kanban:import-jira-code` paste the JSON to inherit it. |
 | **Per-machine** | Jira credentials in `~/.claude-workbench/.env` (base URL, agent email, API token) | Once per machine. After that all repos on that machine share the credentials. |
 | **Per-repo** | This repo's AP in `.claude/kanban-agent.json` | Once per repo. Each repo picks its own AP from the live Jira options list. |
 
@@ -213,8 +213,8 @@ Setup splits into three layers, each with a different lifecycle:
 
 | Scenario | What you run on the new side |
 |---|---|
-| **All-new machine + all-new repo** | `/kanban:init` → `/kanban:initjira-by-code` (does credentials + paste code + assign AP in one flow) |
-| **Same machine, new repo** | `/kanban:init` → `/kanban:initjira-by-code` (credentials auto-skipped — already on this machine; only paste code + assign AP run interactively) |
+| **All-new machine + all-new repo** | `/kanban:init` → `/kanban:import-jira-code` (does credentials + paste code + assign AP in one flow) |
+| **Same machine, new repo** | `/kanban:init` → `/kanban:import-jira-code` (credentials auto-skipped — already on this machine; only paste code + assign AP run interactively) |
 | **Existing repo already in Jira mode** | Nothing — already set up. `/kanban:whoami` to verify. |
 
 ### How it works
@@ -231,7 +231,7 @@ On any other machine / repo:
 
 ```
 > /kanban:init                  # scaffold kanban.json (local mode)
-> /kanban:initjira-by-code      # paste the JSON; runs credentials (if needed) + assign AP
+> /kanban:import-jira-code      # paste the JSON; runs credentials (if needed) + assign AP
 ```
 
 The receiver asks for Jira credentials only the first time on a given machine. If `conventions.notes` is non-empty, the receiver also has to type `I have read these` to acknowledge before init completes (the friction is intentional — see issue #10).

--- a/kanban_quickstart_zhtw.md
+++ b/kanban_quickstart_zhtw.md
@@ -173,7 +173,7 @@ init 完之後：
 
 ```
 > /kanban:status     # 從 Jira 拉即時狀態
-> /kanban:next       # 認領這個 AP 最高優先 TODO
+> /kanban:doing      # 執行已在 DOING 的卡片（owner 把 TODO 推進 DOING；agent 執行）
 > /kanban:done       # DOING → In Review（由人類批准成 Done）
 > /kanban:question AGENT-42 "v1 是否保留向下相容？"
 > /kanban:whoami     # 顯示 driver、AP、token 有效性、MCP 衝突
@@ -195,7 +195,7 @@ Setup 拆成**三層**，每層有自己的生命週期：
 
 | 層級 | 內容 | 何時要重跑 |
 |---|---|---|
-| **Per-board（可分享）** | `transitions`、AP custom field id、board metadata、`conventions` 規則 | **一次**。然後 `/kanban:showjira-code`，任何同事 / repo 用 `/kanban:initjira-by-code` 貼 JSON 就繼承 |
+| **Per-board（可分享）** | `transitions`、AP custom field id、board metadata、`conventions` 規則 | **一次**。然後 `/kanban:showjira-code`，任何同事 / repo 用 `/kanban:import-jira-code` 貼 JSON 就繼承 |
 | **Per-machine（每台必做）** | Jira 憑證（`~/.claude-workbench/.env`：base URL、agent email、API token） | 每台機器一次。之後該台所有 repo 共用 |
 | **Per-repo（每個 repo 必做）** | 這個 repo 用哪個 AP（`.claude/kanban-agent.json`） | 每個 repo 一次。各自從 Jira live options 挑 |
 
@@ -203,8 +203,8 @@ Setup 拆成**三層**，每層有自己的生命週期：
 
 | 情境 | 新 receiver 端要跑的 |
 |---|---|
-| **全新機器 + 全新 repo** | `/kanban:init` → `/kanban:initjira-by-code`（一個指令做完憑證 + 貼 code + 選 AP） |
-| **同機器 + 新 repo** | `/kanban:init` → `/kanban:initjira-by-code`（憑證自動跳過——本機已有；只剩貼 code + 選 AP 互動） |
+| **全新機器 + 全新 repo** | `/kanban:init` → `/kanban:import-jira-code`（一個指令做完憑證 + 貼 code + 選 AP） |
+| **同機器 + 新 repo** | `/kanban:init` → `/kanban:import-jira-code`（憑證自動跳過——本機已有；只剩貼 code + 選 AP 互動） |
 | **既有 repo 已是 jira mode** | 啥都不用——已 setup。`/kanban:whoami` 可驗證 |
 
 ### 運作原理
@@ -221,7 +221,7 @@ Setup 拆成**三層**，每層有自己的生命週期：
 
 ```
 > /kanban:init                  # scaffold kanban.json (local mode)
-> /kanban:initjira-by-code      # 貼 JSON；視情況跑憑證 + 選 AP
+> /kanban:import-jira-code      # 貼 JSON；視情況跑憑證 + 選 AP
 ```
 
 第一次在某台機器跑時會問憑證；同台第二個 repo 時自動跳過。如果 code 帶 `conventions.notes` 非空，接收端必須輸入 `I have read these` 才能完成 init（這個 friction 是刻意的——詳見 issue #10）。

--- a/mentor_quickstart.md
+++ b/mentor_quickstart.md
@@ -90,7 +90,8 @@ workbench-mentor review --format json               # exit 0 clean, 2 on violati
 Just two layers: `doc/SPEC.md` (the truth) + tasks (kanban.json or `doc/task.md`).
 
 ```
-> /kanban:next            # if kanban installed — pick a TODO and start
+> /kanban:next            # local mode (if kanban installed) — pick a TODO and start
+> /kanban:doing           # jira mode (if kanban installed) — work the DOING pool
 > /mentor:status          # see compliance + task overview
 ```
 

--- a/mentor_quickstart_zhtw.md
+++ b/mentor_quickstart_zhtw.md
@@ -90,7 +90,8 @@ workbench-mentor review --format json               # 乾淨 exit 0；有違規 
 只有兩層：`doc/SPEC.md`（事實）+ tasks（kanban.json 或 `doc/task.md`）。
 
 ```
-> /kanban:next            # 有裝 kanban 的話——挑一個 TODO 開始做
+> /kanban:next            # local mode（有裝 kanban 的話）——挑一個 TODO 開始做
+> /kanban:doing           # jira mode（有裝 kanban 的話）——執行已在 DOING 的卡片
 > /mentor:status          # 看合規狀況 + 任務概覽
 ```
 

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/create-sub.md
+++ b/plugins/kanban/commands/create-sub.md
@@ -59,7 +59,7 @@ Response:
 ```
 
 Each created card is auto-assigned this repo's AP (so it shows up on
-the next `/kanban:next`). If the AP assignment fails (network /
+the next `/kanban:doing`). If the AP assignment fails (network /
 permission), the card still exists — surface in the report.
 
 ## 2. Render
@@ -80,11 +80,15 @@ After spawning sub-cards, the LLM typically:
 
 1. `/kanban:reply <parent> --to <commenter-accountId> --body "..."`
    — notify the human about the breakdown.
-2. `/kanban:next --task-id <first-sub>` — claim the first sub-card.
-3. Work on it, complete via `/kanban:done`.
-4. Move to the next sub-card.
+2. Owner reviews the sub-cards and moves the first one to DOING
+   (TODO → DOING is the owner's call — see #33). When the @-mention
+   from the owner explicitly authorizes start, the agent may instead
+   call `/kanban:transition <first-sub> --to DOING`.
+3. `/kanban:doing` — read the DOING pool and pick up the first sub-card.
+4. Work on it, complete via `/kanban:done`.
+5. Move to the next sub-card.
 
-Don't claim all sub-cards at once — the kanban-workflow skill says
+Don't work all sub-cards in parallel — the kanban-workflow skill says
 "never start more than one task at a time in the same session."
 
 ## Absolute rules
@@ -93,6 +97,6 @@ Don't claim all sub-cards at once — the kanban-workflow skill says
   response to an @-mention with clear "do it" intent). Don't proactively
   break down cards that look big.
 - Never omit the parent — sub-cards without a parent should just be
-  created via `/kanban:next` workflows.
+  created via `/kanban:create` and worked through `/kanban:doing`.
 - Never invent titles — they must come from the user's request or the
   LLM's classified breakdown of the parent's description.

--- a/plugins/kanban/commands/doing.md
+++ b/plugins/kanban/commands/doing.md
@@ -1,0 +1,95 @@
+---
+description: Work the DOING pool — read every card you currently own (status=DOING) and execute them in a sensible order.
+allowed-tools: Read, Bash(python3:*), Bash(date:*)
+---
+
+# /kanban:doing
+
+Work through every card the owner has placed in `DOING` for this AP.
+The Skill `kanban-workflow` (loaded automatically) governs the rules.
+
+This command is **read-then-execute**, not pick-from-TODO. The state
+machine the plugin enforces:
+
+```
+TODO  ──(owner moves)──▶  DOING  ──(/kanban:doing executes)──▶  DONE
+                            │                                    ▲
+                            └──(/kanban:block REVIEW)──▶ REVIEW ──┘
+                                                          │
+                                                          └──(owner moves back)──▶  DOING
+```
+
+- **TODO → DOING** is the **owner's** call (Jira UI, or whatever
+  intake flow the team uses). The agent must never pull a card from
+  TODO into DOING — that's curation, not execution.
+- **DOING → DONE** is yours, after executing successfully.
+- **DOING → REVIEW** is yours when blocked / needs owner judgement.
+- **REVIEW → DOING** is the owner's ("keep going") or **REVIEW →
+  DONE** ("good enough").
+
+## 0. Pre-flight
+
+- Read `kanban.json#backend.driver`. Local-mode does not have AP
+  routing; this command is jira-only — tell the user to use
+  `/kanban:next` if they're in local mode (still works there).
+- `$CLAUDE_PROJECT_DIR` (or `git rev-parse --show-toplevel`) → kanban
+  path.
+
+## 1. Fetch the DOING set
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py list-doing \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{ok, ap, doing: [{id, title, priority, started, ap}, ...]}`.
+
+| Shape | Action |
+|---|---|
+| `{ok: true, doing: [...]}` (non-empty) | proceed to step 2 |
+| `{ok: true, doing: []}` | print `No DOING cards for AP <ap>; owner needs to move a TODO into DOING (Jira UI or ask the owner).` Stop. Do **not** auto-pick from TODO. |
+| `{ok: false, error}` | surface the error verbatim. If it mentions `kanban-agent.json`, suggest `/kanban:assign-ap`. |
+
+## 2. Decide execution order
+
+When `doing` has more than one card, read each card's title +
+description (via `/kanban:show <id>` or whatever you need) and decide
+the order based on:
+
+- explicit `Blocks`/`is-blocked-by` issue links — predecessors first
+- shared module / file affinity — batch cards that touch the same code
+- priority field as a tie-breaker (P0 > P1 > ...)
+
+Print the chosen order in one line, e.g.:
+
+```
+DOING (3): BZK-625 → BZK-626 → BZK-627 (linked chain; same module)
+```
+
+## 3. Execute one at a time
+
+Work the cards sequentially — actively executing one at a time
+(WIP=1). For the active card:
+
+- Read its full description and any prior comments (`/kanban:show`).
+- Make the changes the description calls for.
+- When done: `/kanban:done <id>` (or whatever your team calls the
+  DOING → DONE move).
+- When stuck and need owner input: `/kanban:block <id> --to REVIEW
+  --reason "..."`.
+
+After finishing one card, self-loop into the next without requiring
+the user to re-invoke `/kanban:doing`.
+
+## Absolute rules
+
+- **Never** transition a card from TODO into DOING. That belongs to
+  the owner. If the owner asks you to "start working on BZK-NN",
+  ask them to move it to DOING first — or document an explicit
+  per-team agreement (in `conventions.notes` via
+  `/kanban:edit-conventions`) that authorizes the agent to pull.
+- **Never** decide what's "important enough" to start. Priority
+  curation is the owner's responsibility; the agent's job is to
+  execute what's already curated.
+- Read-then-execute. This command itself does not transition any
+  cards — `/kanban:done` and `/kanban:block` do.

--- a/plugins/kanban/commands/edit-conventions.md
+++ b/plugins/kanban/commands/edit-conventions.md
@@ -80,7 +80,7 @@ time they re-import. To push the update now:
 
   1. Run /kanban:showjira-code in this repo
   2. Share the printed JSON with your team
-  3. Each teammate runs /kanban:initjira-by-code on their repo and
+  3. Each teammate runs /kanban:import-jira-code on their repo and
      pastes the new code (the ack flow re-fires because the hash changed)
 ```
 
@@ -90,4 +90,4 @@ time they re-import. To push the update now:
 - Never bypass the length guardrails silently — warn and re-prompt.
 - Never write conventions on behalf of another repo. The source-of-truth
   is wherever the user is running this command. Other repos pull via
-  `/kanban:initjira-by-code`.
+  `/kanban:import-jira-code`.

--- a/plugins/kanban/commands/enable-automation.md
+++ b/plugins/kanban/commands/enable-automation.md
@@ -54,6 +54,8 @@ Hook contents to write:
 set -euo pipefail
 changed=$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD 2>/dev/null || true)
 if printf '%s\n' "$changed" | grep -q '^kanban\.json$'; then
+    # Replace /kanban:next with /kanban:doing for Jira-mode repos —
+    # /kanban:next prints a deprecation notice in Jira mode (#33).
     claude -p "kanban.json changed via git pull. /kanban:next and execute." \
       --allowedTools "Read,Write,Edit,Bash(git:*),Bash(date:*)" \
       --permission-mode acceptEdits \

--- a/plugins/kanban/commands/fix-ap-screen.md
+++ b/plugins/kanban/commands/fix-ap-screen.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash(python3:*)
 
 Recover from the issue #6 failure mode where the AP custom field was
 created (e.g. by an older `/kanban:initjira` on 0.3.1) but never
-associated with any Jira screen. Symptom: `/kanban:next` returns nothing
+associated with any Jira screen. Symptom: `/kanban:doing` returns nothing
 even though there are TODO cards, because `customfield_X cannot be set`
 on any issue, so no card carries an AP value.
 

--- a/plugins/kanban/commands/import-jira-code.md
+++ b/plugins/kanban/commands/import-jira-code.md
@@ -1,0 +1,198 @@
+---
+description: Bootstrap or re-sync Jira mode in this repo from a code emitted elsewhere — skips DSL setup. Replaces /kanban:initjira-by-code (#34).
+allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*), Bash(git:*), AskUserQuestion
+---
+
+# /kanban:import-jira-code
+
+Import a `kanban-jira-code/2` JSON payload (emitted by
+`/kanban:showjira-code` on a sibling repo / machine) into the current
+repo. Two use cases, same command:
+
+- **First-run bootstrap** — fresh repo, no `backend.jira` yet. Equivalent
+  to running `/kanban:initjira` but skipping the parts the code already
+  carries (board URL, transitions DSL, AP field discovery).
+- **Re-sync** — repo is already on Jira mode but the team's
+  configuration drifted (e.g. `/kanban:edit-conventions` added a rule on
+  machine A; machine B re-imports to pick it up). The conventions ack
+  hash forces re-acknowledgment when notes change; the AP step is
+  idempotent (skipped when the local AP is still on the board).
+
+Skips compared to `/kanban:initjira`:
+
+- Step 2: board URL parse (the code carries `projectKey` / `boardId`)
+- Step 3: compound transition DSL (the code carries `transitions`)
+- Step 4: AP custom-field discovery (the code carries `ap.fieldId`)
+
+You still need:
+
+- Step 1: Jira credentials on this machine (the code does NOT contain a
+  token — it is per-machine).
+- Step 3: this repo's AP assignment (idempotent — see below).
+
+## 0. Pre-flight
+
+- Confirm `kanban.json` exists at the project root. If missing, run
+  `/kanban:init` first.
+- `$CLAUDE_PROJECT_DIR` (or `git rev-parse --show-toplevel`) → kanban path.
+- If `kanban.json#backend.driver` is already `"jira"`, ask the user
+  whether to overwrite the current mapping (the import will replace
+  `backend.jira` wholesale). For routine re-sync this is the expected
+  flow — say yes; for a fresh code from an unfamiliar source, double-check
+  it's the right team's payload first.
+
+## Step 1/3 — Credentials
+
+If `~/.claude-workbench/.env` already has valid Jira credentials, skip.
+To check, call `read-credentials` and verify `tokenPresent` is true:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
+# expect: {"baseUrl": "...", "email": "...", "tokenPresent": true}
+```
+
+Do **not** use the `health` helper as the oracle here — at this point
+`kanban.json#backend.driver` is still `"local"` (or being switched), so
+`health` may run against the local driver and return `ok=true` regardless
+of whether Jira credentials exist. See #31.
+
+If credentials are missing, run the same Step 1 flow as `/kanban:initjira`
+(capture base URL, agent email, API token; validate via
+`validate-credentials`; persist via `store-credentials`).
+
+## Step 2/3 — Paste and import the code
+
+Ask the user via `AskUserQuestion` to paste the JSON code emitted by
+`/kanban:showjira-code` on the source machine. Strip leading/trailing
+whitespace and any surrounding code-fence backticks (the user is likely
+copy-pasting from a chat).
+
+Validate the structure: must be a JSON object with `schema` equal to
+`kanban-jira-code/1` or `kanban-jira-code/2`. Surface any parse error
+verbatim.
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py import-jira-code \
+  --kanban-path '<kanban.json path>' \
+  --code-json '<the pasted JSON>'
+```
+
+| Response | Action |
+|---|---|
+| `{ok: true, imported: {...}, schema, conventions, ackRequired}` | print one-line summary: imported `<projectKey>/<boardId>`, `<N>` transitions, AP field `<fieldName>`. If `ackRequired` is true, proceed to step 2.5. |
+| `{ok: false, error: ..., errors?: [...]}` | surface the error(s); ask the user to re-paste |
+
+After two validation failures, abort.
+
+## Step 2.5/3 — Acknowledge team conventions (only if `ackRequired`)
+
+When the imported code carries a non-empty `conventions` block (notes
+the team agreed to share), the user must read them before import can
+complete. The friction is intentional — pasting code is not the same as
+having read it. The conventions hash is checked against the prior ack
+in `.claude/kanban-agent.json`, so re-sync where conventions didn't
+change auto-skips this step.
+
+Render the notes as a numbered list, then ask via `AskUserQuestion`:
+
+```
+⚠ Team conventions you should know before starting work:
+
+  1. <note 1>
+  2. <note 2>
+  3. <note 3>
+
+If `blockedRequiresLink` is true:
+  ⚙ This team requires `--blocked-by KEY` on every /kanban:block call.
+
+Type the literal phrase 'I have read these' to acknowledge and continue:
+```
+
+The ack must be the **exact** string `I have read these` (case-sensitive,
+trim leading/trailing whitespace). Other answers (`yes`, `Y`, `ok`,
+`sure`, `已讀`, etc.) are **not** accepted — re-prompt once. After two
+mismatches, abort import with:
+
+> Import aborted — conventions not acknowledged. Re-run when ready, or run
+> `/kanban:show-conventions` to read them outside the import flow.
+
+Once the literal phrase is entered, persist the ack:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py record-conventions-ack \
+  --kanban-path '<kanban.json path>'
+```
+
+This writes a hash + timestamp to `.claude/kanban-agent.json` so future
+re-runs of `/kanban:import-jira-code` (with the same conventions) skip
+this step.
+
+## Step 3/3 — Assign this repo's AP (idempotent)
+
+For re-sync this is usually a no-op: the repo already has its AP set in
+`.claude/kanban-agent.json#ap`, and that name still exists on the board.
+First check whether the existing assignment is still valid:
+
+```bash
+# 1. Read the repo's existing AP (None on first-run)
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-agent-ap \
+  --kanban-path '<kanban.json path>'
+
+# 2. Read the board's currently-registered AP roster
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py live-list-aps \
+  --kanban-path '<kanban.json path>'
+```
+
+Decision matrix:
+
+| Local `ap` | In `live-list-aps#registered`? | Action |
+|---|---|---|
+| set (e.g. `narrative-fin-agent`) | yes | print `AP: <name> (kept from existing config)` and skip the prompt |
+| set | no — name was de-registered upstream | warn `AP <name> is no longer on the board roster — please re-pick` and re-prompt as for first-run |
+| not set | n/a | first-run flow: list options + prompt |
+
+For first-run / re-prompt flow, show the live AP roster and let the user
+pick:
+
+```
+| Response | Action |
+|---|---|
+| `{ok: true, registered: [...]}` | list options; ask the user to pick or `/kanban:register-ap <new>` first |
+```
+
+If the user picks an existing AP:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py assign-ap \
+  --kanban-path '<kanban.json path>' --name '<picked-ap>'
+```
+
+If the user wants a new AP, instruct them to run
+`/kanban:register-ap <name>` then `/kanban:assign-ap <name>`.
+
+## Done
+
+```
+✓ /kanban:import-jira-code complete.
+
+Project:    <projectKey>
+Board:      #<boardId>
+Driver:     jira (imported from code)
+Transitions: <count>  (e.g. TODO→Selected for Development, DOING→In Progress, ...)
+AP field:   <fieldName> (<fieldId>)
+This repo:  <ap-name>  (kept | newly assigned)
+
+Try: /kanban:status
+```
+
+## Absolute rules
+
+- Never accept a code with `schema != "kanban-jira-code/1"` and
+  `schema != "kanban-jira-code/2"`.
+- Never invent fields the code is missing (e.g. don't synthesise an AP
+  field from any local hint — the code is authoritative).
+- Never surface the API token in any output.
+- Never write to `kanban.json` via Edit/Write — go through the helper.
+- The conventions ack hash mechanism is the team-drift safety net —
+  preserve it. Re-importing after a conventions change *must* force
+  a fresh ack; do not bypass step 2.5 for "convenience".

--- a/plugins/kanban/commands/initjira-by-code.md
+++ b/plugins/kanban/commands/initjira-by-code.md
@@ -1,158 +1,29 @@
 ---
-description: Bootstrap Jira mode in this repo from a code emitted elsewhere — skips DSL setup.
+description: DEPRECATED alias — use /kanban:import-jira-code (#34).
 allowed-tools: Read, Bash(python3:*), Bash(test:*), Bash(ls:*), Bash(git:*), AskUserQuestion
 ---
 
-# /kanban:initjira-by-code
+# /kanban:initjira-by-code  *(deprecated alias)*
 
-Short version of `/kanban:initjira` for repos / machines that already have
-a sibling repo configured for the same Jira board. Skips:
+Renamed in kanban@0.3.16 (#34): the helper subcommand has always been
+`import-jira-code`, the slash command should match. Also, the command
+already supported re-import on a configured repo — the new name makes
+that obvious instead of hiding it behind "init".
 
-- Step 2: board URL parse (the code carries `projectKey` / `boardId`)
-- Step 3: compound transition DSL (the code carries `transitions`)
-- Step 4: AP custom-field discovery (the code carries `ap.fieldId`)
+**Use `/kanban:import-jira-code` instead.** This alias forwards to the
+same flow for one release cycle, then will be removed.
 
-You still need:
+## Action
 
-- Step 1: Jira credentials on this machine (the code does NOT contain a
-  token — it is per-machine).
-- Step 5: this repo's AP assignment.
+1. Print the deprecation notice:
 
-## 0. Pre-flight
+   ```
+   /kanban:initjira-by-code is deprecated as of kanban@0.3.16 (#34).
+   Use /kanban:import-jira-code — same flow, clearer name, supports
+   both first-run bootstrap and re-sync. This alias will be removed
+   in a future release.
+   ```
 
-- Confirm `kanban.json` exists at the project root. If missing, run
-  `/kanban:init` first.
-- `$CLAUDE_PROJECT_DIR` (or `git rev-parse --show-toplevel`) → kanban path.
-- If `kanban.json#backend.driver` is already `"jira"`, ask the user
-  whether to overwrite the current mapping (the import will replace
-  `backend.jira` wholesale).
-
-## Step 1/3 — Credentials
-
-If `~/.claude-workbench/.env` already has valid Jira credentials, skip.
-To check, call `read-credentials` and verify `tokenPresent` is true:
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
-# expect: {"baseUrl": "...", "email": "...", "tokenPresent": true}
-```
-
-Do **not** use the `health` helper as the oracle here — at this point
-`kanban.json#backend.driver` is still `"local"` (nothing has switched it
-to `"jira"` yet), so `health` runs against the local driver and returns
-`ok=true` regardless of whether Jira credentials exist. See #31.
-
-If credentials are missing, run the same Step 1 flow as `/kanban:initjira`
-(capture base URL, agent email, API token; validate via
-`validate-credentials`; persist via `store-credentials`).
-
-## Step 2/3 — Paste and import the code
-
-Ask the user via `AskUserQuestion` to paste the JSON code emitted by
-`/kanban:showjira-code` on the source machine. Strip leading/trailing
-whitespace and any surrounding code-fence backticks (the user is likely
-copy-pasting from a chat).
-
-Validate the structure: must be a JSON object with `schema` equal to
-`kanban-jira-code/1` or `kanban-jira-code/2`. Surface any parse error
-verbatim.
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py import-jira-code \
-  --kanban-path '<kanban.json path>' \
-  --code-json '<the pasted JSON>'
-```
-
-| Response | Action |
-|---|---|
-| `{ok: true, imported: {...}, schema, conventions, ackRequired}` | print one-line summary: imported `<projectKey>/<boardId>`, `<N>` transitions, AP field `<fieldName>`. If `ackRequired` is true, proceed to step 2.5. |
-| `{ok: false, error: ..., errors?: [...]}` | surface the error(s); ask the user to re-paste |
-
-After two validation failures, abort.
-
-## Step 2.5/3 — Acknowledge team conventions (only if `ackRequired`)
-
-When the imported code carries a non-empty `conventions` block (notes
-the team agreed to share), the user must read them before init can
-complete. The friction is intentional — pasting code is not the same as
-having read it.
-
-Render the notes as a numbered list, then ask via `AskUserQuestion`:
-
-```
-⚠ Team conventions you should know before starting work:
-
-  1. <note 1>
-  2. <note 2>
-  3. <note 3>
-
-If `blockedRequiresLink` is true:
-  ⚙ This team requires `--blocked-by KEY` on every /kanban:block call.
-
-Type the literal phrase 'I have read these' to acknowledge and continue:
-```
-
-The ack must be the **exact** string `I have read these` (case-sensitive,
-trim leading/trailing whitespace). Other answers (`yes`, `Y`, `ok`,
-`sure`, `已讀`, etc.) are **not** accepted — re-prompt once. After two
-mismatches, abort init with:
-
-> Init aborted — conventions not acknowledged. Re-run when ready, or run
-> `/kanban:show-conventions` to read them outside the init flow.
-
-Once the literal phrase is entered, persist the ack:
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py record-conventions-ack \
-  --kanban-path '<kanban.json path>'
-```
-
-This writes a hash + timestamp to `.claude/kanban-agent.json` so future
-re-runs of `/kanban:initjira-by-code` (with the same conventions) skip
-this step.
-
-## Step 3/3 — Assign this repo's AP
-
-Same as `/kanban:initjira` step 5. Show the live AP roster from Jira:
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py live-list-aps \
-  --kanban-path '<kanban.json path>'
-```
-
-| Response | Action |
-|---|---|
-| `{ok: true, registered: [...]}` | list options; ask the user to pick or `/kanban:register-ap <new>` first |
-
-If the user picks an existing AP:
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py assign-ap \
-  --kanban-path '<kanban.json path>' --name '<picked-ap>'
-```
-
-If the user wants a new AP, instruct them to run
-`/kanban:register-ap <name>` then `/kanban:assign-ap <name>`.
-
-## Done
-
-```
-✓ /kanban:initjira-by-code complete.
-
-Project:    <projectKey>
-Board:      #<boardId>
-Driver:     jira (imported from code)
-Transitions: <count>  (e.g. TODO→Selected for Development, DOING→In Progress, ...)
-AP field:   <fieldName> (<fieldId>)
-This repo:  <ap-name>
-
-Try: /kanban:status
-```
-
-## Absolute rules
-
-- Never accept a code with `schema != "kanban-jira-code/1"`.
-- Never invent fields the code is missing (e.g. don't synthesise an AP
-  field from any local hint — the code is authoritative).
-- Never surface the API token in any output.
-- Never write to `kanban.json` via Edit/Write — go through the helper.
+2. Then follow the flow at `/kanban:import-jira-code` exactly. Do not
+   re-implement the steps here — read the body of `import-jira-code.md`
+   in this same `commands/` directory and execute it.

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -9,7 +9,7 @@ Arguments: `$ARGUMENTS`
 
 This command switches a project to **Jira mode** end-to-end: credentials,
 board, workflow check, Agent Property (AP) custom field, and the first AP
-registration. After it completes, `/kanban:next`, `/kanban:done`, and
+registration. After it completes, `/kanban:doing`, `/kanban:done`, and
 `/kanban:block` operate against Jira with anti-self-approve enforcement.
 
 The helper `${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py` does the network +
@@ -120,7 +120,7 @@ Print `✓ project=<projectName> (<projectKey>); board=<boardName> (<boardType>)
 
 > **Tip — already configured the same board in another repo or machine?**
 > Skip this entire flow: run `/kanban:showjira-code` in the source repo,
-> copy the printed JSON, then run `/kanban:initjira-by-code` in this repo
+> copy the printed JSON, then run `/kanban:import-jira-code` in this repo
 > and paste it. Jumps straight from credentials to step 5 (assign AP).
 
 ## Step 3/5 — Compound transitions (canonical → Jira)
@@ -303,7 +303,7 @@ list verbatim and suggest:
 > ⚠ AP field created, but couldn't attach it to: `<screen names>`.
 > Ask a Jira admin to add `<fieldName>` to those screens, or run
 > `/kanban:fix-ap-screen` after they grant you permission. **Until at
-> least one screen carries the field, `/kanban:next` will return no
+> least one screen carries the field, `/kanban:doing` will return no
 > work even if cards exist.**
 
 On `ok=true`, persist the new field:
@@ -423,7 +423,7 @@ MCP scan:   ✓ no conflicts | ⚠ <count> conflict(s)
 Try:
   • /kanban:whoami       — confirm current state
   • /kanban:status       — read live Jira state for this AP
-  • /kanban:next         — claim the next TODO for this AP
+  • /kanban:doing         — claim the next TODO for this AP
 ```
 
 ## Absolute rules

--- a/plugins/kanban/commands/mentions.md
+++ b/plugins/kanban/commands/mentions.md
@@ -75,10 +75,14 @@ For each mention, the LLM should follow the `kanban-jira-agent` skill's
 
 - Read the card (description + recent comments)
 - Estimate workload
-- Small (1–3h): `/kanban:next --task-id <KEY>` to claim, do the work,
-  then `/kanban:reply <KEY> --to <authorAccountId> --body "..."`
+- Small (1–3h): the @-mention authorizes you to move the card —
+  `/kanban:transition <KEY> --to DOING`, then `/kanban:doing` to pick
+  it up, do the work, then `/kanban:reply <KEY> --to <authorAccountId>
+  --body "..."`
 - Large (>3h): `/kanban:create-sub <KEY> --title "..."` to spawn 2–5
-  sub-cards, then claim them one at a time
+  sub-cards; owner moves the first sub into DOING (or you may
+  `/kanban:transition` it on their behalf when their mention's intent
+  is clear), then `/kanban:doing` to work it
 - Uncertain: `/kanban:question <KEY> "<clarifying question>"`
 
 ## 4. Mark as read

--- a/plugins/kanban/commands/next.md
+++ b/plugins/kanban/commands/next.md
@@ -1,20 +1,33 @@
 ---
-description: Pick the next kanban task and move it to DOING.
+description: DEPRECATED — use /kanban:doing (Jira mode) or /kanban:next is still the local-mode pick-one helper.
 argument-hint: [--category=X] [--priority=Y] [<task-id>]
 allowed-tools: Read, Bash(python3:*), Bash(date:*)
 ---
 
-# /kanban:next
+# /kanban:next  *(deprecated for Jira mode — see /kanban:doing)*
 
 Arguments: `$ARGUMENTS`
 
-Pick the next eligible TODO task and transition it to DOING. The Skill
-`kanban-workflow` (loaded automatically) governs the rules.
+## 0. Driver check + deprecation nudge
 
-## 0. Driver check
+Read `kanban.json#backend.driver`. If absent, treat as `"local"`.
 
-Read `kanban.json` first. Look at `backend.driver`. If absent, treat as
-`"local"`. If `"jira"`, follow the Jira flow at the end of this file.
+- **Jira mode**: this command is **deprecated**. Print a deprecation
+  notice and stop:
+
+  ```
+  /kanban:next is deprecated for Jira mode (kanban@0.3.16 — see #33).
+  Use /kanban:doing instead — it works the cards already in DOING
+  rather than pulling from TODO. Owner curates TODO → DOING; agent
+  executes DOING.
+  ```
+
+  Do **not** auto-pick. The agent must not be the one moving cards
+  from TODO into DOING.
+
+- **Local mode**: continue with the existing flow below. Local mode
+  has no AP / curation distinction, so the pick-one semantics are
+  still correct here.
 
 ## 1. Parse arguments (local driver)
 
@@ -54,25 +67,10 @@ Then begin executing the task described in `description`. Treat
 `description` as the brief — ask the user for clarification if anything is
 ambiguous rather than guessing.
 
-## Jira flow
-
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py claim-next \
-  --kanban-path '<kanban.json path>'
-```
-
-| Shape | Action |
-|---|---|
-| `{ok: true, claimed: {id, title, priority, ap}}` | print `Claiming <id> "<title>" (P<n>, ap=<ap>)`, begin executing |
-| `{ok: true, claimed: null, reason}` | print `No TODO cards for AP <ap>` and stop |
-| `{ok: false, error}` | surface verbatim. If error mentions `kanban-agent.json`, suggest `/kanban:assign-ap`. |
-
 ## Absolute rules
 
+- **Jira mode**: never auto-pick from TODO. The deprecation nudge above
+  is the only correct behavior. See #33 for the rationale.
 - Never start a task whose deps are not all DONE (local mode — helper enforces).
 - Never start a task in DONE or BLOCKED.
-- Never start more than one task at a time in the same session. If a DOING
-  task already exists with assignee `claude-code`, confirm with the user
-  before starting a new one.
 - Never call the Write/Edit tool on `kanban.json` — go through the helper.
-- Jira mode: never bypass `claim-next` — it enforces AP routing.

--- a/plugins/kanban/commands/reconcile.md
+++ b/plugins/kanban/commands/reconcile.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash(python3:*)
 # /kanban:reconcile
 
 Read-only diagnostic. Finds cards that are present in Jira but invisible
-to `/kanban:status` / `/kanban:next` / `cmd_sync_summary` because they
+to `/kanban:status` / `/kanban:doing` / `cmd_sync_summary` because they
 don't satisfy the AP + status filter the plugin uses.
 
 Two checks:
@@ -18,7 +18,7 @@ Two checks:
 2. **Missing AP** — open card in the project with no AP custom field
    set. Cause: manual creation in Jira UI, an old import that pre-dates
    0.3.8, broken `/kanban:initjira` step 5, etc. Such cards never
-   appear in `/kanban:next` regardless of their status.
+   appear in `/kanban:doing` regardless of their status.
 
 `/kanban:sync` (auto on `SessionStart`) already prints a one-line drift
 reminder when this command would surface anything. This command is the
@@ -55,14 +55,14 @@ Otherwise render two sections (skip the section if its count is zero):
   Backlog:
     BZK-700
 
-[missing AP — N card(s) with no AP set, invisible to /kanban:next]
+[missing AP — N card(s) with no AP set, invisible to /kanban:doing]
   BZK-820  BZK-821  ...
 
 Suggested next steps:
   • For unmapped statuses: re-run /kanban:initjira (step 3) and add DSL
     lines mapping `TO PROGRESS` and `Backlog` to canonical columns —
     OR move the cards back to a mapped status in the Jira UI.
-  • For missing AP: claim them via /kanban:next (per repo) or set the
+  • For missing AP: claim them via /kanban:doing (per repo) or set the
     AP field directly in Jira UI for cards owned by other agents.
 ```
 

--- a/plugins/kanban/commands/show-conventions.md
+++ b/plugins/kanban/commands/show-conventions.md
@@ -55,7 +55,7 @@ Acknowledgement: <✓ acknowledged | ⚠ not acknowledged in this repo>
 
 If `alreadyAcked` is false, append:
 
-> Run `/kanban:initjira-by-code` (re-paste the same code) to ack, or
+> Run `/kanban:import-jira-code` (re-paste the same code) to ack, or
 > just type `I have read these` next time you re-init.
 
 ## Absolute rules

--- a/plugins/kanban/commands/showjira-code.md
+++ b/plugins/kanban/commands/showjira-code.md
@@ -8,7 +8,7 @@ allowed-tools: Read, Bash(python3:*), Bash(git:*)
 
 Emit the current `kanban.json#backend.jira` block as a compact JSON code
 suitable for pasting into another repo / another machine via
-`/kanban:initjira-by-code`. Use this to share a board's compound-transition
+`/kanban:import-jira-code`. Use this to share a board's compound-transition
 mapping across teammates' machines without re-running the DSL setup
 everywhere.
 
@@ -24,7 +24,7 @@ everywhere.
 - `conventions` (since /2): team narrative notes + per-team toggles
   (e.g. `blockedRequiresLink`). Empty by default — author via
   `/kanban:edit-conventions`. Receivers must acknowledge non-empty
-  notes before `/kanban:initjira-by-code` completes.
+  notes before `/kanban:import-jira-code` completes.
 
 ## What's deliberately excluded
 
@@ -35,7 +35,7 @@ everywhere.
   shared agent Atlassian account.
 - API token, base URL credentials — never. Those live in
   `~/.claude-workbench/.env` and are per-machine; the receiver runs
-  `/kanban:reset-credentials` (or step 1 of `/kanban:initjira-by-code`).
+  `/kanban:reset-credentials` (or step 1 of `/kanban:import-jira-code`).
 
 ## 0. Pre-flight
 
@@ -60,7 +60,7 @@ Print the code as a fenced JSON block, then a one-line hint:
 
 ```
 Share this code with your teammates. They paste it into
-/kanban:initjira-by-code and skip the DSL setup.
+/kanban:import-jira-code and skip the DSL setup.
 
 ```json
 {
@@ -74,7 +74,7 @@ Share this code with your teammates. They paste it into
 \```
 
 (Each receiver still needs their own Jira credentials — the code does
-NOT contain tokens. Run `/kanban:initjira-by-code` on the receiver
+NOT contain tokens. Run `/kanban:import-jira-code` on the receiver
 side; if they don't yet have credentials saved, the command will
 capture them up-front.)
 ```

--- a/plugins/kanban/lib/conventions.py
+++ b/plugins/kanban/lib/conventions.py
@@ -160,7 +160,7 @@ def has_recent_ack(
     conventions: dict[str, Any] | None,
 ) -> bool:
     """Return True iff `.claude/kanban-agent.json` records an ack whose
-    hash matches `conventions`. Allows /kanban:initjira-by-code to skip
+    hash matches `conventions`. Allows /kanban:import-jira-code to skip
     the friction prompt when the user has already acknowledged this exact
     convention set in this repo.
     """

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1560,6 +1560,52 @@ def cmd_read_agent_ap(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_list_doing(args: argparse.Namespace) -> int:
+    """List my-AP cards currently in DOING. Read-only — does NOT pull
+    from TODO and does NOT transition. Backs `/kanban:doing` (#33).
+
+    Returns: {ok, ap, doing: [{id, title, priority, started, ...}, ...]}
+    The slash-command then reads the list and decides execution order
+    across the (small) DOING set without scanning the wider backlog.
+    """
+    p = Path(args.kanban_path)
+    if not p.exists():
+        _fail(f"kanban.json not found at {p}")
+        return 1
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        _fail("backend.driver must be 'jira'")
+        return 1
+    ap = _read_repo_ap(p)
+    if not ap:
+        _fail(
+            "this repo has no AP set — run /kanban:assign-ap <name> first",
+        )
+        return 1
+
+    from drivers import get_driver
+    from drivers.base import TaskFilter
+
+    driver = get_driver(data, p.parent)
+    try:
+        cards = driver.list_tasks(TaskFilter(column="DOING", ap=ap))
+    except Exception as e:  # noqa: BLE001
+        _fail(f"{type(e).__name__}: {e}")
+        return 1
+    out: list[dict[str, Any]] = []
+    for t in cards:
+        out.append({
+            "id": t.id,
+            "title": t.title,
+            "priority": t.priority,
+            "started": t.started,
+            "ap": t.ap,
+        })
+    _emit({"ok": True, "ap": ap, "doing": out})
+    return 0
+
+
 def cmd_claim_next(args: argparse.Namespace) -> int:
     p = Path(args.kanban_path)
     if not p.exists():
@@ -2733,6 +2779,14 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("claim-next")
     s.add_argument("--kanban-path", required=True)
     s.set_defaults(func=cmd_claim_next)
+
+    s = sub.add_parser(
+        "list-doing",
+        help="List my-AP cards currently in DOING. Read-only; does not "
+             "pull from TODO. Used by /kanban:doing (#33).",
+    )
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_list_doing)
 
     s = sub.add_parser("transition")
     s.add_argument("--kanban-path", required=True)

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22; do  # 8-22: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23; do  # 8-23: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase23.py
+++ b/plugins/kanban/scripts/test_phase23.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Phase 23 regression checks for kanban v0.3.16 — `list-doing` helper
+backing /kanban:doing.
+
+Closes #33. /kanban:doing replaces the single-step "auto-pick from
+TODO" model with "agent works the cards already in DOING for its AP."
+The owner curates TODO → DOING; the agent's job is to execute, not
+play PM. The new helper subcommand is read-only: it never transitions
+a card and never pulls from TODO.
+
+Cases:
+  (a) Happy path — DOING has cards: returns them with id/title/
+      priority/started/ap fields, and the JQL hitting Jira filters by
+      both column=DOING and ap=<repo_ap>.
+  (b) Empty DOING — returns ok=true with doing=[] (slash command then
+      tells the user "owner needs to move a TODO into DOING").
+  (c) No repo AP set in .claude/kanban-agent.json — fail with the
+      assign-ap nudge.
+  (d) Local backend — fail (jira-only command).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _mock_client(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return JiraClient(
+        "https://x", "a@b", "tok",
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old
+    return rc, out
+
+
+def _seed_jira_kanban(td: pathlib.Path, *, with_ap: bool = True) -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW", "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    if with_ap:
+        (td / ".claude").mkdir()
+        (td / ".claude" / "kanban-agent.json").write_text(
+            json.dumps({"ap": "agent-fin"}) + "\n"
+        )
+    return p
+
+
+def _seed_local_kanban(td: pathlib.Path) -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "local"},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _stub_driver(cards: list, *, captured_filter: list):
+    """Return a stub driver whose list_tasks() captures the TaskFilter
+    it was called with and returns the prepared cards. Used to verify
+    cmd_list_doing passes the right column+ap to the driver layer
+    without having to mock the full HTTP path."""
+    from drivers.base import Task
+
+    class _StubDrv:
+        name = "jira"
+
+        def list_tasks(self, filter=None):
+            captured_filter.append(filter)
+            return cards
+
+    return _StubDrv()
+
+
+def _mk_task(*, id, title, priority="P1", started=None, ap="agent-fin"):
+    from drivers.base import Task
+    return Task(
+        id=id, title=title, column="DOING",
+        priority=priority, category=None, tags=[], depends=[],
+        assignee=None, description="", comments=[],
+        created="x", updated="y",
+        started=started, completed=None,
+        ap=ap,
+    )
+
+
+def test_list_doing_returns_doing_cards_filtered_by_ap():
+    """list_tasks must be called with TaskFilter(column=DOING, ap=<repo_ap>);
+    the response is shaped as {ok, ap, doing: [...]}.
+    """
+    captured: list = []
+    cards = [
+        _mk_task(id="AGENT-101", title="first doing", priority="P0"),
+        _mk_task(id="AGENT-102", title="second doing", priority="P1"),
+    ]
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        import drivers as _drv_mod
+        d_orig = _drv_mod.get_driver
+        _drv_mod.get_driver = lambda data, root: _stub_driver(cards, captured_filter=captured)
+        try:
+            class A: kanban_path = str(kp)
+            rc, out = _capture(_jira_setup.cmd_list_doing, A())
+        finally:
+            _drv_mod.get_driver = d_orig
+
+    assert rc == 0, out
+    j = json.loads(out)
+    assert j["ok"] is True
+    assert j["ap"] == "agent-fin"
+    assert len(j["doing"]) == 2
+    assert {c["id"] for c in j["doing"]} == {"AGENT-101", "AGENT-102"}
+
+    # The TaskFilter passed to driver.list_tasks must constrain BOTH
+    # column AND ap — that's the heart of #33 (don't scan the whole
+    # backlog; only the DOING set for this repo's AP).
+    assert len(captured) == 1
+    f = captured[0]
+    assert f.column == "DOING", f
+    assert f.ap == "agent-fin", f
+
+
+def test_list_doing_empty_returns_ok_with_empty_list():
+    """Empty DOING is ok=true (the slash command then tells the user
+    'owner needs to move a TODO into DOING'); never auto-fall-through."""
+    captured: list = []
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        import drivers as _drv_mod
+        d_orig = _drv_mod.get_driver
+        _drv_mod.get_driver = lambda data, root: _stub_driver([], captured_filter=captured)
+        try:
+            class A: kanban_path = str(kp)
+            rc, out = _capture(_jira_setup.cmd_list_doing, A())
+        finally:
+            _drv_mod.get_driver = d_orig
+
+    assert rc == 0, out
+    j = json.loads(out)
+    assert j["ok"] is True
+    assert j["doing"] == []
+
+
+def test_list_doing_without_repo_ap_fails():
+    """Missing .claude/kanban-agent.json → fail, hint at /kanban:assign-ap."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td, with_ap=False)
+
+        class A: kanban_path = str(kp)
+        rc, out = _capture(_jira_setup.cmd_list_doing, A())
+
+    assert rc != 0, out
+    j = json.loads(out)
+    assert j.get("ok") is False
+    assert "assign-ap" in (j.get("error") or ""), j
+
+
+def test_list_doing_against_local_backend_fails():
+    """Jira-only command — refuse on local backend."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_local_kanban(td)
+
+        class A: kanban_path = str(kp)
+        rc, out = _capture(_jira_setup.cmd_list_doing, A())
+
+    assert rc != 0, out
+    j = json.loads(out)
+    assert j.get("ok") is False
+    assert "jira" in (j.get("error") or "").lower(), j
+
+
+def main() -> int:
+    cases = [
+        ("list_doing_returns_doing_cards_filtered_by_ap",
+         test_list_doing_returns_doing_cards_filtered_by_ap),
+        ("list_doing_empty_returns_ok_with_empty_list",
+         test_list_doing_empty_returns_ok_with_empty_list),
+        ("list_doing_without_repo_ap_fails",
+         test_list_doing_without_repo_ap_fails),
+        ("list_doing_against_local_backend_fails",
+         test_list_doing_against_local_backend_fails),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase23: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase23: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/skills/kanban-jira-agent/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-agent/SKILL.md
@@ -17,12 +17,18 @@ Jira MCP server even if one is available in your environment.
 summary; cards listed are yours. If you suspect stale state, run
 `/kanban:sync` again explicitly.
 
-## Picking work
+## Working the DOING pool
 
-- `/kanban:next` — claims the highest-priority TODO card scoped to your AP,
-  transitions it to In Progress, and posts a `[<ap>] [S] claimed` system
-  comment. Do this **before** starting any work.
-- Do not claim a card already DOING by another AP — the precheck hook
+- `/kanban:doing` — read every card already in DOING scoped to your AP,
+  decide an execution order across them (deps, module affinity,
+  priority as tiebreaker), then work them sequentially. Read-only —
+  this command does NOT pull from TODO.
+- **TODO → DOING is the owner's call.** If a card you want to work is
+  still in TODO, ask the owner to move it (Jira UI or their own
+  `/kanban:transition`); do not transition it yourself unless an
+  explicit @-mention from the owner names that card with start intent
+  (see "When you're @-mentioned" below).
+- Do not work a DOING card owned by another AP — the precheck hook
   warns you when you mention such a card.
 
 ## During work
@@ -60,19 +66,21 @@ Treat each mention as a directive. Process:
 
 3. **Act based on estimate**:
 
-   - **Small** — claim and execute:
+   - **Small** — the @-mention authorizes you to transition this card
+     into DOING (the owner is the one asking):
      ```
-     /kanban:next --task-id <KEY>      # claim, move to DOING
+     /kanban:transition <KEY> --to DOING    # owner-authorized TODO → DOING move
+     /kanban:doing                          # read DOING and pick this card up
      # ... do the actual work ...
-     /kanban:done <KEY>                 # transition to REVIEW
+     /kanban:done <KEY>                     # transition to REVIEW
      /kanban:reply <KEY> --to <authorAccountId> --body "<verdict + status>"
      ```
-   - **Large** — break down without claiming the parent:
+   - **Large** — break down without transitioning the parent:
      ```
      /kanban:create-sub <KEY> --title "..." --title "..." --title "..."
      /kanban:reply <KEY> --to <authorAccountId> --body "Spawned <N> sub-cards: <list>"
-     # then claim the first sub-card and start
-     /kanban:next --task-id <first-sub-key>
+     # owner reviews and moves the first sub-card to DOING; then:
+     /kanban:doing
      ```
    - **Ask first** — don't claim anything yet:
      ```

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -85,7 +85,7 @@
               "properties": {
                 "notes": {
                   "type": "array",
-                  "description": "Short prose notes shown to anyone importing the board code. Receivers are required to acknowledge before /kanban:initjira-by-code completes.",
+                  "description": "Short prose notes shown to anyone importing the board code. Receivers are required to acknowledge before /kanban:import-jira-code completes.",
                   "items": { "type": "string" }
                 },
                 "blockedRequiresLink": {


### PR DESCRIPTION
## Summary

Two slash command renames; helper subcommands and overall framing now match what the commands actually do.

### #33 — `/kanban:next` → `/kanban:doing` (Jira mode)

The old name implied a single-step "pick the next task" model, but the actual workflow on a multi-card AP is "agent works through every card the owner has placed in DOING, reasoning across them." The new command reads only `status=DOING AND assignee=this-AP` cards and **never pulls from TODO**.

```
TODO  ──(owner moves)──▶  DOING  ──(/kanban:doing executes)──▶  DONE
```

- **TODO → DOING is the owner's call.** Agent must never pull unless an explicit @-mention from the owner names a card with start intent.
- **Token-cost win**: an 11-card TODO backlog was being scanned just to pick one card — now only the small DOING set is read.
- **Local mode keeps `/kanban:next` semantics** — local has no AP routing, the pick-one model is still right there.
- `/kanban:next` becomes a deprecation shim for one release cycle: in Jira mode it prints a notice and stops; in local mode it still works.

### #34 — `/kanban:initjira-by-code` → `/kanban:import-jira-code`

The helper has always been `import-jira-code` — the slash command now matches. The new name also makes obvious that the command is **not** just first-run init: it works for re-sync too. To smooth the re-sync path:

- **Step 3 (AP) is now idempotent**: when `.claude/kanban-agent.json#ap` is set AND the AP still appears in `live-list-aps`, the prompt is skipped and a one-line confirmation is printed. Re-import after a `/kanban:edit-conventions` change becomes friction-free.
- The conventions ack-hash mechanism is preserved (forces re-ack when notes drift — that's the team-drift safety net).
- `/kanban:initjira-by-code` becomes a deprecation shim that prints a notice and forwards.

Closes #33
Closes #34

## Files

**New**:
- `plugins/kanban/commands/doing.md` — read-then-execute model, explicit "owner moves TODO→DOING" rule
- `plugins/kanban/commands/import-jira-code.md` — bootstrap + re-sync, idempotent AP step
- `plugins/kanban/scripts/test_phase23.py` — 4 cases for `list-doing`

**Modified**:
- `plugins/kanban/scripts/jira_setup.py` — new `cmd_list_doing` + `list-doing` argparse
- `plugins/kanban/commands/next.md` — deprecation shim (Jira) + local fallback
- `plugins/kanban/commands/initjira-by-code.md` — deprecation shim
- `plugins/kanban/skills/kanban-jira-agent/SKILL.md` — "Picking work" → "Working DOING", explicit "TODO→DOING is owner's call"
- 18 cross-reference updates across README, quickstarts, SKILL, and Jira-flavored commands

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 23 phases green
- [x] Phase 23 (4 new cases): list-doing returns DOING-only cards with TaskFilter(column=DOING, ap=<repo_ap>); empty DOING is `ok=true` with empty list; missing repo AP fails with assign-ap nudge; local backend refused
- [ ] Manual: in a Jira-mode repo with cards in DOING, run `/kanban:doing` and verify only DOING cards (not TODO) are listed
- [ ] Manual: in a Jira-mode repo, run `/kanban:next` and verify the deprecation notice appears
- [ ] Manual: run `/kanban:import-jira-code` on a repo that already has its AP set; verify Step 3 prints `AP: <name> (kept from existing config)` and skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)