### PR TITLE
fix(kanban): 0.3.24 — anti-self-approve keyed on statusCategory (#50)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,58 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-06 (kanban anti-self-approve keyed on statusCategory)
+
+### Fixed
+- **kanban 0.3.24** — anti-self-approve guard now keys on the target
+  Jira status's `statusCategory` rather than just the canonical name
+  `APPROVED`. Closes #50.
+
+  **The bug**: pre-fix, `transition --to APPROVED` (or the legacy
+  `--to DONE` alias) blocked **any** agent-driven transition to
+  canonical APPROVED when the agent owned the card. But teams whose
+  DSL maps canonical APPROVED to a non-terminal Jira status (e.g.
+  `transitions.APPROVED.status == "REVIEW"` plus `addLabels:
+  ["kanban_awaiting_approval"]` for a soft "agent done, awaiting
+  human approval" intermediate) got blocked on a path that's
+  semantically NOT a self-approval — the agent is just signalling
+  completion; the human still has to push REVIEW → Done.
+
+  Reporter (`narrative-fin-agent`) had to PATCH labels via Jira REST
+  directly to recover, breaking the "DSL is the only thing touching
+  transitions/labels" invariant.
+
+  **The fix**: query Jira's `statusCategory` for the target status
+  (lazy-cached via `get_project_statuses` per driver instance):
+
+  - `category == "done"` → fire the strict guard (true approval —
+    existing behavior preserved when DSL maps to a Jira terminal Done)
+  - `category in {"indeterminate", "new"}` → allow (intermediate
+    stage; the actual #50 fix)
+  - `category is None` (lookup failed) → refuse with a **distinct**
+    error message so the caller can tell "Jira API hiccup" apart from
+    "you're trying to self-approve". Lookup is cached even on failure
+    to avoid retry storms; user can retry the operation.
+
+  Strict (fail-closed) policy on lookup failure preserves the safety
+  invariant — anti-self-approve must not be skippable just because
+  the network hiccuped. The distinct error wording lets a human
+  retrying after a transient failure tell what's going on.
+
+  **Performance**: one extra `get_project_statuses` call per driver
+  lifetime; cached after that. For a `/kanban:doing` session with
+  multiple transitions, the cost is amortised over the session.
+
+  **kanban-jira-agent SKILL** updated with the precise contract and
+  the failure-mode error message so agents can recognise it.
+
+  Phase 29 covers seven cases: strict block when category=done +
+  AP=mine + assignee=agent (existing behavior preserved); allow when
+  category=indeterminate (the #50 fix); allow when category=new;
+  lookup failure → distinct error (NOT SelfApproveRefused); recording
+  for another human still works on done category; lazy cache reused
+  on second transition; cache failure not retried.
+
 ## 2026-05-04 (kanban canonical DONE → APPROVED rename)
 
 ### Changed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -92,6 +92,13 @@ class JiraDriver:
         self.email = env.get("JIRA_AGENT_EMAIL", "")
         self._token = env.get("JIRA_API_TOKEN", "")
         self._client: JiraClient | None = None
+        # Lazy cache of `{status_name: category_key}` for the project.
+        # Populated on first call to `_get_status_category` and reused
+        # within the driver instance. Used by anti-self-approve to
+        # distinguish a true terminal-Done transition from an
+        # intermediate APPROVED step (#50). `None` until populated;
+        # `{}` if the lookup ever failed (avoid retry storms).
+        self._status_categories: dict[str, str] | None = None
 
     # --- helpers -------------------------------------------------------
 
@@ -111,6 +118,43 @@ class JiraDriver:
     def _canonical_to_status(self, column: str) -> str | None:
         spec = self._canonical_spec(column)
         return spec.get("status") if spec else None
+
+    def _get_status_category(self, status_name: str) -> str | None:
+        """Return the Jira statusCategory key (`new`, `indeterminate`,
+        `done`) for the given status display name, or None if the
+        lookup couldn't resolve it.
+
+        Lazy-populates a per-instance cache on first call. On API
+        failure we cache an empty map so subsequent calls don't hammer
+        Jira; the caller treats None as "unknown — fail closed" (#50).
+
+        Used by anti-self-approve to tell apart a true terminal-Done
+        transition (block) from an intermediate APPROVED step where
+        the DSL maps APPROVED to a non-terminal Jira status — e.g.
+        `transitions.APPROVED.status == "REVIEW"` for teams that use
+        a soft "agent done, awaiting human approval" intermediate
+        before the human pushes REVIEW → Done.
+        """
+        if not status_name:
+            return None
+        if self._status_categories is None:
+            self._status_categories = {}
+            if not self.project_key:
+                return None
+            try:
+                client = self._client_or_raise()
+                types = client.get_project_statuses(self.project_key) or []
+            except (JiraError, RuntimeError):
+                # Lookup failed — keep the empty cache so we don't retry
+                # on every transition; caller treats None as unknown.
+                return None
+            for issue_type in types:
+                for status in (issue_type or {}).get("statuses") or []:
+                    nm = status.get("name") or ""
+                    cat = (status.get("statusCategory") or {}).get("key")
+                    if nm and cat and nm not in self._status_categories:
+                        self._status_categories[nm] = cat
+        return self._status_categories.get(status_name)
 
     def _issue_to_task(self, issue: dict[str, Any]) -> Task:
         f = issue.get("fields") or {}
@@ -408,10 +452,38 @@ class JiraDriver:
             if flavor_spec.get("assignee"):
                 spec["assignee"] = flavor_spec["assignee"]
 
+        # Early category check — fail fast on lookup failure before
+        # spending a get_task hit. Per #50, anti-self-approve must only
+        # fire when the target Jira status is the workflow's true
+        # terminal Done — not for teams whose DSL maps APPROVED to an
+        # intermediate status (e.g. canonical APPROVED → Jira "REVIEW"
+        # with the `kanban_awaiting_approval` label, where the agent is
+        # just signalling completion; the human still has to push
+        # REVIEW → Done). The status's `statusCategory` key is the
+        # Jira-native semantic flag:
+        #   `done`          → guard applies (true approval)
+        #   `indeterminate` → intermediate, allow
+        #   `new`           → also intermediate, allow
+        #   None (lookup failed) → fail closed (refuse with a distinct
+        #     message so the user can tell "Jira API hiccup" apart from
+        #     "you're trying to self-approve")
+        target_category: str | None = None
+        if to_column == "APPROVED":
+            target_category = self._get_status_category(target_status)
+            if target_category is None:
+                raise RuntimeError(
+                    f"cannot verify whether status {target_status!r} is the "
+                    f"workflow's terminal Done state (Jira status-category "
+                    f"lookup failed). For safety, refusing the transition — "
+                    f"anti-self-approve cannot be skipped without "
+                    f"verification. Retry in a moment, or run /kanban:whoami "
+                    f"to check Jira credentials. See #50."
+                )
+
         # One pre-flight read serves anti-self-approve, the already-in-
         # target-status fast path, and the blocked_by idempotency check.
         existing_for_status = self.get_task(key)
-        if to_column == "APPROVED":
+        if to_column == "APPROVED" and target_category == "done":
             current_ap = self._current_repo_ap()
             if current_ap and existing_for_status.ap and existing_for_status.ap == current_ap:
                 # Only refuse when the agent itself owns the work.
@@ -439,6 +511,8 @@ class JiraDriver:
                         "(or assign the card to that human first if you "
                         "are recording on their behalf)"
                     )
+        # else (target_category in {"indeterminate", "new"}): intermediate
+        # state, no self-approve concern (#50).
         client = self._client_or_raise()
 
         # Step 0 — blocked_by issue links (only meaningful when transitioning

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase17.py
+++ b/plugins/kanban/scripts/test_phase17.py
@@ -76,6 +76,16 @@ def _attach_mock(drv, queue, calls):
         drv.base_url, drv.email, drv._token,
         transport=t, sleep=lambda _: None,
     )
+    # Pre-seed the status-category cache so anti-self-approve doesn't
+    # need a separate Jira API hit during these tests (#50). Phase 17's
+    # DSL maps APPROVED → "Done" (statusCategory=done), so the guard
+    # paths exercised here remain the strict-block path.
+    drv._status_categories = {
+        "To Do": "new",
+        "In Progress": "indeterminate",
+        "Done": "done",
+        "REVIEW": "indeterminate",
+    }
 
 
 def _seed_repo_ap(repo: pathlib.Path, ap: str = "agent-fin"):

--- a/plugins/kanban/scripts/test_phase19.py
+++ b/plugins/kanban/scripts/test_phase19.py
@@ -117,6 +117,18 @@ def _attach_mock(drv, queue, calls):
         drv.base_url, drv.email, drv._token,
         transport=t, sleep=lambda _: None,
     )
+    # Pre-seed status-category cache (#50) so transition tests skip
+    # the lookup hop. Phase 19's locale tests use 審查 / 完成 etc.
+    drv._status_categories = {
+        "To Do": "new",
+        "In Progress": "indeterminate",
+        "REVIEW": "indeterminate",
+        "Done": "done",
+        "Resolved": "done",
+        "進行中": "indeterminate",
+        "審查": "indeterminate",
+        "完成": "done",
+    }
 
 
 def _seed_repo_ap(repo: pathlib.Path, ap: str = "agent-fin"):

--- a/plugins/kanban/scripts/test_phase29.py
+++ b/plugins/kanban/scripts/test_phase29.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Phase 29 regression checks for kanban v0.3.24 — anti-self-approve
+keyed on Jira `statusCategory`, not on the canonical state name.
+
+Closes #50. Pre-fix: anti-self-approve fired for any transition where
+`to_column == "APPROVED"` AND the agent owned the card. Teams whose
+DSL maps canonical APPROVED to a non-terminal Jira status (e.g.
+`status: "REVIEW"` + `addLabels: ["kanban_awaiting_approval"]` for
+"agent done, awaiting human review") got blocked on a path that's
+semantically NOT a self-approval — the agent is just signalling
+completion; the human still has to push REVIEW → Done.
+
+The fix queries Jira's `statusCategory` for the target status (lazy
+cache via `get_project_statuses`):
+  - `category == "done"`     → fire the strict guard (true approval)
+  - `category in {indeterminate, new}` → allow (intermediate stage)
+  - `category is None`       → distinct error refusing for safety
+                              (lookup failed; user can retry)
+
+Cases:
+  (a) APPROVED → status with category=done + agent owns + assignee=
+      agent → blocked with the existing SelfApproveRefused message.
+      (Existing strict-guard behavior preserved when DSL maps to a
+      true terminal Done.)
+  (b) APPROVED → status with category=indeterminate + agent owns +
+      assignee=agent → allowed (the actual #50 fix). The compound
+      transition runs as normal: status change, label add, assignee.
+  (c) APPROVED → status with category=new + agent owns → also allowed
+      (intermediate stage, just on the other side).
+  (d) APPROVED → status whose category lookup returns None → fail
+      with a DISTINCT error message (not SelfApproveRefused) so the
+      caller can tell "Jira API hiccup" apart from "self-approve".
+  (e) APPROVED → done category, but assignee is a different human →
+      allowed (recording for someone else; existing #19 #20 behavior
+      preserved).
+  (f) `_get_status_category` is lazy — only one `get_project_statuses`
+      call regardless of how many transitions happen on the same
+      driver instance.
+  (g) When the driver-level lookup fails the first time, the second
+      transition does NOT retry (cache an empty map; per-process
+      cost is bounded).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+# --- helpers ------------------------------------------------------------
+
+
+def _seed_jira_data(*, approved_status="Done"):
+    """Seed kanban.json data with `transitions.APPROVED.status` taken
+    from the `approved_status` param — lets each test exercise the
+    guard against done / indeterminate / new categories."""
+    return {
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "boardId": 1, "projectKey": "AGENT",
+            "agentAccountId": "5e-agent",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "REVIEW": {"status": "REVIEW"},
+                "APPROVED": {
+                    "status": approved_status,
+                    "addLabels": ["kanban_awaiting_approval"]
+                    if approved_status != "Done" else [],
+                },
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "APPROVED", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }
+
+
+def _patched_driver(data, project_root):
+    from drivers.jira import JiraDriver
+    from lib import credentials
+    orig = credentials.read
+    credentials.read = lambda prefix=None: {
+        "JIRA_BASE_URL": "https://x", "JIRA_AGENT_EMAIL": "a@b",
+        "JIRA_API_TOKEN": "tok",
+    }
+    try:
+        drv = JiraDriver(data, project_root)
+    finally:
+        credentials.read = orig
+    return drv
+
+
+def _attach_mock(drv, queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=t, sleep=lambda _: None,
+    )
+
+
+def _seed_repo_ap(repo: pathlib.Path, ap: str = "agent-fin"):
+    (repo / ".claude").mkdir(parents=True, exist_ok=True)
+    (repo / ".claude" / "kanban-agent.json").write_text(
+        json.dumps({"ap": ap}) + "\n"
+    )
+
+
+def _issue(key, *, status="In Progress", assignee_acct="5e-agent",
+           ap_value="agent-fin", labels=()):
+    f = {
+        "summary": "x",
+        "status": {"name": status},
+        "priority": {"name": "P1"},
+        "assignee": {"accountId": assignee_acct} if assignee_acct else None,
+        "labels": list(labels),
+        "created": "x", "updated": "y",
+        "issuelinks": [],
+    }
+    if ap_value is not None:
+        f["customfield_10042"] = {"value": ap_value}
+    return {"key": key, "fields": f}
+
+
+def _project_statuses_response(*, mapping):
+    """Build a `/rest/api/3/project/{key}/statuses` response — single
+    issue type whose `statuses` array enumerates the given
+    name → category-key pairs."""
+    statuses = [
+        {"id": str(i),
+         "name": name,
+         "statusCategory": {"key": cat, "name": cat.title()}}
+        for i, (name, cat) in enumerate(mapping.items(), start=10000)
+    ]
+    return _Response(200, json.dumps([
+        {"id": "10001", "name": "Story", "statuses": statuses},
+    ]).encode(), {})
+
+
+# --- (a) strict guard preserved when category=done ----------------------
+
+
+def test_block_when_target_category_is_done():
+    """APPROVED → "Done" (category=done) + AP=mine + assignee=agent →
+    SelfApproveRefused (existing behavior preserved)."""
+    data = _seed_jira_data(approved_status="Done")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            # statusCategory lookup
+            _project_statuses_response(mapping={
+                "To Do": "new",
+                "In Progress": "indeterminate",
+                "Done": "done",
+            }),
+            # pre-flight read
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="In Progress",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.jira import SelfApproveRefused
+        try:
+            drv.transition("AGENT-1", "APPROVED")
+            assert False, "expected SelfApproveRefused"
+        except SelfApproveRefused as e:
+            assert "agent-fin" in str(e)
+
+
+# --- (b) (c) intermediate categories now allowed ------------------------
+
+
+def test_allow_when_target_category_is_indeterminate():
+    """APPROVED → "REVIEW" (category=indeterminate) + AP=mine →
+    transition runs (the actual #50 fix). Agent is signalling
+    completion, not approving — human still has to push REVIEW → Done.
+    """
+    data = _seed_jira_data(approved_status="REVIEW")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _project_statuses_response(mapping={
+                "In Progress": "indeterminate",
+                "REVIEW": "indeterminate",
+                "Done": "done",
+            }),
+            # pre-flight read (status="In Progress")
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="In Progress",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+            # client.get_transitions
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            # transition_issue
+            _Response(204, b"", {}),
+            # PUT labels
+            _Response(204, b"", {}),
+            # post-transition refresh
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="REVIEW",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin",
+                       labels=["kanban_awaiting_approval"])
+            ).encode(), {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        # Should NOT raise — this is the regression #50 fixes.
+        result = drv.transition("AGENT-1", "APPROVED")
+        assert result.id == "AGENT-1"
+
+
+def test_allow_when_target_category_is_new():
+    """APPROVED → some status with category=new (rare; would mean
+    APPROVED maps back to a TODO-like state) — also allowed.
+    Anti-self-approve only fires on `done`."""
+    data = _seed_jira_data(approved_status="Backlog")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _project_statuses_response(mapping={
+                "Backlog": "new",
+                "In Progress": "indeterminate",
+            }),
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="In Progress",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "31", "name": "Backlog",
+                 "to": {"id": "1", "name": "Backlog"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="Backlog",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin",
+                       labels=["kanban_awaiting_approval"])
+            ).encode(), {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        result = drv.transition("AGENT-1", "APPROVED")
+        assert result.id == "AGENT-1"
+
+
+# --- (d) lookup failure → distinct error --------------------------------
+
+
+def test_lookup_failure_yields_distinct_error_not_self_approve():
+    """When `get_project_statuses` returns 404 / fails to surface the
+    target status, the helper returns None and the driver refuses
+    with a DISTINCT error message — caller can tell 'API hiccup'
+    apart from 'you tried to self-approve'."""
+    data = _seed_jira_data(approved_status="Done")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            # statusCategory lookup fails
+            _Response(404, b'{"errorMessages":["nope"]}', {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        from drivers.jira import SelfApproveRefused
+        try:
+            drv.transition("AGENT-1", "APPROVED")
+            assert False, "expected RuntimeError"
+        except SelfApproveRefused:
+            assert False, "should NOT be SelfApproveRefused"
+        except RuntimeError as e:
+            msg = str(e)
+            assert "lookup failed" in msg
+            assert "anti-self-approve cannot be skipped" in msg
+            # Mention the user-actionable next step
+            assert "Retry" in msg or "retry" in msg
+
+
+# --- (e) recording-for-other still works for done category --------------
+
+
+def test_done_category_allows_when_assignee_is_other_human():
+    """APPROVED → "Done" (category=done) + AP=mine + assignee=different
+    human → allowed (existing #19 / #20 behavior preserved). Agent is
+    recording on someone else's behalf, not approving its own work."""
+    data = _seed_jira_data(approved_status="Done")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            _project_statuses_response(mapping={
+                "In Progress": "indeterminate",
+                "Done": "done",
+            }),
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="In Progress",
+                       assignee_acct="some-human",  # not agent
+                       ap_value="agent-fin")
+            ).encode(), {}),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "31", "name": "Done",
+                 "to": {"id": "10004", "name": "Done"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(
+                _issue("AGENT-1", status="Done",
+                       assignee_acct="some-human",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        result = drv.transition("AGENT-1", "APPROVED")
+        assert result.id == "AGENT-1"
+
+
+# --- (f) (g) lazy cache, no retry on failure ----------------------------
+
+
+def test_status_category_cache_is_lazy_and_reused():
+    """Two transitions on the same driver instance trigger
+    `get_project_statuses` only once. The second call reuses the
+    cached map."""
+    data = _seed_jira_data(approved_status="REVIEW")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            # First transition: statusCategory lookup
+            _project_statuses_response(mapping={
+                "In Progress": "indeterminate",
+                "REVIEW": "indeterminate",
+                "Done": "done",
+            }),
+            # First transition: pre-flight + transitions list + apply +
+            # labels PUT + refresh
+            _Response(200, json.dumps(
+                _issue("A-1", status="In Progress",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(
+                _issue("A-1", status="REVIEW", labels=["kanban_awaiting_approval"])
+            ).encode(), {}),
+            # Second transition: NO statusCategory lookup. Just
+            # pre-flight + ... etc.
+            _Response(200, json.dumps(
+                _issue("A-2", status="In Progress",
+                       assignee_acct="5e-agent",
+                       ap_value="agent-fin")
+            ).encode(), {}),
+            _Response(200, json.dumps({"transitions": [
+                {"id": "21", "name": "REVIEW",
+                 "to": {"id": "10115", "name": "REVIEW"}},
+            ]}).encode(), {}),
+            _Response(204, b"", {}),
+            _Response(204, b"", {}),
+            _Response(200, json.dumps(
+                _issue("A-2", status="REVIEW", labels=["kanban_awaiting_approval"])
+            ).encode(), {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        drv.transition("A-1", "APPROVED")
+        drv.transition("A-2", "APPROVED")
+
+        # Exactly one call to /rest/api/3/project/AGENT/statuses
+        cat_calls = [
+            c for c in calls if "/project/AGENT/statuses" in c["url"]
+        ]
+        assert len(cat_calls) == 1, [c["url"] for c in calls]
+
+
+def test_status_category_lookup_failure_not_retried():
+    """Two transitions where the first fails statusCategory lookup —
+    the second should NOT re-call (avoid retry storms). Both refuse
+    with the distinct error."""
+    data = _seed_jira_data(approved_status="Done")
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        _seed_repo_ap(proj)
+        drv = _patched_driver(data, proj)
+        queue = [
+            # First call: failure (404 — non-retryable so not consumed
+            # by the JiraClient retry loop)
+            _Response(404, b'{"errorMessages":["nope"]}', {}),
+        ]
+        calls: list[dict] = []
+        _attach_mock(drv, queue, calls)
+
+        # First transition fails
+        try:
+            drv.transition("AGENT-1", "APPROVED")
+            assert False, "expected RuntimeError"
+        except RuntimeError:
+            pass
+
+        # Second transition — should NOT call get_project_statuses
+        # again (queue is empty; if it tried we'd hit AssertionError).
+        try:
+            drv.transition("AGENT-2", "APPROVED")
+            assert False, "expected RuntimeError"
+        except RuntimeError:
+            pass
+
+        # Total HTTP calls = 1 (just the first lookup)
+        cat_calls = [
+            c for c in calls if "/project/AGENT/statuses" in c["url"]
+        ]
+        assert len(cat_calls) == 1, [c["url"] for c in calls]
+
+
+def main() -> int:
+    cases = [
+        ("block_when_target_category_is_done",
+         test_block_when_target_category_is_done),
+        ("allow_when_target_category_is_indeterminate",
+         test_allow_when_target_category_is_indeterminate),
+        ("allow_when_target_category_is_new",
+         test_allow_when_target_category_is_new),
+        ("lookup_failure_yields_distinct_error_not_self_approve",
+         test_lookup_failure_yields_distinct_error_not_self_approve),
+        ("done_category_allows_when_assignee_is_other_human",
+         test_done_category_allows_when_assignee_is_other_human),
+        ("status_category_cache_is_lazy_and_reused",
+         test_status_category_cache_is_lazy_and_reused),
+        ("status_category_lookup_failure_not_retried",
+         test_status_category_lookup_failure_not_retried),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase29: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase29: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/scripts/test_phase3.py
+++ b/plugins/kanban/scripts/test_phase3.py
@@ -101,6 +101,17 @@ def _attach_mock(drv, queue, calls):
         transport=_mock_transport(queue, calls),
         sleep=lambda _: None,
     )
+    # Pre-seed status-category cache (#50) so transition tests don't
+    # need a separate Jira API call. APPROVED → "Done" → category=done
+    # exercises the strict guard path; intermediate statuses get
+    # `indeterminate` / `new`.
+    drv._status_categories = {
+        "To Do": "new",
+        "In Progress": "indeterminate",
+        "Done": "done",
+        "REVIEW": "indeterminate",
+        "In Review": "indeterminate",
+    }
 
 
 # --- ap_registry tests ---------------------------------------------------

--- a/plugins/kanban/scripts/test_phase7.py
+++ b/plugins/kanban/scripts/test_phase7.py
@@ -271,6 +271,20 @@ def _attach_mock(drv, queue, calls):
     drv._client = JiraClient(
         drv.base_url, drv.email, drv._token, transport=t, sleep=lambda _: None
     )
+    # Pre-seed status-category cache (#50) so transition tests skip
+    # the live Jira lookup. Default mapping covers the canonical Jira
+    # workflow names that show up across phase 7's seeded DSLs.
+    drv._status_categories = {
+        "To Do": "new",
+        "Selected for Development": "new",
+        "Backlog": "new",
+        "In Progress": "indeterminate",
+        "進行中": "indeterminate",
+        "REVIEW": "indeterminate",
+        "In Review": "indeterminate",
+        "Done": "done",
+        "完成": "done",
+    }
 
 
 def _issue(key, status, labels=(), assignee=None, ap_value=None):

--- a/plugins/kanban/skills/kanban-jira-agent/SKILL.md
+++ b/plugins/kanban/skills/kanban-jira-agent/SKILL.md
@@ -130,8 +130,27 @@ Treat each mention as a directive. Process:
 - `/kanban:done` transitions DOING → In Review with a system comment. The
   human reviewer (or another AP) approves the card by transitioning it to
   Done in the Jira UI.
-- DO NOT push your own card to Done. The plugin refuses (anti-self-approve);
-  the Jira workflow may also reject it. This is intentional.
+- DO NOT push your own card to a Jira status with `statusCategory == done`
+  (typically that's the Jira `Done` column). The plugin's anti-self-approve
+  guard refuses; the Jira workflow may also reject it. This is intentional.
+
+### Anti-self-approve precise contract (#50)
+
+The guard fires only when the canonical APPROVED transition's target Jira
+status has `statusCategory == "done"`. Teams whose DSL maps canonical
+APPROVED to a non-terminal status (e.g. `transitions.APPROVED.status ==
+"REVIEW"` plus `addLabels: ["kanban_awaiting_approval"]` for a soft "agent
+done, awaiting human approval" intermediate) are NOT blocked — the agent
+is signalling completion, not approving its own work; the human still has
+to push REVIEW → Done. This is the common pattern when teams use canonical
+REVIEW for "agent has options for owner to pick" (with flavor
+`needs_decision`) and canonical APPROVED for "agent finished, please
+review" (with `kanban_awaiting_approval`).
+
+If you ever see `cannot verify whether status ... is the workflow's
+terminal Done state`, that's a Jira API hiccup blocking the lookup —
+retry, or run `/kanban:whoami` to check credentials. NOT a self-approve
+refusal.
 
 ## Linking to repo docs
 


### PR DESCRIPTION
## Summary

Pre-fix: `transition --to APPROVED` (or legacy `--to DONE`) blocked **any** agent-driven transition to canonical APPROVED when the agent owned the card. But teams whose DSL maps canonical APPROVED to a non-terminal Jira status (e.g. `transitions.APPROVED.status == "REVIEW"` + `addLabels: ["kanban_awaiting_approval"]` for soft "agent done, awaiting human approval" intermediate) got blocked on a path that's NOT a self-approval — the agent is signalling completion; the human still has to push REVIEW → Done.

Reporter (`narrative-fin-agent`) had to PATCH labels via Jira REST directly to recover, breaking the "DSL is the only thing touching transitions/labels" invariant.

The fix queries Jira's `statusCategory` for the target status (lazy-cached via `get_project_statuses` per driver instance):

| `statusCategory` | Behavior |
|---|---|
| `done` | Fire the strict guard (existing behavior — DSL maps to a true Jira terminal Done) |
| `indeterminate` | **Allow** (the #50 fix — intermediate state, no self-approve concern) |
| `new` | **Allow** (also intermediate) |
| `None` (lookup failed) | Refuse with **distinct** error message — caller can tell "API hiccup" apart from "self-approve" |

**Strict on lookup failure** (fail-closed) preserves the safety invariant — anti-self-approve must not be skippable just because the network hiccuped. The distinct error message lets a retrying human tell what's actually going on.

Closes #50

## Files

- **`plugins/kanban/drivers/jira.py`**:
  - New `_status_categories: dict[str, str] | None` instance cache
  - New `_get_status_category(status_name)` helper — lazy-populates from `get_project_statuses`, returns `None` on failure (cached as empty map to avoid retry storms)
  - `transition()` rewrites the anti-self-approve check: early `_get_status_category` call (fail fast on lookup failure before consuming a `get_task` hit); strict guard fires only when `category == "done"`; distinct `RuntimeError` (not `SelfApproveRefused`) on lookup failure
- **`plugins/kanban/skills/kanban-jira-agent/SKILL.md`** — new "Anti-self-approve precise contract (#50)" section explaining when the guard fires and the lookup-failure error message
- **`plugins/kanban/scripts/test_phase29.py`** — new (7 cases)
- Phases 3 / 7 / 17 / 19 `_attach_mock` helpers updated to pre-seed `drv._status_categories` (preserves strict-guard test paths via `"Done" → "done"` mapping; avoids needing a separate `get_project_statuses` mock in every existing test)
- Version bump 0.3.23 → 0.3.24, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 29 phases green
- [x] **Phase 29 (7 cases)**:
  - Block when category=done + AP=mine + assignee=agent (existing behavior preserved)
  - **Allow when category=indeterminate** (the actual #50 fix)
  - Allow when category=new (also intermediate)
  - Lookup failure → distinct error, NOT `SelfApproveRefused`
  - Recording for another human still works when category=done
  - Lazy cache reused (one `get_project_statuses` per driver)
  - Cache failure not retried (no storm on bad creds)
- [ ] Manual: in `narrative-fin-agent` repo where DSL maps `APPROVED → REVIEW + kanban_awaiting_approval`, run `/kanban:transition <KEY> --to APPROVED` and verify the transition runs cleanly (not blocked)
- [ ] Manual: in a project where DSL maps `APPROVED → Done` (true terminal), confirm anti-self-approve still refuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)