### PR TITLE
feat(kanban): 0.3.22 — REVIEW flavors in transitions DSL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.21",
+      "version": "0.3.22",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,85 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-04 (kanban REVIEW flavors)
+
+### Added
+- **kanban 0.3.22** — transitions DSL now supports `flavors` —
+  same-status sub-classification via labels, atomically applied. The
+  agent's compound transition write merges the chosen flavor's
+  `addLabels` / `removeLabels` / `assignee` into the parent spec on
+  the same write, so the card lands in REVIEW + the flavor label in
+  one operation (no transient "REVIEW without label" window). Closes
+  #45.
+
+  **Why this matters**: REVIEW was a single canonical state but
+  carried two semantically different signals — "agent finished, please
+  approve" vs "agent stuck, posted options, please decide." An outside
+  observer (board glance, JQL, mobile UI) couldn't tell them apart
+  without opening the card. Per-team agents were inventing their own
+  label conventions (`kanban_awaiting_approval` vs `pls-approve` vs
+  `awaiting-review`) — the plugin should provide consistency, not push
+  it onto every team.
+
+  **Why `flavors` instead of new canonical states**: lifecycle stage
+  (canonical state) and within-stage metadata (flavor) are different
+  abstraction layers. Flavors don't trigger different plugin behavior
+  (anti-self-approve, `/kanban:doing`, `/kanban:reconcile` all treat
+  the flavors equivalently). A new canonical state would also force
+  `local` driver migration, SPEC + quickstart updates, and
+  `/kanban:status` column changes — none of which serve the actual
+  use case (label-level triage on the same lifecycle stage).
+
+  **DSL shape** (additive — no flavors block = same as before):
+
+  ```json
+  "REVIEW": {
+    "status": "REVIEW",
+    "flavors": {
+      "awaiting_approval": { "addLabels": ["kanban_awaiting_approval"] },
+      "needs_decision":    { "addLabels": ["kanban_needs_decision"] }
+    },
+    "defaultFlavor": "awaiting_approval"
+  }
+  ```
+
+  - `transition --to REVIEW --flavor awaiting_approval` does status +
+    label add atomically.
+  - `--flavor` required when state has flavors; `defaultFlavor`
+    (optional) is the fallback so `/kanban:done` can stay short.
+  - Invalid / missing flavor → raise with the available flavor list.
+  - State without `flavors` block → ignore stray `--flavor` (forward
+    compat — callers can pass it unconditionally).
+
+  **Slash command updates**:
+
+  - `/kanban:done` — when DSL declares flavors on REVIEW, pass
+    `--flavor awaiting_approval` (the conventional name; respects
+    whatever key the team's DSL uses).
+  - `kanban-jira-agent` SKILL — explains the two flavors and which
+    command path to use for each: `/kanban:done` for
+    `awaiting_approval`, `/kanban:transition --flavor needs_decision`
+    after posting an options comment for `needs_decision`.
+
+  **Naming guidance**: new plugin-suggested labels prefer underscore
+  (`kanban_awaiting_approval`) over colon (`kanban:foo`). The colon
+  form visually parses as a slash-command path and confuses operators.
+  Existing built-in `kanban:blocked` / `kanban:cancelled` keep the
+  colon for back-compat.
+
+  **Forward / back compat**: kanban-jira-code/2 payloads carrying
+  `flavors` blocks survive round-trip through receivers older than
+  0.3.22 — Python's dict round-trip is forgiving and the older driver
+  ignores the unknown keys (it just won't know how to consume
+  `--flavor`). No new schema version needed.
+
+  Phase 27 covers eight cases: validator accepts well-formed flavors;
+  validator rejects six malformed shapes; driver merges flavor's
+  addLabels onto compound write; defaultFlavor fallback; missing
+  flavor + no default raises with available list; invalid flavor
+  raises; state-without-flavors ignores stray `--flavor`;
+  cmd_transition argparse threads `--flavor` into kwargs.
+
 ## 2026-05-04 (kanban clickable URLs in ADF bodies)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/done.md
+++ b/plugins/kanban/commands/done.md
@@ -59,15 +59,36 @@ Identify the target key from `$ARGUMENTS`. If absent, find the single DOING
 card with this repo's AP set (use `/kanban:status` to enumerate; if there
 is not exactly one, ask the user).
 
