### PR TITLE
security(kanban): 0.3.18 — secret-safe token capture (no token in Bash tool)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.17",
+      "version": "0.3.18",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,77 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-03 (kanban secret-safe token capture)
+
+### Security
+- **kanban 0.3.18** — token capture flow no longer routes the API
+  token through the agent's Bash tool, so the token literal can't end
+  up in Claude Code's conversation transcript. Closes #42.
+
+  **The original bug**: `/kanban:reset-credentials` and
+  `/kanban:initjira` step 1 told the agent to capture the token via
+  `AskUserQuestion`, then to run `echo "<TOKEN>" | python3 ... store-
+  credentials ...` through the Bash tool. Claude Code prints every Bash
+  command to the conversation transcript for transparency, so the
+  token literal was logged. The plugin's own leak detector then warned
+  the user to rotate — a self-inflicted loop where you set up the
+  token following the docs and immediately got told you'd leaked it.
+
+  **The fix** has three parts:
+
+  - `_read_token` accepts `prompt=True`, which uses
+    `getpass.getpass`. `getpass` reads from the controlling terminal
+    directly: never argv, never stdin pipe, never the parent
+    process's view of file descriptors. `EOFError` /
+    `KeyboardInterrupt` exit cleanly with rc=2.
+  - `store-credentials` and `validate-credentials` gain
+    `--prompt-token` flags that drive the prompt path. Existing
+    automation that pipes the token via stdin still works (back-compat
+    preserved) but the new agent-facing flow is `--prompt-token`.
+  - `validate-project` gains `--from-env`, which reads the token from
+    `~/.claude-workbench/.env` (where step 1's `store-credentials`
+    wrote it) instead of stdin. This lets `/kanban:initjira` step 2
+    validate the project + board without piping the token through
+    a Bash command at all.
+
+  **Slash command flow change**: `/kanban:reset-credentials` step 3
+  and `/kanban:initjira` step 1 are now USER-DRIVEN — the agent
+  prints a block of instructions for the user to run in their own
+  terminal:
+
+  ```
+  python3 .../jira_setup.py store-credentials \
+    --base-url "<URL>" --email "<EMAIL>" --prompt-token
+  ```
+
+  The user runs this, sees `Jira API token:` (no echo), pastes,
+  presses Enter. The token never traverses the agent's Bash tool, so
+  it never appears in the conversation transcript. The agent then
+  verifies via `read-credentials` (no token in argv) + `/kanban:whoami`
+  (token read from `.env`).
+
+  Both commands now carry an explicit absolute rule: "**NEVER** call
+  the Bash tool with a command that contains the token literal" — and
+  "**NEVER** ask for the token via `AskUserQuestion`" (the user's
+  response is also part of the conversation log).
+
+  Phase 24 covers six cases: `_read_token(prompt=True)` reads from
+  getpass and strips whitespace; clean abort on EOF/Ctrl-C;
+  `store-credentials --prompt-token` writes to `.env` without touching
+  stdin; back-compat — stdin path still works without the flag;
+  `validate-project --from-env` reads from `.env`, never stdin;
+  missing-token-in-`.env` fails with a `reset-credentials` hint.
+
+### Fixed
+- Phase 3's `_setup_cmd` now defaults `HOME` to a throwaway directory
+  so a real `~/.claude-workbench/.env` on the test machine doesn't
+  trigger live Jira API calls and mask the offline-only assertions
+  (e.g. fuzzy-collision check). Symptom on a developer machine with
+  an existing `.env`: `register-ap` saw real credentials, hit the
+  Jira instance, got 404 / 401, and `register_ap_fuzzy_no_force`
+  failed with a network error instead of returning the expected
+  fuzzy-match warning.
+
 ## 2026-05-03 (kanban same-repo-different-machine UX)
 
 ### Changed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/initjira.md
