### PR TITLE
docs(kanban): 0.3.17 — same-repo-different-machine UX clarity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-03 (kanban same-repo-different-machine UX)
+
+### Changed
+- **kanban 0.3.17** — documentation + slash-command guidance for the
+  "same repo cloned on a new machine" flow. No code or test changes;
+  pure UX clarity.
+
+  Background: `kanban.json` is committed by `kanban-autocommit.sh` and
+  travels with the repo via git. In Jira mode it carries the full
+  `backend.jira` block (transitions, projectKey, ap.fieldId,
+  conventions) — i.e. the same payload `/kanban:showjira-code` would
+  emit, except git is the transport. The only legitimately
+  per-machine state is the API token in `~/.claude-workbench/.env`.
+  So when you `git clone` (or `git pull`) a repo that's already in
+  Jira mode on a new machine, you do NOT need to re-paste the code
+  — you just need to capture this machine's token.
+
+  But the existing docs hid that. The Multi-machine cheatsheet only
+  listed "new repo" / "teammate joining" scenarios; readers reached
+  for `/kanban:import-jira-code` and re-pasted redundantly.
+  `/kanban:reset-credentials` was the right tool but its description
+  framed it purely as "rotate Jira credentials," not "first-time
+  setup on this machine for an existing repo."
+
+  Fixed:
+
+  - `commands/reset-credentials.md` description and body now spell
+    out both use cases: first-time-on-this-machine setup AND token
+    rotation.
+  - `commands/import-jira-code.md` step 0 now detects when
+    `backend.jira` already has a non-empty `transitions` map (the
+    git-pull signal) and proactively suggests `/kanban:reset-credentials`
+    before doing a wholesale re-import. Default no on the "continue
+    anyway" prompt — the import will replace `backend.jira` wholesale,
+    which is rarely what someone wants when their config came from
+    git.
+  - `kanban_quickstart.md` + `kanban_quickstart_zhtw.md` cheatsheet
+    gains a new row: "Same repo, different machine → `git pull` +
+    `/kanban:reset-credentials`." A blockquote underneath explains
+    why this works (autocommit hook + git transport).
+
 ## 2026-05-03 (kanban command renames + scope narrowing)
 
 ### Changed

--- a/kanban_quickstart.md
+++ b/kanban_quickstart.md
@@ -215,7 +215,17 @@ Setup splits into three layers, each with a different lifecycle:
 |---|---|
 | **All-new machine + all-new repo** | `/kanban:init` → `/kanban:import-jira-code` (does credentials + paste code + assign AP in one flow) |
 | **Same machine, new repo** | `/kanban:init` → `/kanban:import-jira-code` (credentials auto-skipped — already on this machine; only paste code + assign AP run interactively) |