+**Flavor handling (#45)**: when `kanban.json#backend.jira.transitions.REVIEW`
+declares a `flavors` block, this command must pick one. `/kanban:done`
+ALWAYS means "I finished, please review", so pass `--flavor
+awaiting_approval` (the conventional name; check
+`backend.jira.transitions.REVIEW.flavors` for the actual key — the team
+may have named it differently). When the REVIEW spec has no `flavors`
+block, omit `--flavor` (helper ignores stray values when no flavors).
+
+For the *other* REVIEW flavor — "I'm stuck, here are options, please
+decide" — that is **not** `/kanban:done`'s job. Use `/kanban:transition
+--to REVIEW --flavor needs_decision` directly after posting the options
+comment. See `kanban-jira-agent` SKILL for the @-mention authorization
+contract that triggers that path.
+
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py transition \
-  --kanban-path '<kanban.json path>' --key '<KEY>' --to REVIEW
+  --kanban-path '<kanban.json path>' --key '<KEY>' --to REVIEW \
+  [--flavor awaiting_approval]
 ```
 
 On success print `✓ <KEY> → In Review (awaiting reviewer)`.
 
 If the helper exits with `kind: self-approve`, surface the error verbatim
 and explain another reviewer is required. Do NOT search for workarounds.
+
+If the helper rejects with `transition to 'REVIEW' requires --flavor`,
+the team's DSL declares `flavors` but no `defaultFlavor`. Pick
+`awaiting_approval` (or whatever the equivalent key is in their
+`flavors` map) and re-run. Do NOT add a `defaultFlavor` to kanban.json
+on the user's behalf — that's a team policy decision.
 
 ## Absolute rules
 

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -361,6 +361,46 @@ class JiraDriver:
         if not target_status:
             raise RuntimeError(f"transition spec for {to_column!r} missing `status`")
 
+        # Flavor resolution (#45). When the spec carries a `flavors` block,
+        # the caller must pick one (via --flavor / kwargs["flavor"]) or
+        # the spec must declare a `defaultFlavor`. The chosen flavor's
+        # addLabels / removeLabels / assignee are merged onto the parent
+        # spec, then the rest of the compound write runs unchanged. When
+        # the spec has no flavors, a stray `flavor` kwarg is silently
+        # ignored (forward compat — callers can pass it unconditionally).
+        flavor_name = kwargs.get("flavor")
+        flavors = spec.get("flavors") or {}
+        if flavors:
+            if not flavor_name:
+                flavor_name = spec.get("defaultFlavor")
+            if not flavor_name:
+                raise RuntimeError(
+                    f"transition to {to_column!r} requires --flavor "
+                    f"(available: {sorted(flavors)}); set "
+                    f"transitions.{to_column}.defaultFlavor in kanban.json "
+                    f"to skip this when one flavor is the common case"
+                )
+            if flavor_name not in flavors:
+                raise RuntimeError(
+                    f"unknown flavor {flavor_name!r} for {to_column!r} "
+                    f"(available: {sorted(flavors)})"
+                )
+            flavor_spec = flavors[flavor_name] or {}
+            # Build a merged spec WITHOUT mutating self.transitions_map —
+            # subsequent reads / disambiguate calls still see the pristine
+            # config.
+            merged_add = list(spec.get("addLabels") or []) + list(
+                flavor_spec.get("addLabels") or []
+            )
+            merged_remove = list(spec.get("removeLabels") or []) + list(
+                flavor_spec.get("removeLabels") or []
+            )
+            spec = dict(spec)
+            spec["addLabels"] = merged_add
+            spec["removeLabels"] = merged_remove
+            if flavor_spec.get("assignee"):
+                spec["assignee"] = flavor_spec["assignee"]
+
         # One pre-flight read serves anti-self-approve, the already-in-
         # target-status fast path, and the blocked_by idempotency check.
         existing_for_status = self.get_task(key)

--- a/plugins/kanban/lib/transitions.py
+++ b/plugins/kanban/lib/transitions.py
@@ -380,6 +380,57 @@ def validate(
         if a is not None:
             if not isinstance(a, dict) or not a.get("accountId"):
                 errs.append(f"{col}: assignee must be {{accountId: ...}}")
+        # Flavors — same-status sub-classification via labels (#45).
+        # Each flavor is itself a partial spec (addLabels / removeLabels /
+        # assignee); status comes from the parent. defaultFlavor, when
+        # set, must reference an existing flavor key.
+        flavors = spec.get("flavors")
+        if flavors is not None:
+            if not isinstance(flavors, dict) or not flavors:
+                errs.append(f"{col}: flavors must be a non-empty object")
+            else:
+                for fname, fspec in flavors.items():
+                    if not isinstance(fname, str) or not fname:
+                        errs.append(f"{col}: flavor name must be a non-empty string")
+                        continue
+                    if not isinstance(fspec, dict):
+                        errs.append(f"{col}.flavors.{fname}: must be an object")
+                        continue
+                    for fkey in ("addLabels", "removeLabels"):
+                        fv = fspec.get(fkey)
+                        if fv is not None and not (
+                            isinstance(fv, list)
+                            and all(isinstance(x, str) and x for x in fv)
+                        ):
+                            errs.append(
+                                f"{col}.flavors.{fname}: {fkey} must be a "
+                                f"list of non-empty strings"
+                            )
+                    fa = fspec.get("assignee")
+                    if fa is not None:
+                        if not isinstance(fa, dict) or not fa.get("accountId"):
+                            errs.append(
+                                f"{col}.flavors.{fname}: assignee must be "
+                                f"{{accountId: ...}}"
+                            )
+            # defaultFlavor sanity (only meaningful when flavors block ok)
+            default_flavor = spec.get("defaultFlavor")
+            if default_flavor is not None:
+                if not isinstance(default_flavor, str):
+                    errs.append(f"{col}: defaultFlavor must be a string")
+                elif (
+                    isinstance(flavors, dict)
+                    and flavors
+                    and default_flavor not in flavors
+                ):
+                    errs.append(
+                        f"{col}: defaultFlavor {default_flavor!r} is not in "
+                        f"flavors keys {sorted(flavors)}"
+                    )
+        elif spec.get("defaultFlavor") is not None:
+            errs.append(
+                f"{col}: defaultFlavor set but no flavors block — drop one"
+            )
     return errs
 
 

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1710,6 +1710,8 @@ def cmd_transition(args: argparse.Namespace) -> int:
     kwargs: dict[str, Any] = {}
     if args.reason:
         kwargs["reason"] = args.reason
+    if getattr(args, "flavor", None):
+        kwargs["flavor"] = args.flavor
 
     # Comma-separated list of Jira keys; trim whitespace, drop empties.
     blockers: list[str] = []
@@ -2997,6 +2999,18 @@ def build_parser() -> argparse.ArgumentParser:
              "DMI-1099,INFRA-7) to attach as `is blocked by` issue links "
              "before applying the transition. Idempotent — already-linked "
              "blockers are skipped.",
+    )
+    s.add_argument(
+        "--flavor",
+        help=(
+            "Pick a flavor for canonical states that declare a "
+            "`flavors` block in transitions DSL (#45). The chosen "
+            "flavor's addLabels/removeLabels/assignee merge atomically "
+            "with the parent spec on this transition. Required when the "
+            "state has flavors AND no defaultFlavor is set; ignored when "
+            "the state has no flavors. e.g. --to REVIEW "
+            "--flavor awaiting_approval / --flavor needs_decision."
+        ),
     )
     s.set_defaults(func=cmd_transition)
 

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26; do  # 8-26: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27; do  # 8-27: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase27.py
+++ b/plugins/kanban/scripts/test_phase27.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Phase 27 regression checks for kanban v0.3.22 — REVIEW flavors in
+transitions DSL.
+
+Closes #45. The transitions DSL gains an optional `flavors` block per
+canonical state plus an optional `defaultFlavor` fallback. When the
+caller invokes `transition --flavor NAME`, the chosen flavor's
+addLabels / removeLabels / assignee merge atomically with the parent
+spec onto the compound write. Lifecycle stage (canonical state) and
+within-stage sub-classification (flavor) stay separate concepts; this
+keeps `/kanban:status`, anti-self-approve, and reconcile from
+ballooning.
+
+Cases:
+  (a) `transitions.validate` accepts a well-formed flavors block.
+  (b) `transitions.validate` rejects: non-dict flavors, empty flavors
+      object, non-string flavor name, flavor with bad addLabels,
+      flavor with bad assignee, defaultFlavor not in flavors,
+      defaultFlavor without flavors block.
+  (c) Driver `transition()` with `flavor=` merges that flavor's
+      addLabels onto the parent spec's addLabels (the heart of the
+      atomic write — status + parent labels + flavor labels go in one
+      compound transition).
+  (d) Driver `transition()` with no `flavor=` BUT spec has
+      `defaultFlavor` falls back to the default.
+  (e) Driver `transition()` with no `flavor=` AND no `defaultFlavor`
+      AND spec has flavors → raise with the available flavor list in
+      the message.
+  (f) Driver `transition()` with an invalid flavor name → raise with
+      the available list.
+  (g) Driver `transition()` with `flavor=` on a state that has no
+      flavors block → silently ignore (forward compat — callers can
+      pass it unconditionally without per-spec branching).
+  (h) `cmd_transition` argparse threads `--flavor` into kwargs.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib import transitions as _tr  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+# --- (a) (b) validator ---------------------------------------------------
+
+
+def test_validate_accepts_well_formed_flavors():
+    cfg = {
+        "REVIEW": {
+            "status": "REVIEW",
+            "flavors": {
+                "awaiting_approval": {"addLabels": ["kanban_awaiting_approval"]},
+                "needs_decision": {"addLabels": ["kanban_needs_decision"]},
+            },
+            "defaultFlavor": "awaiting_approval",
+        },
+        "DOING": {"status": "In Progress"},
+    }
+    errs = _tr.validate(cfg)
+    assert errs == [], errs
+
+
+def test_validate_rejects_malformed_flavors():
+    fn = _tr.validate
+
+    # flavors not a dict
+    e = fn({"REVIEW": {"status": "REVIEW", "flavors": []}})
+    assert any("flavors must be" in x for x in e), e
+
+    # empty flavors
+    e = fn({"REVIEW": {"status": "REVIEW", "flavors": {}}})
+    assert any("flavors must be" in x for x in e), e
+
+    # flavor body not a dict
+    e = fn({"REVIEW": {"status": "REVIEW", "flavors": {"x": 42}}})
+    assert any("flavors.x: must be an object" in x for x in e), e
+
+    # bad addLabels inside flavor
+    e = fn({"REVIEW": {"status": "REVIEW",
+                       "flavors": {"x": {"addLabels": [None]}}}})
+    assert any("flavors.x: addLabels must be" in x for x in e), e
+
+    # bad assignee inside flavor
+    e = fn({"REVIEW": {"status": "REVIEW",
+                       "flavors": {"x": {"assignee": "bad"}}}})
+    assert any("flavors.x: assignee must be" in x for x in e), e
+
+    # defaultFlavor not in flavors
+    e = fn({"REVIEW": {"status": "REVIEW",
+                       "flavors": {"a": {}},
+                       "defaultFlavor": "b"}})
+    assert any("defaultFlavor 'b' is not in flavors keys" in x for x in e), e
+
+    # defaultFlavor without flavors block
+    e = fn({"REVIEW": {"status": "REVIEW", "defaultFlavor": "x"}})
+    assert any("defaultFlavor set but no flavors block" in x for x in e), e
+
+
+# --- (c)..(g) driver transition() flavor wiring -------------------------
+
+
+def _seed_jira_data_with_flavors(*, default_flavor=None):
+    review_spec = {
+        "status": "REVIEW",
+        "flavors": {
+            "awaiting_approval": {"addLabels": ["kanban_awaiting_approval"]},
+            "needs_decision": {"addLabels": ["kanban_needs_decision"]},
+        },
+    }
+    if default_flavor is not None:
+        review_spec["defaultFlavor"] = default_flavor
+    return {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "REVIEW": review_spec,
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _seed_jira_data_no_flavors():
+    return {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "REVIEW": {"status": "REVIEW"},
+                "DONE": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "DONE", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    from drivers.jira import JiraDriver
+    from lib import credentials
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _seed_repo_ap(repo, ap="agent-fin"):
+    (repo / ".claude").mkdir(parents=True, exist_ok=True)
+    (repo / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": ap}) + "\n"
+    )
+
+
+def _issue_response(key, *, status_name="In Progress", labels=(),
+                    assignee_acct="some-human", ap_value="agent-fin"):
+    return _Response(200, json.dumps({
+        "key": key,
+        "fields": {
+            "summary": "x",
+            "status": {"name": status_name},
+            "priority": {"name": "P1"},
+            "assignee": {"accountId": assignee_acct} if assignee_acct else None,
+            "labels": list(labels),
+            "created": "x", "updated": "y",
+            "issuelinks": [],
+            "customfield_10042": {"value": ap_value},
+        },
+    }).encode(), {})
+
+
+def test_transition_with_flavor_merges_addlabels():
+    """The compound write must PUT labels including the flavor's
+    addLabels — that's the atomicity guarantee #45 buys."""
+    data = _seed_jira_data_with_flavors()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _issue_response("AGENT-1", status_name="In Progress"),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),  # transition_issue
+            _Response(204, b"", {}),  # PUT labels
+            _issue_response("AGENT-1", status_name="REVIEW",
+                            labels=["kanban_awaiting_approval"]),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("AGENT-1", "REVIEW", flavor="awaiting_approval")
+
+        # Find the PUT to /issue/AGENT-1 (label sync)
+        put_call = next(
+            c for c in calls
+            if c["method"] == "PUT"
+            and "/issue/AGENT-1" in c["url"]
+            and "labels" in (c["body"] or b"").decode("utf-8", errors="replace")
+        )
+        sent = json.loads(put_call["body"])
+        assert "kanban_awaiting_approval" in sent["fields"]["labels"], sent
+
+
+def test_transition_without_flavor_uses_default():
+    """When the spec carries `defaultFlavor`, omitting --flavor falls
+    back to it — convenience for the most-common path."""
+    data = _seed_jira_data_with_flavors(default_flavor="awaiting_approval")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _issue_response("AGENT-1", status_name="In Progress"),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(204, b"", {}),
+            _issue_response("AGENT-1", status_name="REVIEW",
+                            labels=["kanban_awaiting_approval"]),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("AGENT-1", "REVIEW")  # no flavor=
+
+        put_call = next(
+            c for c in calls
+            if c["method"] == "PUT"
+            and "/issue/AGENT-1" in c["url"]
+            and "labels" in (c["body"] or b"").decode("utf-8", errors="replace")
+        )
+        sent = json.loads(put_call["body"])
+        assert "kanban_awaiting_approval" in sent["fields"]["labels"]
+
+
+def test_transition_missing_flavor_no_default_raises():
+    data = _seed_jira_data_with_flavors()  # no defaultFlavor
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        # Pre-flight read still fires; no transition_issue / PUT should
+        # happen before the flavor check rejects.
+        # Actually our code resolves flavor BEFORE the get_task call,
+        # so the queue should be empty (or just the resolution raises
+        # before reading anything).
+        _attach_mock(drv, [], [])
+
+        try:
+            drv.transition("AGENT-1", "REVIEW")
+        except RuntimeError as e:
+            msg = str(e)
+            assert "requires --flavor" in msg, msg
+            assert "awaiting_approval" in msg
+            assert "needs_decision" in msg
+            return
+        raise AssertionError("expected RuntimeError on missing flavor")
+
+
+def test_transition_invalid_flavor_raises():
+    data = _seed_jira_data_with_flavors()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        _attach_mock(drv, [], [])
+
+        try:
+            drv.transition("AGENT-1", "REVIEW", flavor="bogus")
+        except RuntimeError as e:
+            msg = str(e)
+            assert "unknown flavor 'bogus'" in msg
+            assert "awaiting_approval" in msg
+            return
+        raise AssertionError("expected RuntimeError on unknown flavor")
+
+
+def test_transition_flavor_ignored_when_state_has_no_flavors():
+    """Forward compat: callers can pass --flavor unconditionally;
+    states without a flavors block ignore it (no failure, no label)."""
+    data = _seed_jira_data_no_flavors()
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _issue_response("AGENT-1", status_name="In Progress"),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _issue_response("AGENT-1", status_name="REVIEW"),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        # Should NOT raise; the spurious flavor is silently dropped.
+        drv.transition("AGENT-1", "REVIEW", flavor="anything")
+
+        # No label PUT fires (no addLabels in the parent spec, no flavor
+        # block to merge from). Tally should not include a /issue/AGENT-1
+        # PUT with a labels payload.
+        leaked_label_put = any(
+            c["method"] == "PUT"
+            and "/issue/AGENT-1" in c["url"]
+            and "labels" in (c["body"] or b"").decode("utf-8", errors="replace")
+            for c in calls
+        )
+        assert not leaked_label_put, calls
+
+
+# --- (h) cmd_transition wires --flavor through ---------------------------
+
+
+def test_cmd_transition_threads_flavor_into_driver():
+    """Verify the argparse-supplied --flavor reaches driver.transition's
+    kwargs."""
+    received: dict = {}
+
+    class _StubDrv:
+        name = "jira"
+        def transition(self, key, to_column, **kwargs):
+            received["key"] = key
+            received["to_column"] = to_column
+            received["kwargs"] = kwargs
+            from drivers.base import Task
+            return Task(
+                id=key, title="x", column="REVIEW", priority="P1",
+                created="x", updated="y", custom={"raw_status": "REVIEW"},
+            )
+
+    import drivers as _drv_mod
+    d_orig = _drv_mod.get_driver
+    _drv_mod.get_driver = lambda data, root: _StubDrv()
+
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            kp = pathlib.Path(td) / "kanban.json"
+            kp.write_text(json.dumps(_seed_jira_data_with_flavors()))
+
+            class A:
+                kanban_path = str(kp)
+                key = "AGENT-1"
+                to = "REVIEW"
+                reason = None
+                blocked_by = None
+                flavor = "needs_decision"
+            from io import StringIO
+            old = sys.stdout
+            sys.stdout = StringIO()
+            try:
+                try:
+                    rc = _jira_setup.cmd_transition(A())
+                except SystemExit as e:
+                    rc = e.code
+            finally:
+                sys.stdout = old
+    finally:
+        _drv_mod.get_driver = d_orig
+
+    assert rc == 0
+    assert received["kwargs"].get("flavor") == "needs_decision", received
+
+
+def main() -> int:
+    cases = [
+        ("validate_accepts_well_formed_flavors",
+         test_validate_accepts_well_formed_flavors),
+        ("validate_rejects_malformed_flavors",
+         test_validate_rejects_malformed_flavors),
+        ("transition_with_flavor_merges_addlabels",
+         test_transition_with_flavor_merges_addlabels),
+        ("transition_without_flavor_uses_default",
+         test_transition_without_flavor_uses_default),
+        ("transition_missing_flavor_no_default_raises",
+         test_transition_missing_flavor_no_default_raises),
+        ("transition_invalid_flavor_raises",
+         test_transition_invalid_flavor_raises),
+        ("transition_flavor_ignored_when_state_has_no_flavors",
+         test_transition_flavor_ignored_when_state_has_no_flavors),
+        ("cmd_transition_threads_flavor_into_driver",
+         test_cmd_transition_threads_flavor_into_driver),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase27: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase27: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/skills/kanban-jira-agent/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-agent/SKILL.md
@@ -31,6 +31,35 @@ summary; cards listed are yours. If you suspect stale state, run
 - Do not work a DOING card owned by another AP — the precheck hook
   warns you when you mention such a card.
 
+## Two flavors of REVIEW (#45)
+
+When the team's `transitions.REVIEW` declares a `flavors` block, every
+DOING → REVIEW transition must pick one. The two canonical flavors —
+their exact names live in `backend.jira.transitions.REVIEW.flavors`,
+but the conventional naming is:
+
+- **`awaiting_approval`** — you finished the work. Card is ready for
+  the human reviewer to glance, click DONE, and walk away. Use this
+  via `/kanban:done` (which auto-passes the flavor) — most common path.
+- **`needs_decision`** — you got stuck and posted N options in a
+  comment. Card is waiting for the human to *make a choice*; they'll
+  move it back to DOING (or somewhere else) once decided. Use
+  `/kanban:transition <KEY> --to REVIEW --flavor needs_decision`
+  directly after posting the options comment. NOT `/kanban:done`.
+
+The two flavors carry different labels (e.g. `kanban_awaiting_approval`
+vs `kanban_needs_decision`) so the human can JQL-filter or board-glance
+to triage which kind of REVIEW each card needs. Picking wrong leaves
+the wrong label on the card — fix with `/kanban:transition` again with
+the correct flavor (label sets are PUT-overwriting, so the stale label
+gets removed on the next transition).
+
+Naming guidance for new label values your team adopts: prefer
+underscore separators (`kanban_awaiting_approval`) over colon
+(`kanban:awaiting`). The colon form visually parses as a slash-command
+path and confuses operators. Existing built-in `kanban:blocked` /
+`kanban:cancelled` keep the colon form for back-compat.
+
 ## During work
 
 - Found a blocker that needs human input? `/kanban:question <KEY> "<text>"`.

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -168,6 +168,38 @@
           "properties": {
             "accountId": { "type": "string", "minLength": 1 }
           }
+        },
+        "flavors": {
+          "type": "object",
+          "minProperties": 1,
+          "description": "Sub-classification of this canonical state via labels (#45). Each flavor adds its own addLabels/removeLabels/assignee on top of the parent spec, atomically. The parent's `status` is shared. Use when a single canonical lifecycle stage carries multiple semantic flavors that an outside observer should be able to triage at a glance (e.g. REVIEW awaiting_approval vs needs_decision). Naming: prefer underscore-separated values (kanban_awaiting_approval) over colon (kanban:foo) — the latter visually parses as a slash-command path.",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "addLabels": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "removeLabels": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 }
+              },
+              "assignee": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["accountId"],
+                "properties": {
+                  "accountId": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        },
+        "defaultFlavor": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional fallback flavor name used when transition is invoked without --flavor. Must be a key in `flavors`. When unset and `flavors` exists, transition without --flavor raises."
         }
       }
     },


