### PR TITLE
fix(kanban): 0.3.21 — URLs in ADF bodies render as clickable links

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,47 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-04 (kanban clickable URLs in ADF bodies)
+
+### Fixed
+- **kanban 0.3.21** — URLs in agent-posted comments and issue
+  descriptions now render as clickable links in Jira UI instead of
+  plain un-clickable text. Session-reported.
+
+  ADF doesn't auto-linkify text — a URL only renders clickable when
+  the text node carries an explicit `link` mark. The plugin's three
+  ADF builders (`text_to_adf` for descriptions and plain comments,
+  `text_to_adf_with_mention` for `/kanban:reply`'s `@`-mention path,
+  and the driver-level `_agent_comment_body` for prefixed agent
+  comments) all wrapped the entire body in a single plain text node.
+  URLs were faithfully preserved as text but uselessly so — the user
+  had to copy-paste them into the address bar manually.
+
+  New `_text_to_inline_nodes(text)` in `lib/jira_client.py` splits
+  the body on a conservative URL regex (`https?://[^\s<>"\)\]]+`)
+  and emits a list of ADF text nodes — URL spans get
+  `marks: [{type: "link", attrs: {href: url}}]`, non-URL spans stay
+  plain. Trailing sentence punctuation (`.`, `,`, `;`, `:`, `!`,
+  `?`) is stripped off URLs and put back into a following plain
+  span, so "see https://x.com." parses cleanly as URL + period.
+  Closing brackets / quotes are excluded from the regex so URLs
+  inside parens or square brackets don't pull the close-bracket
+  into the link.
+
+  All three ADF builders use the new helper for body content.
+  Existing strong-marked SPEC §9 prefixes (the #27 fix) and
+  `@`-mention chips are untouched. `adf_to_text` round-trips
+  link-marked output back to a clean plain string (lossy on marks
+  but text content preserved — non-destructive to existing
+  text-extraction callers like `find-mentions`).
+
+  Phase 26 covers ten cases: single URL; URL in middle splits
+  3-ways; trailing-punctuation stripping; close-bracket exclusion;
+  multiple URLs each get their own mark; no-URL plain-text path;
+  empty input; `text_to_adf` produces clickable URL; mention path
+  preserves chip + link; driver `_agent_comment_body` keeps strong
+  prefix + clickable body URL together; `adf_to_text` round-trip.
+
 ## 2026-05-04 (plugin READMEs)
 
 ### Documentation

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -20,6 +20,7 @@ from lib import card_cache, credentials, transitions as _tr
 from lib.jira_client import (
     JiraClient,
     JiraError,
+    _text_to_inline_nodes,
     adf_to_text,
     text_to_adf,
     text_to_adf_with_mention,
@@ -180,7 +181,9 @@ class JiraDriver:
         # Two paragraphs: bold prefix on its own line, then the body. ADF
         # doesn't parse markdown — emitting the prefix as a strong-marked
         # text node is the only way to get bold rendering without the raw
-        # `**` showing up in the Jira UI (#27).
+        # `**` showing up in the Jira UI (#27). URLs in the body are
+        # split out into ADF link-marked nodes so they render clickable.
+        body_nodes = _text_to_inline_nodes(body) or [{"type": "text", "text": ""}]
         return {
             "type": "doc",
             "version": 1,
@@ -197,7 +200,7 @@ class JiraDriver:
                 },
                 {
                     "type": "paragraph",
-                    "content": [{"type": "text", "text": body}],
+                    "content": body_nodes,
                 },
             ],
         }

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -395,20 +395,69 @@ class JiraClient:
 # -------- helpers ----------------------------------------------------------
 
 
