### PR TITLE
docs: kanban 0.3.20 README + mentor 0.2.4 slash-command table refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]
@@ -31,7 +31,7 @@
     {
       "name": "mentor",
       "source": "./plugins/mentor",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "description": "Onboarding mentor for Claude Code — prescribes bootstrap reading, doc hierarchy (Epic/Sprint/Issue/ADR), and agent workflow. Replaces docsync.",
       "category": "developer-tools",
       "keywords": ["onboarding", "framework", "epic", "sprint", "issue", "adr", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-04 (plugin READMEs)
+
+### Documentation
+- **kanban 0.3.20** — new `plugins/kanban/README.md` + `README_zhtw.md`.
+  Lists every slash command (24) grouped by purpose (day-to-day,
+  inbox/async, lifecycle, setup), explains driver concepts (local vs
+  Jira, AP routing, compound transitions, conventions), enumerates
+  hooks, sketches the file layout. Drives off the convention "to find
+  available commands, the authoritative source is Claude Code's `/`
+  autocomplete; this README is the offline / discovery surface."
+- **mentor 0.2.4** — `README.md` + `README_zhtw.md` slash-command
+  table updated to include `/mentor:upgrade` and
+  `/mentor:current-state` (both shipped after the v0.1.0 MVP table
+  was written). File-layout `commands/{...}.md` line broadened to
+  reflect the seven shipped commands.
+
 ## 2026-05-04 (kanban precheck recent comments)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/README.md
+++ b/plugins/kanban/README.md
@@ -1,0 +1,132 @@
+# kanban
+
+*[繁體中文](./README_zhtw.md)*
+
+Part of the [claude-workbench](../../README.md) family. Task-state persistence + workflow grammar for Claude Code.
+
+**Two storage modes, same slash-command surface:**
+
+| Mode | Storage | When to pick |
+|---|---|---|
+| **local** | `kanban.json` at the project root | personal projects, single-machine, no team sharing |
+| **jira**  | Jira Cloud (per-board config + per-machine token) | multi-machine teams, async collaboration, mobile review |
+
+You can run `/kanban:init` (local) and graduate to `/kanban:initjira` later — the slash commands stay the same.
+
+See [`kanban_quickstart.md`](../../kanban_quickstart.md) for the walk-through, [`SPEC.md §3`](../../SPEC.md) for full design.
+
+## Install
+
+```
+> /plugin marketplace add kirinchen/claude-workbench
+> /plugin install kanban@claude-workbench
+> /kanban:init                     # local mode — scaffold kanban.json
+# (optional) switch to Jira-backed:
+> /kanban:initjira                 # interactive setup
+> /kanban:assign-ap <name>         # this repo's AP for Jira routing
+```
+
+## Slash commands
+
+The complete list reflects what's installed in your environment — Claude Code's `/` autocomplete is authoritative. As of kanban 0.3.20:
+
+### Day-to-day workflow
+
+| Command | What it does |
+|---|---|
+| `/kanban:status` | Read-only board summary (driver-aware) |
+| `/kanban:sync` | Pull the open-card summary for the current AP |
+| `/kanban:doing` | Work the DOING pool — read every card you currently own and execute in a sensible order *(Jira; local mode keeps `/kanban:next`)* |
+| `/kanban:done` | Mark a task (default: current DOING) as DONE |
+| `/kanban:block <key>` | Move a task to BLOCKED with a required reason |
+| `/kanban:question <key> "<text>"` | Post a question and transition to BLOCKED |
+| `/kanban:reply <key>` | Post a reply comment, optionally `@`-mentioning the recipient |
+
+### Inbox / async signals
+
+| Command | What it does |
+|---|---|
+| `/kanban:mentions` | List Jira comments / descriptions that `@`-mention this agent's account (your inbox) |
+| `/kanban:reconcile` | Surface cards invisible to the canonical view (unmapped status, missing AP) |
+
+### Card lifecycle
+
+| Command | What it does |
+|---|---|
+| `/kanban:create-sub <parent>` | Spawn N sub-cards from a parent issue, linked back via Jira issue link |
+| `/kanban:next` | DEPRECATED in Jira mode (use `/kanban:doing`); still works in local mode |
+
+### Setup / configuration (Jira)
+
+| Command | What it does |
+|---|---|
+| `/kanban:init` | Initialize `kanban.json` + schema in the current project |
+| `/kanban:initjira` | Switch project from local to Jira-backed (5-step interactive) |
+| `/kanban:import-jira-code` | Bootstrap or re-sync Jira mode from a code emitted by another repo |
+| `/kanban:showjira-code` | Print this repo's Jira mapping as shareable JSON (paste-ready for `import-jira-code`) |
+| `/kanban:reset-credentials` | Set or rotate Jira credentials on this machine *(secret-safe — runs in your own terminal)* |
+| `/kanban:assign-ap <name>` | Set the current repo's Agent Property (AP) — written to `.claude/kanban-agent.json` |
+| `/kanban:register-ap <name>` | Register a new AP value to the Jira AP custom field |
+| `/kanban:fix-ap-screen` | Attach the AP custom field to project screens (recovers from issue #6) |
+| `/kanban:edit-conventions` | Author or edit the team's `conventions` block — narrative notes + per-team toggles |
+| `/kanban:show-conventions` | Display the team's `conventions` block (read-only) |
+| `/kanban:enable-automation` | Install a trigger so Claude Code runs on `kanban.json` changes (cron / git hook) |
+| `/kanban:whoami` | Show current driver / board / AP / token validity |
+
+### Deprecated
+
+| Command | Replaced by |
+|---|---|
+| `/kanban:initjira-by-code` | `/kanban:import-jira-code` (#34) |
+| `/kanban:next` (Jira mode) | `/kanban:doing` (#33) |
+
+## Core concepts
+
+- **Canonical columns**: `TODO → DOING → BLOCKED → REVIEW → DONE → CANCELLED`. Slash commands always speak canonical names; the Jira driver translates via the `transitions` DSL.
+- **Compound transitions** (`v0.3+`): `BLOCKED > In Progress + Label` lets multiple canonical states share one Jira status, disambiguated by labels — see `epic/kanban_plugin_ Jira_backend_driver_UPDATE.md`.
+- **Agent Property (AP)**: a Jira single-select custom field that routes cards to specific agents/repos. Each repo declares its AP in `.claude/kanban-agent.json#ap`; commands like `/kanban:doing` filter by it (`cf[<id>] = "<repo's ap>"`).
+- **Conventions**: per-team narrative notes + opt-in toggles (e.g. `blockedRequiresLink: true`) that travel with `/kanban:showjira-code`. Receivers must explicitly acknowledge before `import-jira-code` completes.
+
+## Hooks
+
+- **PreToolUse** (`kanban-guard.sh`) — blocks Edit/Write on `kanban.json`. State changes go through slash commands.
+- **PostToolUse** (`kanban-autocommit.sh`) — auto-commits `kanban.json` as standalone commits when it's the only dirty file.
+- **SessionStart** (`kanban-session-check.sh`) — surfaces DOING / BLOCKED + mention count at session start.
+- **UserPromptSubmit** (`kanban-card-detect.sh`) — when a Jira URL or `KEY-N` is pasted into a prompt, injects card title, status, AP, recent comments as `additionalContext` (Jira mode only).
+
+## File layout
+
+```
+plugins/kanban/
+├── .claude-plugin/plugin.json
+├── commands/                        # 24 slash commands (one .md per command)
+├── drivers/
+│   ├── base.py                      # Driver protocol + Task/Comment dataclasses
+│   ├── local.py                     # kanban.json driver
+│   └── jira.py                      # Jira Cloud driver
+├── lib/
+│   ├── jira_client.py               # HTTP + ADF helpers
+│   ├── kanban_io.py                 # atomic kanban.json read/write
+│   ├── transitions.py               # compound transitions DSL
+│   ├── ap_registry.py               # AP fuzzy-collision check
+│   ├── conventions.py               # team conventions block
+│   ├── credentials.py               # ~/.claude-workbench/.env reader/writer
+│   ├── card_cache.py                # 30s precheck cache
+│   └── card_parser.py               # Jira KEY-N extraction from prompt text
+├── hooks/hooks.json
+├── scripts/
+│   ├── kanban-guard.sh              # PreToolUse
+│   ├── kanban-autocommit.sh         # PostToolUse
+│   ├── kanban-session-check.sh      # SessionStart
+│   ├── kanban-card-detect.sh        # UserPromptSubmit
+│   ├── kanban_local.py              # local-driver helper
+│   ├── jira_setup.py                # Jira-driver helper (subcommands)
+│   ├── cron-runner.sh               # /kanban:enable-automation cron mode
+│   └── test_phase{1..25}.py         # regression suite (108+ checks)
+├── skills/
+│   ├── kanban-workflow/SKILL.md     # generic + local-mode workflow
+│   └── kanban-jira-agent/SKILL.md   # Jira-mode agent behaviour
+└── templates/
+    ├── kanban.example.json
+    └── kanban.schema.json
+```

--- a/plugins/kanban/README_zhtw.md
+++ b/plugins/kanban/README_zhtw.md
@@ -1,0 +1,132 @@
+# kanban
+
+*[English](./README.md)*
+
+[claude-workbench](../../README_zhtw.md) 全家族的一員。Claude Code 的任務狀態持續化 + workflow 文法。
+
+**兩種儲存模式，同一套 slash command：**
+
+| 模式 | 儲存位置 | 適合 |
+|---|---|---|
+| **local** | 專案根目錄的 `kanban.json` | 個人專案、單機、不用團隊共享 |
+| **jira**  | Jira Cloud（per-board 設定 + per-machine token） | 多機器團隊、async 協作、手機審核 |
+
+可以先用 `/kanban:init`（local）之後再 `/kanban:initjira` 升級到 Jira — slash command 介面不變。
+
+完整 walk-through 見 [`kanban_quickstart_zhtw.md`](../../kanban_quickstart_zhtw.md)，完整設計見 [`SPEC_zhtw.md §3`](../../SPEC_zhtw.md)。
+
+## 安裝
+
+```
+> /plugin marketplace add kirinchen/claude-workbench
+> /plugin install kanban@claude-workbench
+> /kanban:init                     # local mode — scaffold kanban.json
+# (選用) 切換到 Jira-backed:
+> /kanban:initjira                 # 互動式 setup
+> /kanban:assign-ap <name>         # 這個 repo 的 AP（Jira routing 用）
+```
+
+## Slash 指令清單
+
+完整可用清單以 Claude Code 的 `/` autocomplete 為準（會反映你目前安裝的 plugin）。kanban 0.3.20 為例：
+
+### 日常工作流
+
+| 指令 | 做什麼 |
+|---|---|
+| `/kanban:status` | 唯讀的看板總覽（driver-aware） |
+| `/kanban:sync` | 拉這個 AP 的 open-card 摘要 |
+| `/kanban:doing` | 工作 DOING 池 — 讀完所有屬於你的卡片，依合理順序執行 *(Jira；local mode 用 `/kanban:next`)* |
+| `/kanban:done` | 把任務（預設目前 DOING）標 DONE |
+| `/kanban:block <key>` | 把任務移到 BLOCKED（要寫 reason） |
+| `/kanban:question <key> "<text>"` | 在卡片 post 問題並轉到 BLOCKED |
+| `/kanban:reply <key>` | 對卡片 post 回覆，可選 `@`-mention 對方 |
+
+### Inbox / 非同步訊號
+
+| 指令 | 做什麼 |
+|---|---|
+| `/kanban:mentions` | 列出 `@`-mention 你 agent 帳號的 comments / descriptions（你的收件匣） |
+| `/kanban:reconcile` | 找出 canonical 看板看不到的卡片（unmapped status、missing AP） |
+
+### 卡片生命週期
+
+| 指令 | 做什麼 |
+|---|---|
+| `/kanban:create-sub <parent>` | 從 parent issue 衍生 N 張子卡，用 Jira issue link 連回去 |
+| `/kanban:next` | Jira mode 已 DEPRECATED（用 `/kanban:doing`）；local mode 還能用 |
+
+### Setup / 設定（Jira）
+
+| 指令 | 做什麼 |
+|---|---|
+| `/kanban:init` | 在當前專案建立 `kanban.json` + schema |
+| `/kanban:initjira` | 把專案從 local 切到 Jira-backed（5-step 互動式） |
+| `/kanban:import-jira-code` | 從另一個 repo 匯出的 code bootstrap 或 re-sync Jira mode |
+| `/kanban:showjira-code` | 把這個 repo 的 Jira 設定印成可分享的 JSON（給 `import-jira-code` 貼用） |
+| `/kanban:reset-credentials` | 設定或更新這台機器的 Jira credentials *(secret-safe — 你自己在自己 terminal 跑)* |
+| `/kanban:assign-ap <name>` | 設定這個 repo 的 Agent Property（寫進 `.claude/kanban-agent.json`） |
+| `/kanban:register-ap <name>` | 註冊新的 AP value 到 Jira AP custom field |
+| `/kanban:fix-ap-screen` | 把 AP custom field attach 到專案 screen（修 issue #6） |
+| `/kanban:edit-conventions` | 撰寫或編輯團隊 `conventions` block — narrative notes + per-team toggles |
+| `/kanban:show-conventions` | 顯示團隊 `conventions` block（read-only） |
+| `/kanban:enable-automation` | 裝一個 trigger 讓 Claude Code 在 `kanban.json` 變動時自動跑（cron / git hook） |
+| `/kanban:whoami` | 顯示目前的 driver / board / AP / token 有效性 |
+
+### 已 Deprecated
+
+| 指令 | 替代 |
+|---|---|
+| `/kanban:initjira-by-code` | `/kanban:import-jira-code`（#34） |
+| `/kanban:next`（Jira mode） | `/kanban:doing`（#33） |
+
+## 核心概念
+
+- **Canonical columns**：`TODO → DOING → BLOCKED → REVIEW → DONE → CANCELLED`。Slash command 永遠講 canonical 名稱；Jira driver 透過 `transitions` DSL 翻譯。
+- **Compound transitions**（`v0.3+`）：`BLOCKED > In Progress + Label` 讓多個 canonical state 共享同一個 Jira status，靠 label disambiguate — 詳見 `epic/kanban_plugin_ Jira_backend_driver_UPDATE.md`。
+- **Agent Property (AP)**：一個 Jira single-select custom field，把卡片 routing 到特定 agent / repo。每個 repo 在 `.claude/kanban-agent.json#ap` 宣告自己的 AP；像 `/kanban:doing` 這類命令會用它 filter（`cf[<id>] = "<repo's ap>"`）。
+- **Conventions**：per-team narrative notes + opt-in toggles（例如 `blockedRequiresLink: true`），跟著 `/kanban:showjira-code` 一起傳遞。接收端必須明確 acknowledge 才能完成 `import-jira-code`。
+
+## Hooks
+
+- **PreToolUse** (`kanban-guard.sh`) — 擋住對 `kanban.json` 的 Edit / Write。狀態變更要走 slash command。
+- **PostToolUse** (`kanban-autocommit.sh`) — 當 `kanban.json` 是唯一 dirty file 時自動 commit 成獨立 commit。
+- **SessionStart** (`kanban-session-check.sh`) — session 開始時印出 DOING / BLOCKED + mention 數量。
+- **UserPromptSubmit** (`kanban-card-detect.sh`) — 當 prompt 裡貼到 Jira URL 或 `KEY-N`，把卡片標題、status、AP、最近的 comments 透過 `additionalContext` 注入（Jira mode only）。
+
+## 檔案結構
+
+```
+plugins/kanban/
+├── .claude-plugin/plugin.json
+├── commands/                        # 24 個 slash command（一個命令一個 .md）
+├── drivers/
+│   ├── base.py                      # Driver protocol + Task/Comment dataclasses
+│   ├── local.py                     # kanban.json driver
+│   └── jira.py                      # Jira Cloud driver
+├── lib/
+│   ├── jira_client.py               # HTTP + ADF helpers
+│   ├── kanban_io.py                 # atomic kanban.json read/write
+│   ├── transitions.py               # compound transitions DSL
+│   ├── ap_registry.py               # AP fuzzy-collision 檢查
+│   ├── conventions.py               # team conventions block
+│   ├── credentials.py               # ~/.claude-workbench/.env reader / writer
+│   ├── card_cache.py                # 30s precheck cache
+│   └── card_parser.py               # 從 prompt 文字抽 Jira KEY-N
+├── hooks/hooks.json
+├── scripts/
+│   ├── kanban-guard.sh              # PreToolUse
+│   ├── kanban-autocommit.sh         # PostToolUse
+│   ├── kanban-session-check.sh      # SessionStart
+│   ├── kanban-card-detect.sh        # UserPromptSubmit
+│   ├── kanban_local.py              # local-driver helper
+│   ├── jira_setup.py                # Jira-driver helper (subcommands)
+│   ├── cron-runner.sh               # /kanban:enable-automation cron mode
+│   └── test_phase{1..25}.py         # regression suite（108+ 個 check）
+├── skills/
+│   ├── kanban-workflow/SKILL.md     # generic + local-mode workflow
+│   └── kanban-jira-agent/SKILL.md   # Jira-mode agent behaviour
+└── templates/
+    ├── kanban.example.json
+    └── kanban.schema.json
+```

--- a/plugins/mentor/.claude-plugin/plugin.json
+++ b/plugins/mentor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mentor",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Onboarding mentor for Claude Code — prescribes bootstrap reading, document hierarchy (Epic/Sprint/Issue/ADR), and agent workflow. Replaces the earlier `docsync` plugin with a broader, framework-driven design. Dev profile.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirinchen/claude-workbench",

--- a/plugins/mentor/README.md
+++ b/plugins/mentor/README.md
@@ -26,17 +26,21 @@ Basic is deliberately minimal — upgrade to `development` later when planning p
 > /mentor:init            # interactive — scan, pick mode, generate structure
 ```
 
-## Slash commands (v0.1.0 MVP)
+## Slash commands
+
+The complete list reflects what's installed in your environment — Claude Code's `/` autocomplete is authoritative. As of mentor 0.2.4:
 
 | Command | Purpose |
 |---|---|
-| `/mentor:init` | Interactive mode selection + structure generation |
+| `/mentor:init` | Interactive setup — scan, pick framework mode, generate structure |
 | `/mentor:status` | Current mode, active sprint, open issues |
 | `/mentor:new` `<epic\|sprint\|issue\|adr>` | Generate a new document from the mode's template |
-| `/mentor:review` | Compliance check — missing docs, orphan issues, template drift |
+| `/mentor:review` | Compliance check — missing docs, orphan issues, frontmatter drift |
+| `/mentor:upgrade` | Re-align an existing project's scaffold with the active framework — list missing docs, optionally fill them in |
+| `/mentor:current-state` | Enable the opt-in `doc/current_state/` layer after the fact, or show its status |
 | `/mentor:migrate-from-docsync` | Read `.claude/docsync.yaml` → write `.claude/mentor.yaml` |
 
-Deferred to v0.2: `/mentor:sprint-start`, `/mentor:sprint-end` (sprint lifecycle with auto-retro).
+Deferred to a future release: `/mentor:sprint-start`, `/mentor:sprint-end` (sprint lifecycle with auto-retro).
 
 ## Hooks
 
@@ -82,7 +86,7 @@ plugins/mentor/
 │       ├── basic-mode-guide.md
 │       ├── development-mode-guide.md
 │       └── task-pickup-workflow.md
-├── commands/{init,status,new,review,migrate-from-docsync}.md
+├── commands/                       # 7 slash commands (init,status,new,review,upgrade,current-state,migrate-from-docsync)
 ├── hooks/hooks.json
 ├── scripts/
 │   ├── framework_engine.py        # config loader + mode resolution

--- a/plugins/mentor/README_zhtw.md
+++ b/plugins/mentor/README_zhtw.md
@@ -26,17 +26,21 @@ basic 是刻意設計成最精簡——等之後出現規劃壓力時再升級�
 > /mentor:init            # 互動式——scan、選模式、產生結構
 ```
 
-## Slash 指令（v0.1.0 MVP）
+## Slash 指令
+
+完整可用清單以 Claude Code 的 `/` autocomplete 為準（會反映你目前安裝的 plugin）。mentor 0.2.4 為例：
 
 | 指令 | 目的 |
 |---|---|
-| `/mentor:init` | 互動式選模式 + 產生結構 |
+| `/mentor:init` | 互動式 setup——scan、選 framework mode、產生結構 |
 | `/mentor:status` | 目前模式、active sprint、open issues |
 | `/mentor:new` `<epic\|sprint\|issue\|adr>` | 從該模式的 template 產生新文件 |
-| `/mentor:review` | 合規檢查——missing docs、orphan issues、template drift |
+| `/mentor:review` | 合規檢查——missing docs、orphan issues、frontmatter drift |
+| `/mentor:upgrade` | 把既有專案 scaffold 對齊當前 framework——列出缺的文件，可選擇直接補上 |
+| `/mentor:current-state` | 事後啟用 opt-in 的 `doc/current_state/` 層，或顯示其狀態 |
 | `/mentor:migrate-from-docsync` | 讀 `.claude/docsync.yaml` → 寫 `.claude/mentor.yaml` |
 
-延後到 v0.2：`/mentor:sprint-start`、`/mentor:sprint-end`（sprint 生命週期 + 自動 retro）。
+延後到未來版本：`/mentor:sprint-start`、`/mentor:sprint-end`（sprint 生命週期 + 自動 retro）。
 
 ## Hooks
 
@@ -82,7 +86,7 @@ plugins/mentor/
 │       ├── basic-mode-guide.md
 │       ├── development-mode-guide.md
 │       └── task-pickup-workflow.md
-├── commands/{init,status,new,review,migrate-from-docsync}.md
+├── commands/                       # 7 個 slash command（init,status,new,review,upgrade,current-state,migrate-from-docsync）
 ├── hooks/hooks.json
 ├── scripts/
 │   ├── framework_engine.py        # config loader + mode resolution


### PR DESCRIPTION
## Summary

Pure docs PR. The user reported a UX pain point — they didn't know `/kanban:mentions` existed because there was no README in the plugin folder listing the commands. Each plugin now has a README that enumerates all slash commands, so users have an offline / discovery surface in addition to Claude Code's `/` autocomplete.

## kanban 0.3.20 (new files)

`plugins/kanban/README.md` + `README_zhtw.md`:

- **24 slash commands grouped by purpose**: day-to-day workflow, inbox / async signals, card lifecycle, setup / configuration, deprecated.
- **Driver concepts**: local vs Jira, Agent Property (AP) routing, compound transitions DSL, conventions block.
- **Hooks rundown**: PreToolUse (`kanban-guard.sh`), PostToolUse (`kanban-autocommit.sh`), SessionStart (`kanban-session-check.sh`), UserPromptSubmit (`kanban-card-detect.sh`).
- **File layout sketch** matching current 0.3.20 state.

## mentor 0.2.4

`plugins/mentor/README.md` + `README_zhtw.md`:

- Slash-command table refreshed from v0.1.0 MVP list to the shipped seven commands. Adds `/mentor:upgrade` and `/mentor:current-state` (both landed after the v0.1.0 README was written).
- File-layout `commands/{...}.md` line broadened to reflect all seven shipped commands.
- "Deferred to v0.2" footer rephrased to "deferred to a future release" (since v0.2 shipped without those commands).

## Files

- `plugins/kanban/README.md` — new (~150 lines)
- `plugins/kanban/README_zhtw.md` — new (~150 lines)
- `plugins/mentor/README.md` — slash-command table + file-layout line refresh
- `plugins/mentor/README_zhtw.md` — same in zh-TW
- Version bumps: kanban 0.3.19 → 0.3.20, mentor 0.2.3 → 0.2.4
- CHANGELOG entry under "Documentation"

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — no behavior change, smoke run still green
- [ ] Manual: render both READMEs in GitHub's preview, verify tables format correctly
- [ ] Manual: cross-reference command names against `ls plugins/kanban/commands/*.md` and `ls plugins/mentor/commands/*.md` — every shipped command should appear in the README, no orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)