### PR DESCRIPTION
> ⚠ **Stacks on #46.** Base branch is `fix/kanban-clickable-links` (PR #46). After #46 merges, rebase this onto main; GitHub auto-flips the base on next push.

## Summary

The transitions DSL now supports `flavors` — same-status sub-classification via labels, atomically applied. The agent's compound transition merges the chosen flavor's `addLabels` / `removeLabels` / `assignee` onto the parent spec on the same write, so the card lands in REVIEW + the flavor label in **one** operation (no transient "REVIEW without label" window).

### Why this matters

REVIEW was a single canonical state but carried two semantically different signals:

| Flavor | Meaning |
|---|---|
| `awaiting_approval` | Agent finished, please review the diff and click DONE |
| `needs_decision` | Agent stuck, posted options in a comment, please pick one |

An outside observer (board glance, JQL filter, mobile UI) couldn't tell them apart without opening the card. Per-team agents were inventing their own label conventions; the plugin should provide consistency.

### Why flavors and not new canonical states

Lifecycle stage (canonical state) and within-stage metadata (flavor) are **different abstraction layers**. Flavors don't trigger different plugin behavior — `anti-self-approve`, `/kanban:doing`, `/kanban:reconcile` all treat them equivalently. A new canonical state would force local-driver migration, SPEC + quickstart updates, `/kanban:status` column changes — none of which serve the actual use case (label-level triage on the same lifecycle stage). See the issue thread for the full architectural discussion.