+# URL detector for clickable-link markup. Conservative on tail characters
+# so a URL at end-of-sentence (e.g. "see https://x.com.") doesn't swallow
+# the period, and a URL inside parens / quotes doesn't pull the closing
+# bracket in. ADF doesn't auto-linkify plain text — without an explicit
+# `link` mark the URL renders as un-clickable text.
+import re as _re
+_URL_RE = _re.compile(r"https?://[^\s<>\"\)\]]+")
+
+
+def _text_to_inline_nodes(text: str) -> list[dict[str, Any]]:
+    """Split `text` on URLs and return ADF text nodes — URL spans get
+    a `link` mark so they render clickable in Jira UI.
+
+    Returns a list ready to drop into a paragraph's `content`. Empty
+    spans collapse so adjacent URLs don't yield empty text nodes.
+    Trailing punctuation that's commonly attached to a sentence
+    (`.`, `,`, `;`, `:`, `!`, `?`) is stripped off the URL and put back
+    in a following plain-text node, so "see https://x.com." parses as
+    URL "https://x.com" + plain ".".
+    """
+    if not text:
+        return []
+    out: list[dict[str, Any]] = []
+    pos = 0
+    for m in _URL_RE.finditer(text):
+        # Plain text segment before the URL
+        if m.start() > pos:
+            out.append({"type": "text", "text": text[pos:m.start()]})
+        url = m.group(0)
+        # Strip trailing punctuation that's almost certainly NOT part
+        # of the URL ("see https://x.com." → URL is x.com, "." is prose)
+        trailer = ""
+        while url and url[-1] in ".,;:!?":
+            trailer = url[-1] + trailer
+            url = url[:-1]
+        if url:
+            out.append({
+                "type": "text",
+                "text": url,
+                "marks": [{"type": "link", "attrs": {"href": url}}],
+            })
+        if trailer:
+            out.append({"type": "text", "text": trailer})
+        pos = m.end()
+    if pos < len(text):
+        out.append({"type": "text", "text": text[pos:]})
+    return out
+
+
 def text_to_adf(text: str) -> dict[str, Any]:
     """Wrap a plain-text body in Atlassian Document Format.
 
-    Used for comments. Does not attempt rich formatting; SPEC §9 prefix is
+    Used for comments and issue descriptions. URLs in the body are
+    detected and wrapped in ADF `link` marks so they render clickable
+    in Jira UI; non-URL spans stay as plain text. SPEC §9 prefix is
     added at the driver layer.
     """
+    nodes = _text_to_inline_nodes(text) or [{"type": "text", "text": ""}]
     return {
         "type": "doc",
         "version": 1,
         "content": [
-            {
-                "type": "paragraph",
-                "content": [{"type": "text", "text": text}],
-            }
+            {"type": "paragraph", "content": nodes},
         ],
     }
 
@@ -515,6 +564,18 @@ def text_to_adf_with_mention(
         ],
     }
     if body_text:
