### PR TITLE
feat(kanban): 0.3.25 — board-config helpers (PR 1 of 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.24",
+      "version": "0.3.25",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,87 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-07 (kanban board-config helper layer — PR 1 of 3)
+
+### Added
+- **kanban 0.3.25** — `lib/board_config.py` + three new helper
+  subcommands lay the foundation for moving the canonical shared
+  board config off per-receiver paste flows
+  (`/kanban:showjira-code` → `/kanban:import-jira-code` round-trip)
+  onto the **Jira project itself**, stored under property key
+  `kanban-config`. Multi-machine teams stop drifting silently when
+  one repo updates the rules.
+
+  This is **PR 1 of 3**. Helpers + tests only — no slash commands,
+  no driver-level passive sync, no removal of the old paste flow yet.
+  PR 2 wires `/kanban:push-board-config` / `/kanban:pull-board-config`
+  / `/kanban:show-board-config` and adds 8h-TTL passive sync at
+  driver init. PR 3 removes `showjira-code` / `import-jira-code` /
+  `initjira-by-code` and ships the migration command.
+
+  **Storage model**:
+  - **Jira project property `kanban-config`** — authoritative; written
+    by push (requires Jira project-admin role), read by pull. 32KB
+    Atlassian-imposed cap, plenty for transitions DSL + conventions.
+  - **`kanban.json#backend.jira`** — git-tracked per-machine cache.
+    Mirrors the property's value. Survives clones; auto-commits on
+    pull just like any other state change.
+  - **`.claude/kanban-agent.json#boardConfigCachedAt`** — ISO 8601
+    timestamp of the last successful pull on this machine. Drives the
+    8-hour passive-sync TTL (constant `CACHE_TTL_HOURS=8` in
+    `lib/board_config`).
+
+  **Authority precedence**: Jira-side wins on read; local push only
+  fires when an admin runs `/kanban:push-board-config` explicitly.
+  Two agents pushing simultaneously is last-writer-wins (Atlassian
+  doesn't expose ETag versioning on properties).
+
+  **Offline behaviour**: when Jira is unreachable, pull fails — the
+  local cache continues to serve. PR 2 will surface a "using stale
+  cache" warning in `/kanban:whoami`.
+
+  **New `lib/board_config.py` surface**:
+  - `push(client, project_key, config)` — writes property; raises
+    `BoardConfigError` with permission-clear message on 403
+  - `pull(client, project_key)` — returns the unwrapped config dict;
+    distinguishes 404 ("no config yet") via `not_found` attribute
+  - `cache_age_hours(repo_root)` — float | None
+  - `is_cache_stale(repo_root, ttl_hours=None)` — bool, default 8h TTL
+  - `mark_synced(repo_root, ts=None)` — writes
+    `.claude/kanban-agent.json#boardConfigCachedAt`, preserves other
+    fields (`ap`, `lastMentionSeenAt`, etc.)
+
+  **New `JiraClient` methods** (`lib/jira_client.py`):
+  - `get_project_property(key, prop_key)` — full envelope
+    `{"key", "value"}`
+  - `set_project_property(key, prop_key, value)` — body is the JSON
+    value to store
+
+  **New helper subcommands** (`scripts/jira_setup.py`):
+  - `push-board-config --kanban-path P` — strips per-machine fields
+    (`agentAccountId`, `ap.registered`) before writing; marks local
+    cache as freshly synced too
+  - `pull-board-config --kanban-path P [--project-key K]` — overwrites
+    `backend.jira` from Jira; **preserves** per-machine fields
+    (`agentAccountId`, `ap.registered`); records `cachedAt`
+  - `read-board-config [--kanban-path P] [--project-key K]` — print
+    Jira-side config without touching local state
+
+  **Coexistence**: `showjira-code` / `import-jira-code` /
+  `initjira-by-code` keep working unchanged in 0.3.25. PR 3 removes
+  them.
+
+  Phase 30 covers eleven cases: push happy path; push 403 →
+  permission-denied with admin-role hint; pull happy path; pull 404
+  → distinct `not_found` error; cache age None when unset; cache age
+  float when set (3h tolerance); stale-cache logic across no-cache /
+  fresh / past-TTL / custom TTL; mark_synced preserves other fields;
+  push command strips per-machine fields; pull command preserves
+  per-machine fields and records `cachedAt`; read command does not
+  touch local kanban.json or `.claude/kanban-agent.json`.
+
+  All 30 phases green.
+
 ## 2026-05-06 (kanban anti-self-approve keyed on statusCategory)
 
 ### Fixed

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/lib/board_config.py
+++ b/plugins/kanban/lib/board_config.py
@@ -1,0 +1,243 @@
+"""Board-side config storage on Jira project properties (#after-50).
+
+Background: pre-0.3.25, multi-machine teams shared the kanban
+`backend.jira` block (transitions DSL, AP field id, conventions notes,
+etc.) by emitting a JSON payload via `/kanban:showjira-code` and
+manually pasting it into `/kanban:import-jira-code` on every receiver.
+That hand-paste flow drifts: changes on the source repo silently fail
+to propagate; new repos/machines have to be told the steps; nothing
+prevents two receivers from ending up on different versions.
+
+The 0.3.25+ replacement: the canonical config lives **on the Jira
+project itself** under property key `kanban-config`. Receivers pull;
+admins push. The local kanban.json is a per-machine cache.
+
+Storage model:
+- **Jira project property** `kanban-config` — authoritative JSON; written
+  by `push()` (requires project-admin Jira role); read by `pull()`.
+- **`kanban.json#backend.jira`** — per-machine cache. Mirrors the Jira
+  property's value. Git-tracked so the cache is auditable and survives
+  fresh clones.
+- **`.claude/kanban-agent.json#boardConfigCachedAt`** — per-machine
+  ISO 8601 timestamp of the last successful pull. Drives passive sync:
+  when the cache is older than `CACHE_TTL_HOURS`, the next operation
+  triggers a refresh.
+
+Public surface:
+    push(client, project_key, config)         -> None
+    pull(client, project_key)                 -> dict[str, Any]
+    cache_age_hours(repo_root)                -> float | None
+    is_cache_stale(repo_root, ttl=None)       -> bool
+    mark_synced(repo_root, ts=None)           -> Path
+    PROPERTY_KEY                              -> "kanban-config"
+    CACHE_TTL_HOURS                           -> 8
+    BoardConfigError                          -> exception type
+
+Concurrency: project property writes are last-writer-wins (Jira does
+not expose ETag versioning on properties). Two admins pushing
+simultaneously is a real but rare edge — `push()` does not attempt
+optimistic concurrency.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+# Jira project property key — this string is part of the on-Jira
+# contract. Don't rename without a migration step.
+PROPERTY_KEY = "kanban-config"
+
+# Passive-sync threshold. After this many hours since the last pull,
+# the next driver operation refreshes the cache. Tunable via
+# /kanban:sync-board-config which forces a pull regardless of TTL.
+CACHE_TTL_HOURS = 8
+
+# .claude/kanban-agent.json field that stores the per-machine timestamp
+# of the most recent successful pull.
+_CACHED_AT_FIELD = "boardConfigCachedAt"
+
+
+class BoardConfigError(RuntimeError):
+    """Raised when a push/pull operation fails in a way the caller
+    should surface to the user (permission denied, malformed payload,
+    Jira unreachable). Distinct from JiraError so callers can
+    differentiate config-layer failures from underlying HTTP errors.
+    """
+
+
+def push(client: Any, project_key: str, config: dict[str, Any]) -> None:
+    """Write `config` to the Jira project's `kanban-config` property.
+
+    `config` is the canonical JSON the team agrees on — typically the
+    `backend.jira` block from a fully-configured kanban.json minus
+    per-machine fields (`agentAccountId` is per-Atlassian-account, but
+    the rest of the block is per-board and should round-trip).
+
+    Raises BoardConfigError on permission failure (403) or other
+    non-retryable issues with a readable message. Other HTTP errors
+    surface from the underlying client.
+    """
+    if not isinstance(config, dict) or not config:
+        raise BoardConfigError("config must be a non-empty JSON object")
+    if not project_key:
+        raise BoardConfigError("project_key is required")
+
+    # Local import to avoid making board_config depend on jira_client at
+    # module load time (callers that only need cache helpers shouldn't
+    # pay that import cost).
+    from lib.jira_client import JiraError
+
+    try:
+        client.set_project_property(project_key, PROPERTY_KEY, config)
+    except JiraError as e:
+        if e.status_code == 403:
+            raise BoardConfigError(
+                f"permission denied writing project property "
+                f"{PROPERTY_KEY!r} on {project_key!r}: agent's Jira "
+                f"account needs project-admin role to push board config. "
+                f"Ask a project admin to push, or grant the agent admin "
+                f"role on this project."
+            ) from e
+        raise BoardConfigError(
+            f"jira: {e.detail or e} (status={e.status_code})"
+        ) from e
+
+
+def pull(client: Any, project_key: str) -> dict[str, Any]:
+    """Read the Jira project's `kanban-config` property and return the
+    config dict.
+
+    Raises BoardConfigError(404-marker) when the property hasn't been
+    set yet — caller distinguishes "no config on board" from "Jira
+    unreachable" by checking `BoardConfigError.not_found` (set on the
+    raised instance for the 404 case only).
+    """
+    if not project_key:
+        raise BoardConfigError("project_key is required")
+
+    from lib.jira_client import JiraError
+
+    try:
+        envelope = client.get_project_property(project_key, PROPERTY_KEY)
+    except JiraError as e:
+        if e.status_code == 404:
+            err = BoardConfigError(
+                f"no board config set yet on Jira project {project_key!r} "
+                f"(property {PROPERTY_KEY!r} does not exist). "
+                f"Run /kanban:push-board-config from a repo whose "
+                f"backend.jira block carries the team's canonical config."
+            )
+            err.not_found = True  # type: ignore[attr-defined]
+            raise err from e
+        raise BoardConfigError(
+            f"jira: {e.detail or e} (status={e.status_code})"
+        ) from e
+
+    if not isinstance(envelope, dict):
+        raise BoardConfigError(
+            "project property response was not a JSON object"
+        )
+    value = envelope.get("value")
+    if not isinstance(value, dict):
+        raise BoardConfigError(
+            "project property `value` is not a JSON object — "
+            "the property may have been set by a non-kanban writer"
+        )
+    return value
+
+
+def cache_age_hours(repo_root: Path) -> float | None:
+    """Return how many hours have elapsed since the last successful
+    pull on this machine, or None if no pull has ever been recorded.
+    """
+    ts_str = _read_cached_at(repo_root)
+    if not ts_str:
+        return None
+    parsed = _parse_iso(ts_str)
+    if parsed is None:
+        return None
+    delta = _utcnow() - parsed
+    return max(delta.total_seconds() / 3600.0, 0.0)
+
+
+def is_cache_stale(repo_root: Path, *, ttl_hours: float | None = None) -> bool:
+    """True when the cache is older than TTL (or has never been
+    populated). Used by the driver layer to decide whether to trigger
+    a passive sync before the next operation.
+    """
+    ttl = ttl_hours if ttl_hours is not None else CACHE_TTL_HOURS
+    age = cache_age_hours(repo_root)
+    if age is None:
+        return True
+    return age >= ttl
+
+
+def mark_synced(repo_root: Path, ts: datetime | None = None) -> Path:
+    """Record `ts` (default: now) as the latest successful pull
+    timestamp. Returns the .claude/kanban-agent.json path.
+    """
+    when = (ts or _utcnow()).isoformat(timespec="seconds")
+    return _write_cached_at(repo_root, when)
+
+
+# --- private helpers ----------------------------------------------------
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(ts: str) -> datetime | None:
+    if not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _agent_path(repo_root: Path) -> Path:
+    return Path(repo_root) / ".claude" / "kanban-agent.json"
+
+
+def _read_cached_at(repo_root: Path) -> str | None:
+    target = _agent_path(repo_root)
+    if not target.exists():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    val = data.get(_CACHED_AT_FIELD)
+    return val if isinstance(val, str) else None
+
+
+def _write_cached_at(repo_root: Path, when: str) -> Path:
+    target = _agent_path(repo_root)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                data = {}
+        except Exception:
+            data = {}
+    else:
+        data = {}
+    data[_CACHED_AT_FIELD] = when
+    target.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return target

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -212,6 +212,40 @@ class JiraClient:
         """Returns a list of issue-types each with their `statuses` array."""
         return self._request("GET", f"/rest/api/3/project/{project_key}/statuses")
 
+    def get_project_property(
+        self, project_key: str, property_key: str
+    ) -> dict[str, Any]:
+        """Read a project entity property — structured JSON keyed under
+        the given property name. Used by the kanban plugin to store
+        board-level config (transitions DSL, AP field, conventions) on
+        the Jira project itself, replacing the per-machine `import-jira-
+        code` paste flow (#issue-after-50).
+
+        Returns the full envelope shape:
+            {"key": "<property_key>", "value": <user-supplied JSON>}
+        Raises `JiraError(404)` when the property hasn't been set yet —
+        callers usually treat that as "no board config yet, fall back
+        to local DSL setup."
+        """
+        return self._request(
+            "GET",
+            f"/rest/api/3/project/{project_key}/properties/{property_key}",
+        )
+
+    def set_project_property(
+        self, project_key: str, property_key: str, value: Any
+    ) -> None:
+        """Write a project entity property. Requires the agent's Jira
+        account to have project-admin role; non-admin writers get 403.
+        Properties cap at 32KB per value (Atlassian limit) — well above
+        what a typical transitions/conventions block needs.
+        """
+        self._request(
+            "PUT",
+            f"/rest/api/3/project/{project_key}/properties/{property_key}",
+            body=value,
+        )
+
     def search_jql(
         self,
         jql: str,

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -941,6 +941,177 @@ def cmd_resolve_doc_link(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_push_board_config(args: argparse.Namespace) -> int:
+    """Push the local `backend.jira` block to the Jira project's
+    `kanban-config` property — the new authoritative storage location
+    for board-level config (replacing /kanban:showjira-code paste-flow,
+    rolling out across 0.3.25+).
+
+    What gets pushed: transitions DSL, ap.fieldId/fieldName, boardId,
+    boardUrl, projectKey, conventions. Per-machine fields
+    (`agentAccountId`, `ap.registered`) are stripped so two machines
+    pushing don't fight over them.
+
+    Requires Jira project-admin role on the agent's account; non-admin
+    pushes return a clear permission-error message.
+    """
+    from lib import board_config as _bc
+
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        return _fail("backend.driver must be 'jira'")
+
+    cfg = dict(backend.get("jira") or {})
+    if not cfg.get("transitions"):
+        return _fail("no transitions defined — run /kanban:initjira first")
+
+    project_key = cfg.get("projectKey")
+    if not project_key:
+        return _fail("backend.jira.projectKey is empty")
+
+    # Strip per-machine / per-account fields. The shared canonical
+    # config is everything that should be identical across teammates;
+    # `agentAccountId` and `ap.registered` are local state.
+    payload = {
+        "boardUrl": cfg.get("boardUrl"),
+        "boardId": cfg.get("boardId"),
+        "projectKey": project_key,
+        "transitions": cfg.get("transitions"),
+    }
+    ap = cfg.get("ap") or {}
+    if ap.get("fieldId"):
+        payload["ap"] = {
+            "fieldId": ap["fieldId"],
+            "fieldName": ap.get("fieldName", ""),
+        }
+    payload["conventions"] = _cv.normalize(cfg.get("conventions"))
+    # Drop nulls so the on-Jira blob stays minimal.
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    client = _client_from_env()
+    try:
+        _bc.push(client, project_key, payload)
+    except _bc.BoardConfigError as e:
+        return _fail(str(e))
+
+    # Mark this machine's cache as freshly synced too — the local
+    # kanban.json content matches what we just pushed, so no immediate
+    # passive sync is needed.
+    _bc.mark_synced(p.parent)
+    _emit({
+        "ok": True,
+        "projectKey": project_key,
+        "propertyKey": _bc.PROPERTY_KEY,
+        "fieldsPushed": sorted(payload.keys()),
+    })
+    return 0
+
+
+def cmd_pull_board_config(args: argparse.Namespace) -> int:
+    """Pull the Jira project's `kanban-config` property and overwrite
+    the local kanban.json's `backend.jira` block with it. Records the
+    sync timestamp in `.claude/kanban-agent.json#boardConfigCachedAt`
+    so passive-sync TTL tracking works on the next driver call.
+
+    Per-machine fields are preserved across the overwrite:
+    `agentAccountId` (which is the shared agent account, but commonly
+    populated from /kanban:initjira step 1) and `ap.registered` (the
+    live AP roster pulled separately via /kanban:live-list-aps).
+    """
+    from lib import board_config as _bc
+
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    backend = data.setdefault("backend", {"driver": "jira"})
+    existing_cfg = dict(backend.get("jira") or {})
+
+    project_key = existing_cfg.get("projectKey") or args.project_key
+    if not project_key:
+        return _fail(
+            "backend.jira.projectKey unset and --project-key not given — "
+            "set the project key in kanban.json or pass --project-key"
+        )
+
+    client = _client_from_env()
+    try:
+        remote = _bc.pull(client, project_key)
+    except _bc.BoardConfigError as e:
+        return _fail(str(e), notFound=getattr(e, "not_found", False))
+
+    # Merge: the pulled config is authoritative for shared fields.
+    # Preserve the per-machine pieces that Jira-side doesn't carry.
+    new_cfg = dict(remote)
+    if existing_cfg.get("agentAccountId"):
+        new_cfg["agentAccountId"] = existing_cfg["agentAccountId"]
+    # Preserve the local AP roster on `ap.registered` (the on-Jira
+    # config carries fieldId/fieldName but not the registered list).
+    if (existing_cfg.get("ap") or {}).get("registered"):
+        new_cfg.setdefault("ap", {}).setdefault("registered", [])
+        new_cfg["ap"]["registered"] = list(existing_cfg["ap"]["registered"])
+        # If pulled `ap` was missing fieldId, fall back to existing.
+        if not new_cfg["ap"].get("fieldId") and (existing_cfg.get("ap") or {}).get("fieldId"):
+            new_cfg["ap"]["fieldId"] = existing_cfg["ap"]["fieldId"]
+            new_cfg["ap"]["fieldName"] = existing_cfg["ap"].get("fieldName", "")
+
+    backend["driver"] = "jira"
+    backend["jira"] = new_cfg
+    kanban_io.save(p, data)
+    _bc.mark_synced(p.parent)
+
+    _emit({
+        "ok": True,
+        "projectKey": project_key,
+        "propertyKey": _bc.PROPERTY_KEY,
+        "transitionsCount": len(new_cfg.get("transitions") or {}),
+    })
+    return 0
+
+
+def cmd_read_board_config(args: argparse.Namespace) -> int:
+    """Read the Jira project's `kanban-config` property without
+    touching local state. Used by /kanban:show-board-config for
+    discovery — humans inspect what's currently published on Jira
+    without disturbing the local cache.
+    """
+    from lib import board_config as _bc
+
+    project_key = args.project_key
+    if not project_key:
+        # Fall through to reading from kanban.json for convenience.
+        if args.kanban_path:
+            p = Path(args.kanban_path)
+            if p.exists():
+                data = kanban_io.load(p)
+                project_key = (
+                    (data.get("backend") or {}).get("jira") or {}
+                ).get("projectKey")
+        if not project_key:
+            return _fail(
+                "--project-key required (or pass --kanban-path to read it "
+                "from backend.jira.projectKey)"
+            )
+
+    client = _client_from_env()
+    try:
+        config = _bc.pull(client, project_key)
+    except _bc.BoardConfigError as e:
+        return _fail(str(e), notFound=getattr(e, "not_found", False))
+
+    _emit({
+        "ok": True,
+        "projectKey": project_key,
+        "propertyKey": _bc.PROPERTY_KEY,
+        "config": config,
+    })
+    return 0
+
+
 def cmd_emit_jira_code(args: argparse.Namespace) -> int:
     """Print the shareable backend.jira block as compact JSON.
 
@@ -3163,6 +3334,47 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--code-json", required=True,
                    help="the JSON code emitted by /kanban:showjira-code on the source machine")
     s.set_defaults(func=cmd_import_jira_code)
+
+    # Board-config helpers (#after-50, kanban 0.3.25+). The
+    # authoritative shared config lives on the Jira project itself
+    # under property key `kanban-config`; these subcommands push/pull/
+    # read that property and keep the local kanban.json + per-machine
+    # cache timestamp in sync. Three slash commands are wired in PR 2:
+    # /kanban:push-board-config, /kanban:pull-board-config, and
+    # /kanban:show-board-config (for discovery).
+    s = sub.add_parser(
+        "push-board-config",
+        help="Write local backend.jira to Jira project property "
+             "(kanban-config); requires project-admin on Jira",
+    )
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_push_board_config)
+
+    s = sub.add_parser(
+        "pull-board-config",
+        help="Pull kanban-config from Jira project property and "
+             "overwrite local backend.jira (preserves per-machine fields)",
+    )
+    s.add_argument("--kanban-path", required=True)
+    s.add_argument(
+        "--project-key",
+        help="Override the project key — defaults to "
+             "backend.jira.projectKey from kanban.json. Useful on first "
+             "pull when the local cache is empty.",
+    )
+    s.set_defaults(func=cmd_pull_board_config)
+
+    s = sub.add_parser(
+        "read-board-config",
+        help="Read-only snapshot of the Jira-side kanban-config "
+             "property. Doesn't touch local state.",
+    )
+    s.add_argument("--kanban-path",
+                   help="optional; used to look up projectKey if "
+                        "--project-key is not given")
+    s.add_argument("--project-key",
+                   help="explicit project key (overrides kanban.json lookup)")
+    s.set_defaults(func=cmd_read_board_config)
 
     s = sub.add_parser("live-list-aps")
     s.add_argument("--kanban-path", required=True)

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase30.py
+++ b/plugins/kanban/scripts/test_phase30.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Phase 30 regression checks for kanban v0.3.25 — board-config helpers.
+
+Background (PR 1 of the showjira-code → board-config replacement):
+
+The canonical shared kanban config (transitions DSL, AP field id,
+conventions) is moving off per-receiver paste-flows and onto the Jira
+project itself, stored under property key `kanban-config`. This phase
+covers the helper layer:
+
+- `lib/board_config.py` primitives (push / pull / cache TTL)
+- `cmd_push_board_config` (kanban.json → Jira)
+- `cmd_pull_board_config` (Jira → kanban.json + cachedAt)
+- `cmd_read_board_config` (read-only snapshot)
+
+Slash commands and driver-level passive sync land in PR 2; the old
+showjira-code/import-jira-code commands stay (no behavior change in
+this PR — additive only).
+
+Cases:
+  (a) _bc.push happy path — calls set_project_property with the right
+      property key + payload.
+  (b) _bc.push translates 403 into a permission-denied
+      BoardConfigError mentioning "project-admin role".
+  (c) _bc.pull happy path — returns the unwrapped `value` dict from
+      the project-property envelope.
+  (d) _bc.pull translates 404 into BoardConfigError with .not_found
+      attribute set, distinct message mentioning push-board-config.
+  (e) _bc.cache_age_hours returns None when no cachedAt exists; a
+      sensible float when one does.
+  (f) _bc.is_cache_stale returns True when no cache, True past TTL,
+      False within TTL.
+  (g) _bc.mark_synced writes ISO timestamp to
+      .claude/kanban-agent.json#boardConfigCachedAt without clobbering
+      other fields.
+  (h) cmd_push_board_config strips per-machine fields (agentAccountId,
+      ap.registered) from the pushed payload.
+  (i) cmd_pull_board_config preserves per-machine fields
+      (agentAccountId, ap.registered) on the local kanban.json after
+      the overwrite.
+  (j) cmd_read_board_config emits the config without touching local
+      kanban.json or .claude/kanban-agent.json.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib import board_config as _bc  # noqa: E402
+from lib.jira_client import JiraClient, JiraError, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    return rc, out, err
+
+
+def _mock_client(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return JiraClient("https://x", "a@b", "tok", transport=t,
+                      sleep=lambda _: None)
+
+
+def _seed_jira_kanban(td: pathlib.Path, *,
+                      project_key="AGENT", with_ap_registered=True,
+                      with_agent_account=True) -> pathlib.Path:
+    cfg = {
+        "boardUrl": f"https://x.atlassian.net/jira/projects/{project_key}/boards/1",
+        "boardId": 1,
+        "projectKey": project_key,
+        "transitions": {
+            "TODO": {"status": "To Do"},
+            "DOING": {"status": "In Progress"},
+            "APPROVED": {"status": "Done"},
+        },
+        "ap": {"fieldId": "customfield_10042",
+               "fieldName": "Claude Agent"},
+        "conventions": {"notes": [], "blockedRequiresLink": False},
+    }
+    if with_ap_registered:
+        cfg["ap"]["registered"] = ["agent-fin", "narrative-fin-agent"]
+    if with_agent_account:
+        cfg["agentAccountId"] = "5e-bot"
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": cfg},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "APPROVED", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+# --- (a) (b) push primitive ---------------------------------------------
+
+
+def test_push_happy_path_calls_set_project_property():
+    queue = [_Response(204, b"", {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    config = {
+        "projectKey": "AGENT",
+        "boardId": 1,
+        "transitions": {"DOING": {"status": "In Progress"}},
+    }
+    _bc.push(client, "AGENT", config)
+
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["method"] == "PUT"
+    assert "/rest/api/3/project/AGENT/properties/kanban-config" in c["url"]
+    body = json.loads((c["body"] or b"").decode())
+    assert body == config
+
+
+def test_push_403_raises_permission_denied_with_admin_hint():
+    queue = [_Response(403, b'{"errorMessages":["nope"]}', {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    try:
+        _bc.push(client, "AGENT", {"transitions": {}})
+    except _bc.BoardConfigError as e:
+        msg = str(e)
+        assert "permission denied" in msg.lower()
+        assert "project-admin role" in msg
+        return
+    raise AssertionError("expected BoardConfigError")
+
+
+# --- (c) (d) pull primitive ---------------------------------------------
+
+
+def test_pull_happy_path_returns_unwrapped_value():
+    envelope = {
+        "key": "kanban-config",
+        "value": {
+            "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+        },
+    }
+    queue = [_Response(200, json.dumps(envelope).encode(), {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    out = _bc.pull(client, "AGENT")
+    assert out == envelope["value"]
+    assert calls[0]["method"] == "GET"
+    assert "/rest/api/3/project/AGENT/properties/kanban-config" in calls[0]["url"]
+
+
+def test_pull_404_raises_not_found_distinct_error():
+    queue = [_Response(404, b'{"errorMessages":["not found"]}', {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    try:
+        _bc.pull(client, "AGENT")
+    except _bc.BoardConfigError as e:
+        assert getattr(e, "not_found", False) is True
+        msg = str(e)
+        assert "no board config set yet" in msg
+        assert "push-board-config" in msg
+        return
+    raise AssertionError("expected BoardConfigError")
+
+
+# --- (e) (f) (g) cache TTL helpers --------------------------------------
+
+
+def test_cache_age_returns_none_when_unset():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        # No .claude/kanban-agent.json yet
+        assert _bc.cache_age_hours(proj) is None
+
+
+def test_cache_age_returns_float_when_set():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        # Mark synced 3h ago
+        three_h_ago = datetime.now(timezone.utc) - timedelta(hours=3)
+        _bc.mark_synced(proj, three_h_ago)
+        age = _bc.cache_age_hours(proj)
+        assert age is not None
+        # Allow tolerance for clock skew between mark and read
+        assert 2.9 <= age <= 3.1, age
+
+
+def test_is_cache_stale_logic():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        # No cache at all → stale
+        assert _bc.is_cache_stale(proj) is True
+
+        # Recent cache (1h ago) with default TTL=8 → fresh
+        one_h_ago = datetime.now(timezone.utc) - timedelta(hours=1)
+        _bc.mark_synced(proj, one_h_ago)
+        assert _bc.is_cache_stale(proj) is False
+
+        # Old cache (10h ago) with default TTL=8 → stale
+        ten_h_ago = datetime.now(timezone.utc) - timedelta(hours=10)
+        _bc.mark_synced(proj, ten_h_ago)
+        assert _bc.is_cache_stale(proj) is True
+
+        # Custom TTL: 1h cache + ttl_hours=0.5 → stale
+        _bc.mark_synced(proj, one_h_ago)
+        assert _bc.is_cache_stale(proj, ttl_hours=0.5) is True
+
+
+def test_mark_synced_preserves_other_fields():
+    with tempfile.TemporaryDirectory() as td:
+        proj = pathlib.Path(td)
+        agent_path = proj / ".claude" / "kanban-agent.json"
+        agent_path.parent.mkdir()
+        agent_path.write_text(json.dumps({
+            "ap": "agent-fin",
+            "lastMentionSeenAt": "2026-05-01T00:00:00+00:00",
+        }))
+
+        _bc.mark_synced(proj)
+
+        data = json.loads(agent_path.read_text())
+        assert data["ap"] == "agent-fin"
+        assert data["lastMentionSeenAt"] == "2026-05-01T00:00:00+00:00"
+        assert "boardConfigCachedAt" in data
+        # Parses as ISO
+        from datetime import datetime
+        datetime.fromisoformat(data["boardConfigCachedAt"])
+
+
+# --- (h) push command strips per-machine fields -------------------------
+
+
+def _patch_client_from_env(client):
+    orig = _jira_setup._client_from_env
+    _jira_setup._client_from_env = lambda: client
+    return orig
+
+
+def _restore_client_from_env(orig):
+    _jira_setup._client_from_env = orig
+
+
+def test_cmd_push_strips_per_machine_fields():
+    """`agentAccountId` and `ap.registered` are per-machine state and
+    must not appear in the pushed payload — two machines pushing
+    shouldn't fight over them."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td, with_ap_registered=True,
+                               with_agent_account=True)
+        queue = [_Response(204, b"", {})]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A: kanban_path = str(kp)
+            rc, out, err = _capture(_jira_setup.cmd_push_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc == 0, (out, err)
+        body = json.loads((calls[0]["body"] or b"").decode())
+        # Per-machine fields stripped
+        assert "agentAccountId" not in body
+        assert "registered" not in (body.get("ap") or {})
+        # Shared fields present
+        assert body["projectKey"] == "AGENT"
+        assert body["transitions"]
+        assert body["ap"]["fieldId"] == "customfield_10042"
+
+
+# --- (i) pull command preserves per-machine fields ----------------------
+
+
+def test_cmd_pull_preserves_per_machine_fields():
+    """After a pull, the local kanban.json's `agentAccountId` and
+    `ap.registered` must survive even though the Jira-side payload
+    doesn't carry them."""
+    remote_payload = {
+        "key": "kanban-config",
+        "value": {
+            "projectKey": "AGENT",
+            "boardId": 1,
+            "boardUrl": "https://x.atlassian.net/jira/projects/AGENT/boards/1",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "APPROVED": {"status": "Done"},
+                "REVIEW": {"status": "REVIEW"},  # extra: pulled adds new entry
+            },
+            "ap": {
+                "fieldId": "customfield_10042",
+                "fieldName": "Claude Agent",
+            },
+            "conventions": {"notes": ["new team rule"], "blockedRequiresLink": True},
+        },
+    }
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td, with_ap_registered=True,
+                               with_agent_account=True)
+        queue = [_Response(200, json.dumps(remote_payload).encode(), {})]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A:
+                kanban_path = str(kp)
+                project_key = None
+            rc, out, err = _capture(_jira_setup.cmd_pull_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc == 0, (out, err)
+        # On-disk kanban.json: shared fields overwritten, per-machine kept
+        on_disk = json.loads(kp.read_text())
+        cfg = on_disk["backend"]["jira"]
+        # New transition pulled in
+        assert "REVIEW" in cfg["transitions"]
+        # Conventions overwrite worked
+        assert cfg["conventions"]["blockedRequiresLink"] is True
+        # Per-machine preserved
+        assert cfg["agentAccountId"] == "5e-bot"
+        assert cfg["ap"]["registered"] == ["agent-fin", "narrative-fin-agent"]
+        assert cfg["ap"]["fieldId"] == "customfield_10042"
+
+        # cachedAt was recorded
+        agent_data = json.loads(
+            (td / ".claude" / "kanban-agent.json").read_text()
+        )
+        assert "boardConfigCachedAt" in agent_data
+
+
+# --- (j) read command doesn't touch local state -------------------------
+
+
+def test_cmd_read_does_not_touch_local():
+    remote_payload = {
+        "key": "kanban-config",
+        "value": {"projectKey": "AGENT", "transitions": {"DOING": {"status": "In Progress"}}},
+    }
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        kp_before = kp.read_bytes()
+        agent_path = td / ".claude" / "kanban-agent.json"
+        agent_before = agent_path.read_bytes() if agent_path.exists() else None
+
+        queue = [_Response(200, json.dumps(remote_payload).encode(), {})]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A:
+                kanban_path = str(kp)
+                project_key = None
+            rc, out, err = _capture(_jira_setup.cmd_read_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["config"] == remote_payload["value"]
+
+        # Local files untouched
+        assert kp.read_bytes() == kp_before
+        if agent_before is not None:
+            assert agent_path.read_bytes() == agent_before
+        else:
+            assert not agent_path.exists()
+
+
+def main() -> int:
+    cases = [
+        ("push_happy_path_calls_set_project_property",
+         test_push_happy_path_calls_set_project_property),
+        ("push_403_raises_permission_denied_with_admin_hint",
+         test_push_403_raises_permission_denied_with_admin_hint),
+        ("pull_happy_path_returns_unwrapped_value",
+         test_pull_happy_path_returns_unwrapped_value),
+        ("pull_404_raises_not_found_distinct_error",
+         test_pull_404_raises_not_found_distinct_error),
+        ("cache_age_returns_none_when_unset",
+         test_cache_age_returns_none_when_unset),
+        ("cache_age_returns_float_when_set",
+         test_cache_age_returns_float_when_set),
+        ("is_cache_stale_logic", test_is_cache_stale_logic),
+        ("mark_synced_preserves_other_fields",
+         test_mark_synced_preserves_other_fields),
+        ("cmd_push_strips_per_machine_fields",
+         test_cmd_push_strips_per_machine_fields),
+        ("cmd_pull_preserves_per_machine_fields",
+         test_cmd_pull_preserves_per_machine_fields),
+        ("cmd_read_does_not_touch_local",
+         test_cmd_read_does_not_touch_local),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase30: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase30: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

**PR 1 of 3** in the showjira-code → board-config replacement. Helpers + tests only — no slash commands, no driver-level passive sync, no removal of the old paste flow yet.

The end-state vision: the canonical shared kanban config (transitions DSL, AP field, conventions) lives on the **Jira project itself** under property key `kanban-config`. Multi-machine teams stop drifting when one repo updates the rules. Receivers pull; admins push.

## Roadmap

| PR | What lands |
|---|---|
| **#52 (this PR)** | helpers + tests only |
| **PR 2** | slash commands (`push-board-config`, `pull-board-config`, `show-board-config`); driver-level 8h TTL passive sync; `/kanban:whoami` shows cache age; `/kanban:initjira` auto-pulls when board has config |
| **PR 3** | remove `showjira-code` / `import-jira-code` / `initjira-by-code`; ship one-time migration command; docs sweep |

## Storage model

- **Jira project property `kanban-config`** — authoritative JSON. Written by push (requires Jira project-admin role), read by pull. 32KB Atlassian cap, plenty for transitions + conventions.
- **`kanban.json#backend.jira`** — git-tracked per-machine cache. Mirrors the property's value. Survives clones; auto-commits on pull.
- **`.claude/kanban-agent.json#boardConfigCachedAt`** — ISO 8601 timestamp of last successful pull on this machine. Drives 8h passive-sync TTL (`CACHE_TTL_HOURS=8` in `lib/board_config`).

## Authority precedence

- **Read**: Jira-side wins. Local cache serves when fresh; passive sync triggers on stale (PR 2).
- **Write**: only when admin runs `/kanban:push-board-config`. Two-admin concurrent push = last-writer-wins (Atlassian doesn't expose ETag versioning on properties; acceptable for a rare race).
- **Offline**: pull fails when Jira unreachable; local cache keeps serving.

## Files

- **`plugins/kanban/lib/board_config.py`** (new): `push`, `pull`, `cache_age_hours`, `is_cache_stale`, `mark_synced`, `BoardConfigError`, `PROPERTY_KEY`, `CACHE_TTL_HOURS`
- **`plugins/kanban/lib/jira_client.py`**: new `get_project_property` / `set_project_property` methods
- **`plugins/kanban/scripts/jira_setup.py`**: three subcommands
  - `push-board-config --kanban-path P` — strips per-machine fields (`agentAccountId`, `ap.registered`) before writing
  - `pull-board-config --kanban-path P [--project-key K]` — overwrites `backend.jira`; **preserves** per-machine fields; records `cachedAt`
  - `read-board-config [--kanban-path P] [--project-key K]` — print without touching local
- **`plugins/kanban/scripts/test_phase30.py`** (new): 11 cases
- Version bump 0.3.24 → 0.3.25, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 30 phases green
- [x] **Phase 30 (11 cases)**: push happy path; push 403 → admin-role hint; pull happy path; pull 404 → distinct `not_found`; cache age `None` when unset; cache age float (3h tolerance); `is_cache_stale` across no-cache/fresh/past-TTL/custom-TTL; `mark_synced` preserves other agent.json fields; push strips per-machine fields; pull preserves per-machine fields + records `cachedAt`; read doesn't touch local state
- [ ] Manual: from a configured kanban-mode repo, `python3 jira_setup.py push-board-config --kanban-path ./kanban.json`, verify Jira project property exists with stripped payload (no `agentAccountId`, no `ap.registered`)
- [ ] Manual: from a fresh repo with only `projectKey` populated, `pull-board-config --project-key AGENT`, verify local kanban.json populated with full transitions block

## Coexistence

`/kanban:showjira-code`, `/kanban:import-jira-code`, `/kanban:initjira-by-code` keep working unchanged in 0.3.25 (deprecation removal lands in PR 3, not here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)