### DSL shape (additive)

```json
"REVIEW": {
  "status": "REVIEW",
  "flavors": {
    "awaiting_approval": { "addLabels": ["kanban_awaiting_approval"] },
    "needs_decision":    { "addLabels": ["kanban_needs_decision"] }
  },
  "defaultFlavor": "awaiting_approval"
}
```

- `transition --to REVIEW --flavor X` does status + label add atomically.
- `--flavor` is required when the state has `flavors`; `defaultFlavor` (optional) is the fallback so `/kanban:done` stays short.
- Invalid / missing flavor → raise with the available flavor list.
- State without `flavors` block → ignore stray `--flavor` (forward compat — callers can pass it unconditionally).

### Slash command + SKILL updates

- `/kanban:done` — when DSL declares flavors on REVIEW, auto-passes `--flavor awaiting_approval` (the conventional name; respects the team's actual key).
- `kanban-jira-agent` SKILL — explains the two flavors and which command path each takes:
  - `awaiting_approval` → `/kanban:done` (auto-handled)
  - `needs_decision` → `/kanban:transition --to REVIEW --flavor needs_decision` after posting options comment

### Naming guidance

New plugin-suggested labels prefer **underscore** over colon: `kanban_awaiting_approval` over `kanban:foo`. The colon form visually parses as a slash-command path and confuses operators. Existing built-in `kanban:blocked` / `kanban:cancelled` keep their colon for back-compat (renaming would invalidate already-labelled cards).

### Forward / back compat

`kanban-jira-code/2` payloads carrying `flavors` survive round-trip through receivers older than 0.3.22 — Python's dict round-trip is forgiving, the older driver ignores unknown keys. No new schema version needed.

Closes #45

## Files

- `plugins/kanban/lib/transitions.py` — validator extended with flavor structure checks
- `plugins/kanban/drivers/jira.py:transition()` — flavor resolution + merge
- `plugins/kanban/scripts/jira_setup.py:cmd_transition` — `--flavor` argparse + kwargs threading
- `plugins/kanban/templates/kanban.schema.json` — `flavors` + `defaultFlavor` under each transitionSpec
- `plugins/kanban/commands/done.md` — auto-pass `--flavor awaiting_approval`; document the needs_decision path
- `plugins/kanban/skills/kanban-jira-agent/SKILL.md` — "Two flavors of REVIEW" section
- `plugins/kanban/scripts/test_phase27.py` — new (8 cases)
- `plugins/kanban/scripts/test_all.sh` — wire phase 27
- Version bump 0.3.21 → 0.3.22, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 27 phases green
- [x] Phase 27 (8 new cases): validator accepts well-formed flavors; validator rejects six malformed shapes; driver merges flavor labels into compound write; defaultFlavor fallback; missing flavor + no default raises with available list; invalid flavor raises; state without flavors ignores stray `--flavor`; cmd_transition threads `--flavor`
- [ ] Manual: configure a board's `transitions.REVIEW` with `flavors` block, run `/kanban:done` and verify the card lands in REVIEW with `kanban_awaiting_approval` label in one observable step
- [ ] Manual: run `/kanban:transition --to REVIEW --flavor needs_decision` and verify the card carries `kanban_needs_decision` label
- [ ] Manual: omit `--flavor` on a REVIEW transition that has no `defaultFlavor` and verify the helper rejects with the available flavor list

🤖 Generated with [Claude Code](https://claude.com/claude-code)