-        body_para["content"].append({"type": "text", "text": " " + body_text})
+        # Leading space separates the mention chip from the body text.
+        # Merge it into the first plain-text inline node when possible
+        # (avoids fragmenting ADF into [" ", text] when [" text"] is
+        # equivalent and matches existing test expectations); fall back
+        # to a standalone space node when the body starts with a
+        # link-marked URL.
+        nodes = _text_to_inline_nodes(body_text)
+        if nodes and not nodes[0].get("marks"):
+            nodes[0]["text"] = " " + nodes[0]["text"]
+            body_para["content"].extend(nodes)
+        elif nodes:
+            body_para["content"].append({"type": "text", "text": " "})
+            body_para["content"].extend(nodes)
     content.append(body_para)
     return {"type": "doc", "version": 1, "content": content}

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do  # 8-25: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26; do  # 8-26: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase26.py
+++ b/plugins/kanban/scripts/test_phase26.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Phase 26 regression checks for kanban v0.3.21 — clickable URLs in
+ADF comment / description bodies.
+
+User-reported (session, no GitHub issue): URLs that the agent posts in
+a Jira comment or description render as plain text, not clickable
+links. ADF doesn't auto-linkify — text nodes need an explicit
+`marks: [{type: "link", attrs: {href: "..."}}]` to be clickable.
+
+The fix: a `_text_to_inline_nodes(text)` helper splits the body on a
+conservative URL regex, wraps URL spans in link-marked text nodes,
+keeps non-URL spans as plain text. All three ADF builders
+(`text_to_adf`, `text_to_adf_with_mention`, `_agent_comment_body`)
+use it.
+
+Cases:
+  (a) `_text_to_inline_nodes` with a single URL produces 1 link-marked
+      node when the entire string is the URL.
+  (b) URL in the middle splits into [text, link, text] nodes.
+  (c) URL at end-of-sentence strips trailing punctuation off the URL —
+      "see https://x.com." → URL "https://x.com" + plain ".".
+  (d) URL inside parens / brackets doesn't pull the closing bracket
+      into the link.
+  (e) Multiple URLs in one string each get their own link mark.
+  (f) Empty / no-URL text returns plain text nodes (or empty list).
+  (g) `text_to_adf("see https://x.com")` produces a doc whose paragraph
+      contains a link-marked node for the URL.
+  (h) `text_to_adf_with_mention(..., body_text="reply at https://x.com")`
+      keeps the mention chip + a plain space + a link-marked URL node.
+  (i) `_agent_comment_body` (driver-level) emits a 2-paragraph doc
+      whose body paragraph carries link marks for URLs (and the prefix
+      paragraph keeps its strong mark, untouched).
+  (j) `adf_to_text` round-trips the link-marked output back to a plain
+      string (lossy on marks but text content preserved).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import (  # noqa: E402
+    _text_to_inline_nodes,
+    adf_to_text,
+    text_to_adf,
+    text_to_adf_with_mention,
+)
+
+
+# --- (a)..(f) helper unit tests -----------------------------------------
+
+
+def _link_href(node):
+    for m in node.get("marks") or []:
+        if m.get("type") == "link":
+            return (m.get("attrs") or {}).get("href")
+    return None
+
+
+def test_inline_nodes_single_url():
+    nodes = _text_to_inline_nodes("https://example.com/path")
+    assert len(nodes) == 1
+    assert nodes[0]["text"] == "https://example.com/path"
+    assert _link_href(nodes[0]) == "https://example.com/path"
+
+
+def test_inline_nodes_url_in_middle():
+    nodes = _text_to_inline_nodes("see https://example.com for details")
+    texts = [n["text"] for n in nodes]
+    assert texts == ["see ", "https://example.com", " for details"]
+    assert _link_href(nodes[1]) == "https://example.com"
+    # Surrounding nodes are plain (no link mark)
+    assert _link_href(nodes[0]) is None
+    assert _link_href(nodes[2]) is None
+
+
+def test_inline_nodes_strips_trailing_punctuation():
+    """A URL at end-of-sentence shouldn't pull the period into the link."""
+    nodes = _text_to_inline_nodes("see https://x.com.")
+    texts = [n["text"] for n in nodes]
+    assert texts == ["see ", "https://x.com", "."]
+    assert _link_href(nodes[1]) == "https://x.com"
+    # Trailing "." is plain text, not part of the link
+    assert _link_href(nodes[2]) is None
+
+
+def test_inline_nodes_does_not_swallow_close_bracket():
+    """URL in parens shouldn't include the close-paren in the link."""
+    nodes = _text_to_inline_nodes("(see https://x.com) for more")
+    texts = [n["text"] for n in nodes]
+    # The regex stops at the close-paren via the `[^...)]+` exclusion
+    assert texts[0] == "(see "
+    assert texts[1] == "https://x.com"
+    assert _link_href(nodes[1]) == "https://x.com"
+    # The closing ")" is in the trailing plain-text span
+    assert ")" in "".join(n["text"] for n in nodes[2:])
+
+
+def test_inline_nodes_multiple_urls():
+    nodes = _text_to_inline_nodes(
+        "first https://a.example then https://b.example end"
+    )
+    link_nodes = [n for n in nodes if _link_href(n)]
+    assert len(link_nodes) == 2
+    assert _link_href(link_nodes[0]) == "https://a.example"
+    assert _link_href(link_nodes[1]) == "https://b.example"
+
+
+def test_inline_nodes_no_url_or_empty():
+    # Plain text with no URL → single plain-text node
+    nodes = _text_to_inline_nodes("just words")
+    assert nodes == [{"type": "text", "text": "just words"}]
+    # Empty string → empty list (caller decides how to fill an empty
+    # paragraph; usually with a single empty text node)
+    assert _text_to_inline_nodes("") == []
+
+
+# --- (g) text_to_adf wraps in a doc + link mark survives ----------------
+
+
+def test_text_to_adf_preserves_link_mark():
+    adf = text_to_adf("see https://x.com")
+    assert adf["type"] == "doc"
+    para = adf["content"][0]
+    assert para["type"] == "paragraph"
+    # Find the link-marked node
+    link_nodes = [n for n in para["content"] if _link_href(n)]
+    assert len(link_nodes) == 1
+    assert _link_href(link_nodes[0]) == "https://x.com"
+
+
+# --- (h) text_to_adf_with_mention keeps URL clickable in body -----------
+
+
+def test_text_to_adf_with_mention_keeps_link_in_body():
+    adf = text_to_adf_with_mention(
+        prefix_text="[ap] [C]",
+        mention_account_id="user-123",
+        mention_display="Kirin",
+        body_text="reply at https://example.com later",
+    )
+    # Doc has 2 paragraphs: prefix + (mention + body)
+    assert len(adf["content"]) == 2
+    body_para = adf["content"][1]
+    types = [n["type"] for n in body_para["content"]]
+    assert types[0] == "mention"
+    # Subsequent body nodes include the link-marked URL
+    link_nodes = [n for n in body_para["content"]
+                  if n.get("type") == "text" and _link_href(n)]
+    assert len(link_nodes) == 1
+    assert _link_href(link_nodes[0]) == "https://example.com"
+
+
+# --- (i) _agent_comment_body keeps strong prefix + link in body ---------
+
+
+def test_agent_comment_body_preserves_prefix_and_links():
+    """Driver-level builder. Prefix paragraph keeps its strong mark
+    (the #27 fix), body paragraph gets URLs as link-marked nodes."""
+    from drivers.jira import JiraDriver
+    from drivers.base import CommentKind
+    from lib import credentials
+
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            data = {
+                "version": "0.2",
+                "backend": {"driver": "jira", "jira": {
+                    "boardUrl": "https://x/projects/A/boards/1",
+                    "boardId": 1, "projectKey": "A",
+                    "transitions": {"DONE": {"status": "Done"}},
+                }},
+                "meta": {"priorities": ["P0"], "categories": [],
+                         "columns": ["TODO", "DOING", "BLOCKED",
+                                     "REVIEW", "DONE", "CANCELLED"],
+                         "created_at": "x", "updated_at": "x"},
+                "tasks": [],
+            }
+            drv = JiraDriver(data, pathlib.Path(td))
+
+            adf = drv._agent_comment_body(
+                "details at https://docs.example.com — please review",
+                CommentKind.COMMENT,
+                ap="agent-fin",
+            )
+    finally:
+        credentials.read = orig
+
+    # Prefix paragraph: single text node with strong mark, no link
+    prefix_para = adf["content"][0]
+    assert prefix_para["type"] == "paragraph"
+    p0 = prefix_para["content"][0]
+    assert p0["text"] == "[agent-fin] [C]"
+    assert {"type": "strong"} in p0["marks"]
+    assert _link_href(p0) is None  # prefix has NO link mark
+
+    # Body paragraph: contains a link-marked node for the URL
+    body_para = adf["content"][1]
+    link_nodes = [n for n in body_para["content"] if _link_href(n)]
+    assert len(link_nodes) == 1
+    assert _link_href(link_nodes[0]) == "https://docs.example.com"
+
+
+# --- (j) adf_to_text round-trip ------------------------------------------
+
+
+def test_adf_to_text_roundtrip_preserves_text_drops_marks():
+    """adf_to_text concatenates text nodes regardless of marks — so
+    URL-marked output flattens back to a plain string with the URL
+    inline. Confirms the link mark is non-destructive to existing
+    text-extraction callers."""
+    adf = text_to_adf("see https://x.com later")
+    flat = adf_to_text(adf)
+    assert flat == "see https://x.com later"
+
+
+def main() -> int:
+    cases = [
+        ("inline_nodes_single_url", test_inline_nodes_single_url),
+        ("inline_nodes_url_in_middle", test_inline_nodes_url_in_middle),
+        ("inline_nodes_strips_trailing_punctuation",
+         test_inline_nodes_strips_trailing_punctuation),
+        ("inline_nodes_does_not_swallow_close_bracket",
+         test_inline_nodes_does_not_swallow_close_bracket),
+        ("inline_nodes_multiple_urls", test_inline_nodes_multiple_urls),
+        ("inline_nodes_no_url_or_empty", test_inline_nodes_no_url_or_empty),
+        ("text_to_adf_preserves_link_mark",
+         test_text_to_adf_preserves_link_mark),
+        ("text_to_adf_with_mention_keeps_link_in_body",
+         test_text_to_adf_with_mention_keeps_link_in_body),
+        ("agent_comment_body_preserves_prefix_and_links",
+         test_agent_comment_body_preserves_prefix_and_links),
+        ("adf_to_text_roundtrip_preserves_text_drops_marks",
+         test_adf_to_text_roundtrip_preserves_text_drops_marks),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase26: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase26: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

URLs in agent-posted comments and issue descriptions used to render as plain un-clickable text in Jira UI. ADF doesn't auto-linkify — text nodes need an explicit `link` mark to be clickable. The plugin's three ADF builders all wrapped body text in a single plain text node, so URLs were faithfully preserved but useless: you had to copy-paste them into the address bar manually.

The fix adds a `_text_to_inline_nodes(text)` helper that splits body text on a conservative URL regex and emits ADF text nodes — URL spans get a `link` mark, non-URL spans stay plain. All three ADF builders (`text_to_adf`, `text_to_adf_with_mention`, driver-level `_agent_comment_body`) use it.

### Robustness details

- **Conservative regex**: `https?://[^\s<>"\)\]]+` — closing brackets and quotes excluded so URLs inside parens / square brackets don't pull the close-bracket into the link.
- **Trailing punctuation stripping**: `.`, `,`, `;`, `:`, `!`, `?` at end of URL get peeled off into a following plain-text span. So `see https://x.com.` parses as URL `https://x.com` + plain `.`.
- **Strong-mark prefix preserved**: the SPEC §9 `[ap] [kind]` prefix paragraph (the #27 fix) keeps its `strong` mark untouched. URLs only get link marks in the body paragraph.
- **`adf_to_text` round-trip non-destructive**: link-marked output flattens back to a plain string with the URL inline. `find-mentions` and other text-extraction callers keep working.
- **Mention path leading-space**: when the body starts with plain text (the common case), the leading space before the body merges into the first plain-text node — so phase 12's existing assertion `body[1].text == " 評估完成"` still holds. When the body starts with a URL, the space is a standalone node before the link.

Session-reported (no GitHub issue filed).

## Files

- `plugins/kanban/lib/jira_client.py` — `_text_to_inline_nodes`, `text_to_adf` and `text_to_adf_with_mention` updates
- `plugins/kanban/drivers/jira.py` — `_agent_comment_body` body uses the new helper, prefix paragraph unchanged
- `plugins/kanban/scripts/test_phase26.py` — new (10 cases)
- `plugins/kanban/scripts/test_all.sh` — wire phase 26
- Version bump 0.3.20 → 0.3.21, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 26 phases green
- [x] Phase 26 (10 cases): single URL; mid-string split; trailing-punctuation strip; close-bracket exclusion; multiple URLs each marked; no-URL plain-text; empty input; `text_to_adf` produces clickable; mention path preserves chip + link; driver `_agent_comment_body` keeps strong prefix + clickable body URL together; `adf_to_text` round-trip
- [x] Phase 12's `text_to_adf_with_mention_shape` continues to pass (leading-space-merge into first plain text node)
- [ ] Manual: post a comment containing a URL via `/kanban:reply` or `/kanban:question`, verify the URL is clickable in Jira UI
- [ ] Manual: create a card via `/kanban:create-sub` with a URL in the description, verify clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)