+++ b/plugins/kanban/commands/initjira.md
@@ -30,52 +30,65 @@ ALWAYS pipe the token via stdin (`echo "$TOKEN" | python3 .../jira_setup.py …`
 
 ## Step 1/3 — Credentials
 
-If credentials already exist (call `python3 jira_setup.py read-credentials` and
-check `tokenPresent`), validate them silently:
+Check if credentials already exist:
 
 ```bash
-echo "$TOKEN_FROM_ENV" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
-  validate-credentials --base-url <baseUrl> --email <email>
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
 ```
 
-But you don't have access to the stored token from this session — instead,
-*delegate the validation to a helper that reads from .env itself*. Use:
+If `tokenPresent: true`, run `/kanban:whoami` to confirm they
+authenticate; if it succeeds, print "Detected valid Jira credentials
+from a previous run. Skipping Step 1." and continue to Step 2.
 
-```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py health --kanban-path <kanban.json>
-```
-
-If health returns `ok=true`, print "Detected valid Jira credentials from a
-previous run. Skipping Step 1." and continue to Step 2.
-
-Otherwise, capture inputs via three separate `AskUserQuestion` calls:
+Otherwise, capture **base URL + email** via two `AskUserQuestion` calls:
 
 1. **Base URL** — example: `https://yourteam.atlassian.net`. Validate the
    pattern `https?://[^/ ]+` before continuing.
 2. **Shared agent account email** — the Atlassian account agents will operate
    under. Pattern: standard email.
-3. **API token** — generated at https://id.atlassian.com/manage-profile/security/api-tokens.
-   30+ alnum characters. Treat as secret — do not display or echo.
 
-Then validate (token via stdin):
+Do **NOT** ask for the API token here. The token is captured in the
+next sub-step by the user themselves, in their own terminal.
 
-```bash
-echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
-  validate-credentials --base-url '<URL>' --email '<EMAIL>'
+### Token capture (USER-DRIVEN — do NOT run via Bash tool)
+
+> ⚠ **The token must NOT enter Claude Code's conversation log.** Claude
+> Code's Bash tool prints every command it runs to the conversation
+> transcript, so any `echo "<token>" | ...` you might construct leaks
+> the token. Use `--prompt-token` (added in kanban@0.3.18) and have the
+> user run it themselves.
+
+Print this block to the user verbatim, then **stop and wait**:
+
+```
+─────────────────────────────────────────────────────────────────
+For security, paste your Jira API token in YOUR OWN terminal, not
+through this chat. Open a terminal on this machine and run:
+
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+    store-credentials --base-url "<URL>" --email "<EMAIL>" \
+    --prompt-token
+
+You'll see:
+  Jira API token:
+Paste the token (generated at
+https://id.atlassian.com/manage-profile/security/api-tokens) at the
+prompt and press Enter (it won't echo). On success: {"ok": true}
+
+Then come back here and tell me "done" so I can verify.
+─────────────────────────────────────────────────────────────────
 ```
 
-Parse the JSON. On `ok=false`, print the error verbatim (it does NOT contain
-the token) and ask the user to re-enter the token. Repeat at most twice. On
-final failure, abort.
+**Substitute** `<URL>` and `<EMAIL>` with the values captured above
+before printing — those aren't secret. Do NOT substitute or invent
+any token-related field.
 
-On `ok=true`, store the credentials:
-
-```bash
-echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
-  store-credentials --base-url '<URL>' --email '<EMAIL>'
-```
-
-Confirm to user: `✓ authenticated as <displayName>; credentials saved.`
+After the user reports "done", verify with `read-credentials` (look for
+`tokenPresent: true`) and then run `/kanban:whoami` to confirm the
+token actually authenticates against Jira. If `whoami` reports
+`UNAUTHENTICATED`, tell the user "the token didn't authenticate — try
+again, or check the URL / email" and loop back to the prompt block.
+On success, confirm: `✓ authenticated as <displayName>; credentials saved.`
 
 ## Step 2/3 — Board URL
 
@@ -89,31 +102,16 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
 Result is `{"projectKey": "...", "boardId": ...}`. If parse fails, ask once
 more, then abort.
 
-Validate that the project + board are reachable with our credentials. The
-helper auto-loads token via `read-credentials`, but for explicit re-validation
-re-prompt is overkill — instead use a single combined check:
+Validate that the project + board are reachable with our credentials.
+The token is already in `~/.claude-workbench/.env` from step 1; use
+`--from-env` so the helper reads it directly — **never** echo the token
+to a Bash command (Claude Code prints every Bash command to the
+conversation log, which would leak the token; #42).
 
 ```bash
-python3 - <<'PY'
-import json, subprocess, sys
-from pathlib import Path
-CHECKER = "${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py"
-BASE = "<URL>"; EMAIL = "<EMAIL>"; PROJECT = "<KEY>"; BOARD = <ID>
-# read token from .env via helper
-out = subprocess.check_output(["python3", CHECKER, "read-credentials"])
-token_present = json.loads(out)["tokenPresent"]
-if not token_present: print("missing token"); sys.exit(1)
-PY
-```
-
-In practice — for Phase 2 ergonomics — call validate-project by re-asking the
-user for the token. Acceptable simplification: the user just typed it; the
-session can hold it briefly in memory.
-
-```bash
-echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
   validate-project --base-url '<URL>' --email '<EMAIL>' \
-  --project '<KEY>' --board <ID>
+  --project '<KEY>' --board <ID> --from-env
 ```
 
 Print `✓ project=<projectName> (<projectKey>); board=<boardName> (<boardType>)`.
@@ -428,10 +426,20 @@ Try:
 
 ## Absolute rules
 
+- **NEVER** call the Bash tool with a command that contains the token
+  literal (e.g. `echo "<actual token>" | ...`). Claude Code prints every
+  Bash command to the conversation transcript, so any such command leaks
+  the token. Token capture is user-driven via `--prompt-token` (the user
+  runs the helper in their own terminal); subsequent steps use
+  `--from-env` so the helper reads the token directly from
+  `~/.claude-workbench/.env`. See #42 for the original "your plugin
+  taught me to leak my own token" report.
+- **NEVER** ask for the token via `AskUserQuestion` either — the user's
+  response is part of the conversation log.
 - Never echo the API token back to the user.
-- Never pass the token via argv (`--token=…`) — always pipe via stdin.
 - Never write `kanban.json` via Edit/Write tools — always go through
   `jira_setup.py write-backend`.
 - If any helper call returns `ok=false`, surface its `error` field verbatim
   and stop; do not invent retry logic beyond what is specified above.
-- Never proceed past a failed `validate-credentials` even with `--partial`.
+- Never proceed past a failed token verification (`whoami` returning
+  UNAUTHENTICATED) even with `--partial`.

--- a/plugins/kanban/commands/reset-credentials.md
+++ b/plugins/kanban/commands/reset-credentials.md
@@ -34,34 +34,67 @@ Current Email:    <email>   (or "(not set)")
 Current Token:    <"present" if tokenPresent else "missing">
 ```
 
-## 1. Capture new values
+## 1. Capture base URL + email
 
-Three `AskUserQuestion` calls. For Base URL / Email, default to current value
-on empty input — tell the user "press Enter to keep current".
+Two `AskUserQuestion` calls. Defaults to current value on empty input —
+tell the user "press Enter to keep current".
 
 1. **Base URL** — same validation as `/kanban:initjira`.
 2. **Email** — Atlassian account email.
-3. **API token** — secret. Do not echo.
 
-## 2. Validate
+Do **NOT** ask for the API token here. The token is captured in step 2
+by the user themselves, in their own terminal, NOT through this chat.
 
-```bash
-echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
-  validate-credentials --base-url '<URL>' --email '<EMAIL>'
+## 2. Token capture (USER-DRIVEN — do not run via Bash tool)
+
+> ⚠ **The token must NOT enter Claude Code's conversation log.** Claude
+> Code's Bash tool prints every command it runs (including any
+> `echo "<token>" | ...` you might be tempted to construct) so the
+> agent must NEVER call Bash with a command that contains the token
+> literal. Doing so leaks the token to the conversation transcript and
+> the user has to rotate. The fix shipped in kanban@0.3.18 (#42-ish)
+> is `--prompt-token`, which captures the token interactively via
+> `getpass` — no argv, no stdin pipe, no echo.
+
+Print this block to the user verbatim, then **stop and wait**:
+
+```
+─────────────────────────────────────────────────────────────────
+For security, paste your Jira API token in YOUR OWN terminal, not
+through this chat. Open a terminal on this machine and run:
+
+  python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
+    store-credentials --base-url "<URL>" --email "<EMAIL>" \
+    --prompt-token
+
+You'll see:
+  Jira API token:
+Paste the token at the prompt and press Enter (it won't echo).
+On success: {"ok": true}
+
+Then come back here and tell me "done" so I can verify.
+─────────────────────────────────────────────────────────────────
 ```
 
-If `ok=false`, surface the error and ask once more for the token. On second
-failure, abort without writing.
+**Substitute** `<URL>` and `<EMAIL>` with the values captured in step 1
+before printing — those aren't secret. Do NOT substitute or invent any
+token-related field.
 
-## 3. Store
+After the user reports "done", proceed to step 3 to verify.
+
+## 3. Verify
+
+The store command itself doesn't validate — it just writes. After the
+user says they ran it, run a separate, no-secret-needed read:
 
 ```bash
-echo "<TOKEN>" | python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py \
-  store-credentials --base-url '<URL>' --email '<EMAIL>'
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-credentials
 ```
 
-This atomically rewrites only the `JIRA_*` lines, leaving any `PUSHOVER_*`
-or other plugin lines untouched.
+If `tokenPresent: true`, run `/kanban:whoami` to confirm the token
+actually authenticates against Jira. If `whoami` reports
+`UNAUTHENTICATED`, tell the user "the token didn't authenticate — try
+again, or check the URL / email" and loop back to step 2.
 
 ## 4. Confirm
 
@@ -69,11 +102,19 @@ or other plugin lines untouched.
 ✓ credentials updated; authenticated as <displayName>.
 ```
 
-Do NOT print the token, the email/URL is fine.
+Do NOT print the token. The email/URL is fine.
 
 ## Absolute rules
 
-- Never echo the API token.
-- Never pass the token via argv — always stdin pipe.
+- **NEVER** call the Bash tool with a command that contains the token
+  as a literal (e.g. `echo "<actual token>" | ...`). Claude Code prints
+  every Bash command to the conversation transcript; doing so leaks the
+  token immediately. Use `--prompt-token` and tell the user to run it
+  themselves. See #42 (the original "I followed your instructions and
+  the plugin then warned me my token was leaked" report).
+- **NEVER** ask for the token via `AskUserQuestion` either — the
+  user's response is part of the conversation log.
+- Never echo the API token in any output.
 - Never modify `kanban.json` here — that is the job of `/kanban:initjira`.
-- If validation fails twice, abort. Do not store an unvalidated token.
+- If verification fails twice, abort. Do not silently leave a bad token
+  in `.env`.

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -131,9 +131,33 @@ def _norm(s: str) -> str:
     return re.sub(r"[^a-z0-9 ]", "", s.lower()).strip()
 
 
-def _read_token() -> str:
+def _read_token(*, prompt: bool = False) -> str:
+    """Read the Jira API token. Default path is stdin (caller pipes the
+    token in — used by automation / CI). When `prompt=True`, the token
+    is captured interactively via `getpass.getpass`, which:
+
+      - reads from /dev/tty (or the platform equivalent) directly,
+      - never echoes typed characters to the terminal,
+      - never enters argv, stdin, or any caller's process tree.
+
+    The prompt path is the secret-safe way to capture a token in a
+    Claude-Code-style flow: the agent prints the command for the user
+    to run in their *own* terminal (NOT through the agent's Bash tool),
+    so the token literal never appears in the conversation log. See
+    SPEC §10 / the 0.3.18 changelog entry for the full rationale.
+    """
+    if prompt:
+        import getpass
+        try:
+            return getpass.getpass("Jira API token: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            sys.stderr.write("\nerror: token prompt aborted\n")
+            sys.exit(2)
     if sys.stdin.isatty():
-        sys.stderr.write("error: token expected on stdin\n")
+        sys.stderr.write(
+            "error: token expected on stdin "
+            "(or use --prompt-token to enter it interactively)\n"
+        )
         sys.exit(2)
     return sys.stdin.read().strip()
 
@@ -180,7 +204,7 @@ def _fail(msg: str, code: int = 1, **extra: Any) -> None:
 
 
 def cmd_validate_credentials(args: argparse.Namespace) -> int:
-    token = _read_token()
+    token = _read_token(prompt=getattr(args, "prompt_token", False))
     try:
         me = _client(args.base_url, args.email, token).get_myself()
     except JiraError as e:
@@ -201,7 +225,7 @@ def cmd_validate_credentials(args: argparse.Namespace) -> int:
 
 
 def cmd_store_credentials(args: argparse.Namespace) -> int:
-    token = _read_token()
+    token = _read_token(prompt=getattr(args, "prompt_token", False))
     if not token:
         _fail("empty token")
     credentials.write(
@@ -243,7 +267,20 @@ def cmd_parse_board_url(args: argparse.Namespace) -> int:
 
 
 def cmd_validate_project(args: argparse.Namespace) -> int:
-    token = _read_token()
+    if getattr(args, "from_env", False):
+        # Read token from `~/.claude-workbench/.env` (where step 1's
+        # store-credentials wrote it). Avoids agents having to pipe the
+        # token through stdin during initjira's step 2 — see #42.
+        env = credentials.read("JIRA_")
+        token = env.get("JIRA_API_TOKEN", "")
+        if not token:
+            _fail(
+                "no JIRA_API_TOKEN in ~/.claude-workbench/.env — "
+                "run /kanban:reset-credentials first",
+            )
+            return 1
+    else:
+        token = _read_token(prompt=getattr(args, "prompt_token", False))
     client = _client(args.base_url, args.email, token)
     try:
         proj = client.get_project(args.project)
@@ -2687,11 +2724,30 @@ def build_parser() -> argparse.ArgumentParser:
     s = sub.add_parser("validate-credentials")
     s.add_argument("--base-url", required=True)
     s.add_argument("--email", required=True)
+    s.add_argument(
+        "--prompt-token", action="store_true",
+        help=(
+            "Capture the token interactively via getpass (no echo, no "
+            "argv, no stdin pipe). Use this when running the command "
+            "yourself in a terminal — keeps the token out of any "
+            "Claude Code Bash-tool conversation log. Without this flag "
+            "the token is read from stdin."
+        ),
+    )
     s.set_defaults(func=cmd_validate_credentials)
 
     s = sub.add_parser("store-credentials")
     s.add_argument("--base-url", required=True)
     s.add_argument("--email", required=True)
+    s.add_argument(
+        "--prompt-token", action="store_true",
+        help=(
+            "Capture the token interactively via getpass (no echo, no "
+            "argv, no stdin pipe). Recommended path for human-driven "
+            "setup; keeps the token out of any agent's conversation "
+            "log. Without this flag the token is read from stdin."
+        ),
+    )
     s.set_defaults(func=cmd_store_credentials)
 
     s = sub.add_parser("read-credentials")
@@ -2706,6 +2762,20 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--email", required=True)
     s.add_argument("--project", required=True)
     s.add_argument("--board", required=True, type=int)
+    s.add_argument(
+        "--from-env", action="store_true",
+        help=(
+            "Read the token from ~/.claude-workbench/.env instead of "
+            "stdin. Recommended in agent-driven flows so the token "
+            "doesn't have to traverse stdin via a Bash-tool command "
+            "(which would log to the conversation transcript). Step 1's "
+            "store-credentials populates the .env file."
+        ),
+    )
+    s.add_argument(
+        "--prompt-token", action="store_true",
+        help="Capture the token interactively via getpass (no echo).",
+    )
     s.set_defaults(func=cmd_validate_project)
 
     s = sub.add_parser("build-status-map")

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23; do  # 8-23: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do  # 8-24: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (#42)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase24.py
+++ b/plugins/kanban/scripts/test_phase24.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Phase 24 regression checks for kanban v0.3.18 — secret-safe token
+capture via `--prompt-token` and `validate-project --from-env`.
+
+Background (#42): the original `store-credentials` flow had the agent
+construct `echo "<TOKEN>" | python3 ... store-credentials ...` and run
+it through Claude Code's Bash tool. Claude Code prints every Bash
+command to the conversation transcript for transparency, so the token
+literal ends up in the conversation log. The plugin's own leak detector
+then warned the user to rotate — a self-inflicted loop the user has to
+work around.
+
+The fix:
+
+1. `_read_token(prompt=True)` uses `getpass.getpass`, which reads from
+   the controlling terminal (never argv, never stdin pipe, never the
+   parent process's view of the file descriptors). Used by the user
+   themselves in their own terminal; the agent prints the command and
+   waits for the user to confirm.
+2. `validate-project --from-env` reads the token from
+   `~/.claude-workbench/.env` instead of stdin, so step 2 of
+   `/kanban:initjira` doesn't need the agent to pipe the token through
+   a Bash command either.
+
+Cases:
+  (a) `_read_token(prompt=True)` calls `getpass.getpass` and returns
+      the stripped result.
+  (b) `_read_token(prompt=True)` aborts cleanly on EOFError /
+      KeyboardInterrupt rather than crashing the helper.
+  (c) `cmd_store_credentials` with `--prompt-token` writes the token
+      from the prompt into `.env` (no stdin needed).
+  (d) `cmd_validate_project` with `--from-env` reads the token from
+      `~/.claude-workbench/.env` and never touches stdin.
+  (e) `cmd_validate_project` with `--from-env` and missing token in
+      `.env` fails with a clear "run reset-credentials" hint.
+  (f) Back-compat: `cmd_store_credentials` without `--prompt-token`
+      still reads from stdin (existing automation paths must keep
+      working).
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _capture(fn, args, *, stdin_bytes: bytes | None = None):
+    """Run `fn(args)` capturing stdout. Optionally feed `stdin_bytes`
+    on stdin (replaces sys.stdin)."""
+    old_out = sys.stdout
+    old_in = sys.stdin
+    sys.stdout = io.StringIO()
+    if stdin_bytes is not None:
+        sys.stdin = io.StringIO(stdin_bytes.decode())
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_out
+        sys.stdin = old_in
+    return rc, out
+
+
+# --- (a) (b) _read_token prompt path ------------------------------------
+
+
+def test_read_token_prompt_reads_from_getpass():
+    """When called with prompt=True, _read_token uses getpass.getpass —
+    never falls through to stdin (which would prompt for token via the
+    leaky path)."""
+    import getpass
+    orig = getpass.getpass
+    getpass.getpass = lambda prompt="": "  super-secret-token  "
+    try:
+        token = _jira_setup._read_token(prompt=True)
+    finally:
+        getpass.getpass = orig
+    # Whitespace stripped so trailing newlines from paste don't poison
+    # the env file.
+    assert token == "super-secret-token", repr(token)
+
+
+def test_read_token_prompt_handles_user_abort():
+    """Ctrl-C / EOF at the prompt exits cleanly, not with an unhandled
+    exception."""
+    import getpass
+    orig = getpass.getpass
+
+    def raises(prompt=""):
+        raise EOFError()
+
+    getpass.getpass = raises
+    try:
+        try:
+            _jira_setup._read_token(prompt=True)
+        except SystemExit as e:
+            assert e.code == 2
+            return
+        raise AssertionError("expected SystemExit on EOF")
+    finally:
+        getpass.getpass = orig
+
+
+# --- (c) (f) store-credentials prompt + stdin paths ---------------------
+
+
+def _isolated_credentials(td: pathlib.Path):
+    """Point credentials.ENV_DIR / ENV_FILE at a sandbox so we don't
+    touch the user's real .env. The constants are evaluated at module
+    load via Path.home(), so changing HOME at runtime is too late —
+    monkey-patch the constants directly. Returns originals to restore."""
+    from lib import credentials
+    home = td / "fakehome"
+    cw = home / ".claude-workbench"
+    cw.mkdir(parents=True, exist_ok=True)
+    orig_dir = credentials.ENV_DIR
+    orig_file = credentials.ENV_FILE
+    credentials.ENV_DIR = cw
+    credentials.ENV_FILE = cw / ".env"
+    return (orig_dir, orig_file)
+
+
+def _restore_credentials(originals):
+    from lib import credentials
+    credentials.ENV_DIR, credentials.ENV_FILE = originals
+
+
+def _read_env_token(td: pathlib.Path) -> str | None:
+    env_file = td / "fakehome" / ".claude-workbench" / ".env"
+    if not env_file.exists():
+        return None
+    for line in env_file.read_text().splitlines():
+        if line.startswith("JIRA_API_TOKEN="):
+            return line.split("=", 1)[1].strip().strip('"')
+    return None
+
+
+def test_store_credentials_prompt_token_writes_env_no_stdin():
+    """Happy path for the secret-safe capture: --prompt-token gets the
+    token from getpass, writes it to .env, never touches stdin."""
+    import getpass
+    orig_getpass = getpass.getpass
+    getpass.getpass = lambda prompt="": "tk-from-prompt-12345"
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        originals = _isolated_credentials(td)
+        try:
+            class A:
+                base_url = "https://x.atlassian.net"
+                email = "a@b.com"
+                prompt_token = True
+
+            # NOTE: stdin is a real TTY here; without --prompt-token the
+            # helper would sys.exit(2). Verify --prompt-token bypasses
+            # that path entirely.
+            rc, out = _capture(_jira_setup.cmd_store_credentials, A())
+            assert rc == 0, out
+            j = json.loads(out)
+            assert j["ok"] is True
+            assert _read_env_token(td) == "tk-from-prompt-12345"
+        finally:
+            _restore_credentials(originals)
+            getpass.getpass = orig_getpass
+
+
+def test_store_credentials_stdin_path_still_works():
+    """Back-compat: existing automation that pipes the token via stdin
+    must keep working (CI, scripts, etc.)."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        originals = _isolated_credentials(td)
+        try:
+            class A:
+                base_url = "https://x.atlassian.net"
+                email = "a@b.com"
+                prompt_token = False
+
+            rc, out = _capture(
+                _jira_setup.cmd_store_credentials, A(),
+                stdin_bytes=b"tk-from-stdin-67890\n",
+            )
+            assert rc == 0, out
+            assert _read_env_token(td) == "tk-from-stdin-67890"
+        finally:
+            _restore_credentials(originals)
+
+
+# --- (d) (e) validate-project --from-env --------------------------------
+
+
+def _seed_env_with_token(td: pathlib.Path, token: str):
+    """Pre-populate ~/.claude-workbench/.env with a token so
+    validate-project --from-env has something to read. Match the
+    unquoted format that credentials.write produces (no surrounding
+    double quotes)."""
+    home = td / "fakehome"
+    cw = home / ".claude-workbench"
+    cw.mkdir(parents=True, exist_ok=True)
+    (cw / ".env").write_text(
+        f"JIRA_BASE_URL=https://x.atlassian.net\n"
+        f"JIRA_AGENT_EMAIL=a@b.com\n"
+        f"JIRA_API_TOKEN={token}\n"
+    )
+
+
+def test_validate_project_from_env_reads_token_not_stdin():
+    """The from-env path should pick up the token from .env and call
+    Jira with it; stdin is irrelevant. We can't actually hit Jira in
+    tests, so monkey-patch the JiraClient to assert the token reaches
+    it without ever passing through stdin."""
+    received: dict[str, str] = {}
+
+    class _StubClient:
+        def __init__(self, base_url, email, token):
+            received["base_url"] = base_url
+            received["email"] = email
+            received["token"] = token
+
+        def get_project(self, key):
+            return {"name": "Project X", "key": key}
+
+        def get_board(self, board_id):
+            return {"name": "Board Y", "type": "scrum"}
+
+    orig_client = _jira_setup._client
+    _jira_setup._client = _StubClient
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        originals = _isolated_credentials(td)
+        try:
+            _seed_env_with_token(td, "tk-from-env-XYZ")
+
+            class A:
+                base_url = "https://x.atlassian.net"
+                email = "a@b.com"
+                project = "AGENT"
+                board = 1
+                from_env = True
+                prompt_token = False
+
+            # stdin is empty/TTY — without --from-env this would fail.
+            rc, out = _capture(_jira_setup.cmd_validate_project, A())
+            assert rc == 0, out
+            j = json.loads(out)
+            assert j["ok"] is True
+            assert received["token"] == "tk-from-env-XYZ"
+        finally:
+            _restore_credentials(originals)
+            _jira_setup._client = orig_client
+
+
+def test_validate_project_from_env_missing_token_fails_with_hint():
+    """When .env exists but has no JIRA_API_TOKEN, fail with an actionable
+    message — don't proceed with an empty token (which would 401)."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        originals = _isolated_credentials(td)
+        try:
+            # Create empty .env (no JIRA_API_TOKEN line)
+            home = td / "fakehome"
+            cw = home / ".claude-workbench"
+            cw.mkdir(parents=True, exist_ok=True)
+            (cw / ".env").write_text("")
+
+            class A:
+                base_url = "https://x.atlassian.net"
+                email = "a@b.com"
+                project = "AGENT"
+                board = 1
+                from_env = True
+                prompt_token = False
+
+            rc, out = _capture(_jira_setup.cmd_validate_project, A())
+            assert rc != 0, out
+            j = json.loads(out)
+            assert j.get("ok") is False
+            err = (j.get("error") or "").lower()
+            assert "no jira_api_token" in err, j
+            assert "reset-credentials" in err, j
+        finally:
+            _restore_credentials(originals)
+
+
+def main() -> int:
+    cases = [
+        ("read_token_prompt_reads_from_getpass",
+         test_read_token_prompt_reads_from_getpass),
+        ("read_token_prompt_handles_user_abort",
+         test_read_token_prompt_handles_user_abort),
+        ("store_credentials_prompt_token_writes_env_no_stdin",
+         test_store_credentials_prompt_token_writes_env_no_stdin),
+        ("store_credentials_stdin_path_still_works",
+         test_store_credentials_stdin_path_still_works),
+        ("validate_project_from_env_reads_token_not_stdin",
+         test_validate_project_from_env_reads_token_not_stdin),
+        ("validate_project_from_env_missing_token_fails_with_hint",
+         test_validate_project_from_env_missing_token_fails_with_hint),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase24: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase24: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase3.py
+++ b/plugins/kanban/scripts/test_phase3.py
@@ -305,6 +305,13 @@ def test_transition_allows_when_ap_differs():
 def _setup_cmd(*args, env_extra=None):
     cmd = ["python3", str(PLUGIN / "scripts" / "jira_setup.py"), *args]
     env = dict(os.environ)
+    # Default HOME to a throwaway dir so a real ~/.claude-workbench/.env
+    # on the test machine can't sneak Jira credentials into the helper
+    # (which would trigger live API calls and mask offline-only
+    # assertions like the fuzzy-collision check).
+    if "HOME" not in (env_extra or {}):
+        env["HOME"] = "/tmp/kanban-phase3-fakehome"
+        os.makedirs(env["HOME"], exist_ok=True)
     if env_extra:
         env.update(env_extra)
     return subprocess.run(cmd, capture_output=True, env=env)
@@ -316,8 +323,14 @@ def test_register_ap_fuzzy_no_force():
         kp = pathlib.Path(td) / "kanban.json"
         kp.write_text(json.dumps(_mk_data(registered=["agent-fin"])))
 
+        # Isolate HOME so a real ~/.claude-workbench/.env on the test
+        # machine doesn't trigger a live Jira call (which would 401/404
+        # and mask the fuzzy-match assertion).
+        fakehome = pathlib.Path(td) / "fakehome"
+        fakehome.mkdir(parents=True, exist_ok=True)
         out = _setup_cmd(
-            "register-ap", "--kanban-path", str(kp), "--name", "agent-fix"
+            "register-ap", "--kanban-path", str(kp), "--name", "agent-fix",
+            env_extra={"HOME": str(fakehome)},
         )
         assert out.returncode == 0, out.stderr
         j = json.loads(out.stdout)


### PR DESCRIPTION
## Summary

The original token-capture flow leaked the API token into Claude Code's conversation transcript. User-reported scenario: follow `/kanban:reset-credentials` on Windows, the agent runs `echo "<token>" | python3 ... store-credentials ...` through the Bash tool, Claude Code prints every Bash command to the transcript for transparency, and the plugin's own leak detector then warns "your token was leaked, rotate." Self-inflicted loop.

The fix removes the token from the agent's Bash tool entirely.

### Code

- `_read_token(prompt=True)` uses `getpass.getpass` — reads from the controlling terminal directly: never argv, never stdin pipe, never file descriptors visible to the parent process. EOFError / Ctrl-C exit cleanly with rc=2.
- `store-credentials` + `validate-credentials` gain `--prompt-token` flags driving the getpass path.
- `validate-project` gains `--from-env` reading the token from `~/.claude-workbench/.env` (where step 1 wrote it) instead of stdin. Step 2 of `/kanban:initjira` no longer pipes the token through Bash at all.
- Stdin pipe paths preserved for back-compat (CI/automation).

### Slash command flow

`/kanban:reset-credentials` step 3 and `/kanban:initjira` step 1 are now **USER-DRIVEN**. The agent prints:

```
For security, paste your Jira API token in YOUR OWN terminal, not
through this chat. Open a terminal on this machine and run:

  python3 .../jira_setup.py store-credentials \
    --base-url "<URL>" --email "<EMAIL>" --prompt-token

You'll see:
  Jira API token:
Paste the token at the prompt and press Enter (it won't echo).

Then come back here and tell me "done" so I can verify.
```

User runs it themselves. Token never traverses the agent's Bash tool, never enters the conversation transcript. Agent verifies via `read-credentials` (no token in argv) + `/kanban:whoami` (token read from `.env`).

Both commands carry new absolute rules:
- **NEVER** call Bash with a command containing the token literal.
- **NEVER** ask for the token via `AskUserQuestion` either (the response is also part of the conversation log).

### Drive-by fix

Phase 3's `_setup_cmd` now defaults `HOME` to a throwaway dir so a real `~/.claude-workbench/.env` on the test machine can't trigger live Jira API calls and mask offline-only assertions like the fuzzy-collision check. This was a long-standing isolation bug — symptoms only show on developer machines with an existing `.env`.

Closes #42

## Files

- `plugins/kanban/scripts/jira_setup.py` — `_read_token` prompt path, `--prompt-token` on two subcommands, `--from-env` on `validate-project`
- `plugins/kanban/commands/reset-credentials.md` — step 3 user-driven rewrite + new absolute rules
- `plugins/kanban/commands/initjira.md` — step 1 user-driven rewrite, step 2 `--from-env`, new absolute rules
- `plugins/kanban/scripts/test_phase24.py` — new (6 cases)
- `plugins/kanban/scripts/test_phase3.py` — `_setup_cmd` HOME isolation
- `plugins/kanban/scripts/test_all.sh` — wire phase 24
- Version bump 0.3.17 → 0.3.18, CHANGELOG Security entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 24 phases green (verified both with and without a real `.env` on the test machine)
- [x] Phase 24 (6 new cases): getpass path returns stripped token; clean abort on EOF; `store-credentials --prompt-token` writes `.env` without touching stdin; back-compat stdin path still works; `validate-project --from-env` reads `.env` and never stdin; missing-token in `.env` fails with `reset-credentials` hint
- [ ] Manual: on a fresh machine, run the new `/kanban:reset-credentials` flow end-to-end. Verify that no Bash command containing the token appears in the conversation transcript at any point
- [ ] Manual: run `/kanban:initjira` from scratch on a clean machine; verify steps 1+2 never echo the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)