-| **Existing repo already in Jira mode** | Nothing — already set up. `/kanban:whoami` to verify. |
+| **Same repo, different machine** (you cloned a repo that's already in Jira mode) | `git pull` → `/kanban:reset-credentials`. `kanban.json` already carries the full `backend.jira` block via git, so the only thing this machine needs is your per-machine Jira token. **No need to re-paste the code.** |
+| **Existing repo already in Jira mode on this machine** | Nothing — already set up. `/kanban:whoami` to verify. |
+
+> **Why same-repo-different-machine is easy**: `kanban.json` is committed
+> by the `kanban-autocommit.sh` PostToolUse hook and travels with `git
+> push` / `git pull`. The `backend.jira` block (transitions, projectKey,
+> ap.fieldId, conventions) is the same payload `/kanban:showjira-code`
+> would emit — except git is doing the transport for you. The only
+> per-machine state is your Jira API token in `~/.claude-workbench/.env`,
+> which is not in git (and shouldn't be — each machine should have its
+> own token).
 
 ### How it works
 

--- a/kanban_quickstart_zhtw.md
+++ b/kanban_quickstart_zhtw.md
@@ -205,7 +205,15 @@ Setup 拆成**三層**，每層有自己的生命週期：
 |---|---|
 | **全新機器 + 全新 repo** | `/kanban:init` → `/kanban:import-jira-code`（一個指令做完憑證 + 貼 code + 選 AP） |
 | **同機器 + 新 repo** | `/kanban:init` → `/kanban:import-jira-code`（憑證自動跳過——本機已有；只剩貼 code + 選 AP 互動） |
-| **既有 repo 已是 jira mode** | 啥都不用——已 setup。`/kanban:whoami` 可驗證 |
+| **同 repo + 換機器**（clone 一個已經是 jira mode 的 repo） | `git pull` → `/kanban:reset-credentials`。`kanban.json` 已經帶完整 `backend.jira` block 透過 git 過來了，這台只缺自己這台機器的 Jira token。**不用重貼 code。** |
+| **既有 repo 已是 jira mode 在這台** | 啥都不用——已 setup。`/kanban:whoami` 可驗證 |
+
+> **為什麼同 repo 換機器這麼簡單**：`kanban.json` 會被 `kanban-autocommit.sh`
+> PostToolUse hook 自動 commit，跟著 `git push` / `git pull` 走。`backend.jira`
+> block（transitions、projectKey、ap.fieldId、conventions）就是
+> `/kanban:showjira-code` 印出來那份 JSON——只是 git 幫你做傳輸。唯一 per-machine
+> 的東西是你 `~/.claude-workbench/.env` 裡的 Jira API token，那個不在 git 裡
+> （也不該在——每台機器各拿一張 token 比較安全）。
 
 ### 運作原理
 

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/import-jira-code.md
+++ b/plugins/kanban/commands/import-jira-code.md
@@ -35,11 +35,29 @@ You still need:
 - Confirm `kanban.json` exists at the project root. If missing, run
   `/kanban:init` first.
 - `$CLAUDE_PROJECT_DIR` (or `git rev-parse --show-toplevel`) → kanban path.
-- If `kanban.json#backend.driver` is already `"jira"`, ask the user
-  whether to overwrite the current mapping (the import will replace
-  `backend.jira` wholesale). For routine re-sync this is the expected
-  flow — say yes; for a fresh code from an unfamiliar source, double-check
-  it's the right team's payload first.
+- **Check whether the config is already in place from git.** Read
+  `kanban.json#backend.jira` — if `driver == "jira"` AND `transitions`
+  is non-empty (any keys configured), this repo already has its full
+  Jira config from a prior `git pull`. The most likely intent in that
+  case is "I cloned this repo on a new machine and just need to set my
+  Jira token here," not "I want to re-paste the entire code." Surface
+  this proactively:
+
+  ```
+  ⓘ kanban.json already has a complete backend.jira block (probably
+    from `git pull`). On a same-repo-different-machine setup, what
+    you usually want is just /kanban:reset-credentials to capture the
+    Jira token for THIS machine — config itself travels via git.
+
+    Continue with full re-import anyway? [y/N]
+  ```
+
+  Default no. If the user says no, exit with a one-line nudge to run
+  `/kanban:reset-credentials`. If yes, proceed with the rest of the
+  flow — the import will replace `backend.jira` wholesale (which is
+  the correct behavior for a genuine config drift / re-sync).
+- If the user opts in (or `backend.jira` is empty / driver is `local`),
+  proceed.
 
 ## Step 1/3 — Credentials
 

--- a/plugins/kanban/commands/reset-credentials.md
+++ b/plugins/kanban/commands/reset-credentials.md
@@ -1,12 +1,22 @@
 ---
-description: Rotate Jira API credentials for the current machine.
+description: Set or rotate Jira credentials on this machine — entry point for both first-time-on-this-machine setup and token rotation.
 allowed-tools: Bash(python3:*), AskUserQuestion
 ---
 
 # /kanban:reset-credentials
 
-Re-prompt and overwrite the Jira credentials in `~/.claude-workbench/.env`.
-Use when the API token has been rotated, expired, or exposed.
+Capture (or re-capture) the Jira credentials in `~/.claude-workbench/.env`.
+Two main use cases:
+
+- **First-time setup on a new machine for an existing repo.** When you
+  `git clone` (or `git pull`) a repo that already has Jira mode
+  configured, `kanban.json` carries the full `backend.jira` block
+  (transitions, projectKey, ap.fieldId, conventions) already — config
+  travels via git. The only thing this machine is missing is your
+  Jira API token, which is per-machine by design. Run this command to
+  capture it, no need to re-paste the code via `/kanban:import-jira-code`.
+- **Token rotation.** Existing token expired, was rotated by an admin,
+  or was exposed; replace it.
 
 This command does NOT touch `kanban.json`, AP registry, or any other
 plugin's configuration. Only the `JIRA_*` lines in `.env` are replaced.


### PR DESCRIPTION
## Summary

Surface the existing-but-hidden "same repo, different machine" flow.

**Background**: `kanban.json` is committed by `kanban-autocommit.sh` and travels with the repo via git. In Jira mode it carries the full `backend.jira` block (transitions, projectKey, ap.fieldId, conventions) — the same payload `/kanban:showjira-code` would emit, except git is the transport. The only legitimately per-machine state is the API token in `~/.claude-workbench/.env`.

So when you `git clone` (or `git pull`) a repo that's already in Jira mode on a new machine, you do **NOT** need to re-paste the code via `/kanban:import-jira-code`. You just need to capture this machine's Jira token.

But the existing docs hid that:

- The Multi-machine cheatsheet only listed "new repo" / "teammate joining" scenarios; readers reached for `/kanban:import-jira-code` and re-pasted the same code their `git pull` just delivered.
- `/kanban:reset-credentials` was the right tool but its description framed it purely as "rotate Jira credentials" — readers couldn't tell it was also the entry point for "first-time-on-this-machine setup."

## Files (docs-only, no code or test changes)

- `plugins/kanban/commands/reset-credentials.md` — description + body now cover both use cases: first-time-on-this-machine setup AND token rotation.
- `plugins/kanban/commands/import-jira-code.md` — step 0 detects when `backend.jira` already has a non-empty `transitions` map (the git-pull signal) and proactively suggests `/kanban:reset-credentials` before doing a wholesale re-import. Default **no** on the "continue anyway" prompt — re-import would clobber the just-pulled config.
- `kanban_quickstart.md` + `kanban_quickstart_zhtw.md` — cheatsheet gains a "Same repo, different machine → `git pull` + `/kanban:reset-credentials`" row, plus a blockquote explaining the autocommit-hook + git-transport mechanic.
- Version bump 0.3.16 → 0.3.17, CHANGELOG entry.

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 23 phases still green (smoke run; this PR has no behavior change)
- [ ] Manual: on a fresh machine, `git clone` a Jira-mode repo, verify `/kanban:reset-credentials` description now reads as the right entry point
- [ ] Manual: in a repo where `backend.jira.transitions` is already populated (came from git), run `/kanban:import-jira-code`, verify the new pre-flight prompt appears and defaults to no

🤖 Generated with [Claude Code](https://claude.com/claude-code)