### PR TITLE
feat(kanban): 0.3.26 — board-config slash commands + passive sync (PR 2 of 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.25",
+      "version": "0.3.26",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,92 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-07 (kanban board-config slash commands + passive sync — PR 2 of 3)
+
+### Added
+- **kanban 0.3.26** — three new slash commands and SessionStart-
+  triggered passive sync wire up the helpers from PR 1 (#52, 0.3.25).
+  Multi-machine teams now stay in sync without manual paste flow.
+  This is **PR 2 of 3**; PR 3 removes `showjira-code` /
+  `import-jira-code` / `initjira-by-code` and ships the migration
+  command.
+
+  **New slash commands**:
+  - `/kanban:push-board-config` — admin uploads this repo's
+    `backend.jira` block to the Jira project property `kanban-config`
+    (the canonical shared source). Strips per-machine fields
+    (`agentAccountId`, `ap.registered`) before pushing. Requires
+    Jira project-admin role; non-admin pushes get a clear permission
+    message pointing at the role grant.
+  - `/kanban:pull-board-config [--project-key K]` — anyone can pull
+    the latest config from Jira. Overwrites local `backend.jira`,
+    preserves per-machine fields, records `cachedAt`. Resets the 8h
+    TTL clock for passive sync. Useful when you know the team just
+    pushed and don't want to wait for the next session, or when
+    bootstrapping a fresh repo.
+  - `/kanban:show-board-config` — read-only inspection of the
+    Jira-side payload. Doesn't touch local state, doesn't reset the
+    cache TTL. Useful for spotting drift between local cache and the
+    canonical Jira-side config.
+
+  **Passive sync at SessionStart** (`cmd_sync_summary`):
+  When the local board-config cache is older than `CACHE_TTL_HOURS`
+  (8h, defined in `lib/board_config`), `/kanban:sync` opportunistically
+  pulls from Jira before rendering its open-cards summary. The pull
+  result feeds the same session — fresh transitions / conventions
+  are honored immediately. Best-effort:
+  - 404 (no config on Jira yet) — silent skip; common during
+    early adoption.
+  - 403 (permission denied) — stderr warning; continue with stale
+    cache.
+  - missing credentials — silent skip; the token row in
+    `/kanban:whoami` already surfaces this.
+  - any other failure — stderr warning; continue.
+
+  **`/kanban:whoami`** gains a `Board config:` row showing where the
+  config lives on Jira plus the local cache age:
+  ```
+  Board config:  Jira project AGENT properties.kanban-config
+                 (synced 3h ago, fresh)
+  ```
+  Or for never-synced state:
+  ```
+  Board config:  Jira project AGENT properties.kanban-config
+                 (never synced — run /kanban:pull-board-config)
+  ```
+  Backed by a tiny new helper subcommand `read-board-config-cache`
+  that returns metadata (cachedAt, cacheAgeHours, stale, ttlHours)
+  without making any Jira call.
+
+  **Internal**: shared merge helper `_apply_pulled_board_config` used
+  by both the explicit `pull-board-config` subcommand and the new
+  `_maybe_passive_sync_board_config` entry point. Identical merge
+  semantics — Jira-side wins on shared fields, per-machine fields
+  preserved.
+
+  **Drive-by fix**: latent bug in `JiraDriver.list_tasks` that
+  referenced uninitialised `self.partial` / `self.label_fallback`
+  attributes (legacy v0.2 fields removed in v0.3 migrate_legacy).
+  Triggered when iterating columns whose canonical → Jira status
+  mapping was undefined. Defensive `getattr(..., False)` /
+  `getattr(..., {})` so the lookup falls through cleanly.
+
+  **Coexistence**: `/kanban:showjira-code`, `/kanban:import-jira-code`,
+  `/kanban:initjira-by-code` continue to work unchanged. PR 3
+  removes them along with their helper subcommands.
+
+  Phase 31 covers ten cases: passive sync local-mode no-op; fresh-
+  cache no-op (no Jira call); stale + successful pull (overwrites
+  local + preserves per-machine + records cachedAt); stale + 404
+  silent skip; stale + 403 warns + continues; stale + missing
+  credentials silent skip; `read-board-config-cache` never-synced /
+  fresh / stale; `cmd_sync_summary` end-to-end with stale cache
+  (pull then summary). Plus 3 phase-18 sync_summary tests updated to
+  pre-mark the cache fresh (so passive sync doesn't consume their
+  reconcile mock queue).
+
+  All 31 phases green.
+
 ## 2026-05-07 (kanban board-config helper layer — PR 1 of 3)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/pull-board-config.md
+++ b/plugins/kanban/commands/pull-board-config.md
@@ -1,0 +1,64 @@
+---
+description: Pull the Jira project's `kanban-config` property and refresh the local kanban.json cache. Runs automatically on /kanban:sync when cache > 8h old; this command forces an immediate sync.
+allowed-tools: Read, Bash(python3:*)
+---
+
+# /kanban:pull-board-config
+
+Fetch the Jira project's `kanban-config` property and overwrite this
+repo's `backend.jira` block with it. Records the sync timestamp so
+the 8h passive-sync TTL clock resets.
+
+**You don't usually need this command.** `/kanban:sync` (which runs at
+SessionStart) already pulls automatically when the cache is stale
+(≥ 8h since last pull). Run this command when:
+
+- You know the team just pushed new config and want the update now
+  (don't want to wait for the next session)
+- Your local `backend.jira` looks wrong / drifted and you want to
+  reset to the canonical Jira-side version
+- Bootstrapping a fresh repo on a new machine — see
+  `/kanban:initjira` for the guided flow that includes a pull
+
+## 0. Pre-flight
+
+- Confirm `kanban.json` exists. If missing, run `/kanban:init` first.
+- The command needs a `projectKey` to know which project's property
+  to read. Resolved in this order:
+  1. `kanban.json#backend.jira.projectKey` (most common path)
+  2. `--project-key` CLI arg (used when local cache hasn't been
+     populated yet — e.g. fresh-machine bootstrap)
+
+## 1. Pull
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py pull-board-config \
+  --kanban-path '<kanban.json path>' \
+  [--project-key '<KEY>']
+```
+
+| Response | Action |
+|---|---|
+| `{ok: true, projectKey, propertyKey, transitionsCount}` | print `✓ Pulled board config from Jira project <projectKey> (<transitionsCount> transitions)`; mention `/kanban:whoami` to verify cache freshness |
+| `{ok: false, notFound: true, error}` | print the error verbatim; suggest `/kanban:push-board-config` to publish this repo's config (if user has admin role) |
+| `{ok: false, error}` mentioning permission / network | surface verbatim; cache stays stale |
+
+## 2. What gets overwritten + what's preserved
+
+**Overwritten** (Jira-side wins):
+- `transitions` (the DSL — full block)
+- `boardUrl`, `boardId`, `projectKey`
+- `ap.fieldId`, `ap.fieldName`
+- `conventions`
+
+**Preserved** (per-machine state):
+- `agentAccountId` — your local Atlassian account binding
+- `ap.registered` — local AP roster hint (refresh separately via
+  `/kanban:live-list-aps` if it looks stale)
+
+## Absolute rules
+
+- Never write to Jira from this command — it's a one-way download.
+- Never echo or mutate any token-related field.
+- If pull fails, the existing local `kanban.json` stays untouched —
+  you continue using the previous cache.

--- a/plugins/kanban/commands/push-board-config.md
+++ b/plugins/kanban/commands/push-board-config.md
@@ -1,0 +1,73 @@
+---
+description: Push the local backend.jira block to the Jira project's `kanban-config` property — admin-only, makes this team's config the canonical source for all receivers.
+allowed-tools: Read, Bash(python3:*), AskUserQuestion
+---
+
+# /kanban:push-board-config
+
+Write this repo's `backend.jira` block (transitions DSL, AP field id,
+boardId/Url, projectKey, conventions) to the Jira project property
+`kanban-config`. After this push, **anyone running `/kanban:sync` on
+the same Jira project** will receive your config on their next stale-
+cache refresh (within 8 hours), or immediately on `/kanban:pull-
+board-config`.
+
+This replaces the older `/kanban:showjira-code` → paste →
+`/kanban:import-jira-code` round-trip flow. **Single source of truth
+on Jira**; receivers don't have to be told the steps.
+
+## Permission requirement
+
+Writing project entity properties requires the agent's Jira account
+to have **project-admin role** on this project. If you get
+`permission denied`, ask a project admin to push (or grant the agent
+admin role on this project — Jira UI: Project Settings → Permissions
+→ Administrators).
+
+## 0. Pre-flight
+
+- Confirm `kanban.json` exists. If missing, run `/kanban:init` then
+  `/kanban:initjira` first.
+- Confirm `backend.driver == "jira"` and `backend.jira.transitions`
+  is non-empty. The push payload comes from those local fields.
+- Warn the user this overwrites whatever's currently on the Jira
+  project property (last-writer-wins; Atlassian doesn't do ETag
+  versioning on properties). For routine pushes from a single source
+  repo this is the expected flow; for "sync from teammate" cases
+  consider `/kanban:pull-board-config` instead.
+
+## 1. Push
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py push-board-config \
+  --kanban-path '<kanban.json path>'
+```
+
+| Response | Action |
+|---|---|
+| `{ok: true, projectKey, propertyKey, fieldsPushed}` | print `✓ Pushed <fieldsPushed.length> fields to Jira project <projectKey> properties.<propertyKey>`; mention all teammates' next `/kanban:sync` will pick this up |
+| `{ok: false, error}` mentioning `permission denied` | surface verbatim; explain admin role is required |
+| `{ok: false, error}` mentioning network / 4xx / 5xx | surface verbatim |
+
+## 2. What gets pushed
+
+The agent strips per-machine fields before pushing:
+- `agentAccountId` — per-Atlassian-account, not per-board
+- `ap.registered` — local hint for the AP roster; Jira itself is the
+  source of truth (read live via `/kanban:live-list-aps`)
+
+Pushed fields: `boardUrl`, `boardId`, `projectKey`, `transitions`,
+`ap.fieldId`, `ap.fieldName`, `conventions`.
+
+## Absolute rules
+
+- **Never** push without explicit user intent — this overwrites the
+  team's shared config. If a teammate just made changes you'd be
+  clobbering theirs.
+- Never mock up the config — only push the actual `backend.jira`
+  block from this repo's `kanban.json`.
+- Never write to `kanban.json` from this command (push is a one-way
+  upload to Jira; doesn't mutate the local cache except marking it
+  freshly synced).
+- If push fails on permission, do NOT retry with a different account
+  or workaround — the right move is to ask a project admin.

--- a/plugins/kanban/commands/show-board-config.md
+++ b/plugins/kanban/commands/show-board-config.md
@@ -1,0 +1,53 @@
+---
+description: Read the Jira project's `kanban-config` property and print it — read-only inspection without touching local kanban.json.
+allowed-tools: Read, Bash(python3:*)
+---
+
+# /kanban:show-board-config
+
+Fetch the Jira project's `kanban-config` property and print it as
+JSON. Read-only — does NOT update the local cache, does NOT change
+any local files. Use this to:
+
+- Inspect what's currently published on Jira (e.g. compare against
+  your local `kanban.json` to spot drift)
+- Verify a recent `/kanban:push-board-config` actually wrote what
+  you expected
+- Triage when a teammate's pulled config looks wrong — confirm the
+  source-of-truth Jira-side payload before debugging further
+
+## 0. Pre-flight
+
+The command needs a `projectKey`. Resolved in this order:
+1. `kanban.json#backend.jira.projectKey` (most common path; pass
+   `--kanban-path`)
+2. `--project-key` CLI arg directly (e.g. inspecting a project not
+   currently configured locally)
+
+## 1. Read
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-board-config \
+  --kanban-path '<kanban.json path>'
+```
+
+Or with explicit project key:
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-board-config \
+  --project-key 'AGENT'
+```
+
+| Response | Action |
+|---|---|
+| `{ok: true, projectKey, propertyKey, config}` | pretty-print the `config` block (transitions, ap, conventions, etc.). Optionally diff against the local `backend.jira` from `kanban.json` and call out any drifted fields. |
+| `{ok: false, notFound: true, error}` | print "no board config published on Jira project <projectKey> yet"; if the user has the canonical config locally, suggest `/kanban:push-board-config` |
+| `{ok: false, error}` mentioning permission / network | surface verbatim |
+
+## Absolute rules
+
+- Read-only. Never mutate local kanban.json or `.claude/kanban-agent.json`
+  from this command. Cache TTL is unaffected — this isn't counted as
+  a "successful pull" for passive-sync purposes (use
+  `/kanban:pull-board-config` if you actually want to refresh the cache).
+- Never echo tokens or any credentials field.

--- a/plugins/kanban/commands/whoami.md
+++ b/plugins/kanban/commands/whoami.md
@@ -84,6 +84,22 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py mcp-conflict-scan \
 The `Jira MCP` row reports `✓ none` (empty conflicts) or
 `⚠ N detected: <comma-list>` (so the user knows what to scope away).
 
+Read the board-config cache state (no Jira API call):
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-board-config-cache \
+  --kanban-path '<kanban.json path>'
+```
+
+Returns `{cachedAt, cacheAgeHours, stale, ttlHours, projectKey, propertyKey}`.
+The `Board config` row maps from these:
+
+| Response | Board config row reads |
+|---|---|
+| `cachedAt: null` | `Jira project <projectKey> properties.kanban-config (never synced — run /kanban:pull-board-config)` |
+| `cachedAt` set, `stale: false` | `Jira project <projectKey> properties.kanban-config (synced <cacheAgeHours>h ago, fresh)` |
+| `cachedAt` set, `stale: true` | `Jira project <projectKey> properties.kanban-config (synced <cacheAgeHours>h ago, ⚠ stale — auto-syncs on next /kanban:sync)` |
+
 Render:
 
 ```
@@ -98,6 +114,7 @@ AP (this repo):   <ap or "(unset — run /kanban:assign-ap <name>)">
 AP (registered):  <live comma-list or "(empty — run /kanban:register-ap <name>)" or "<list> (offline — local hint)">
 Token:            <validity row>
 Transitions:      <count> defined  (e.g. TODO→..., DOING→..., ...)
+Board config:     <cache row>
 Jira MCP:         <conflict row>
 ```
 

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -293,7 +293,7 @@ class JiraDriver:
                 status = self._canonical_to_status(filter.column)
                 if status:
                     clauses.append(f'status = "{status}"')
-                elif self.partial and filter.column in self.label_fallback:
+                elif getattr(self, "partial", False) and filter.column in getattr(self, "label_fallback", {}):
                     clauses.append(f'labels = "{self.label_fallback[filter.column]}"')
             if filter.assignee:
                 clauses.append(f'assignee = "{filter.assignee}"')

--- a/plugins/kanban/lib/board_config.py
+++ b/plugins/kanban/lib/board_config.py
@@ -132,6 +132,14 @@ def pull(client: Any, project_key: str) -> dict[str, Any]:
             )
             err.not_found = True  # type: ignore[attr-defined]
             raise err from e
+        if e.status_code == 403:
+            raise BoardConfigError(
+                f"permission denied reading project property "
+                f"{PROPERTY_KEY!r} on {project_key!r}: agent's Jira "
+                f"account doesn't have permission to read project "
+                f"entity properties on this project. Ask a project "
+                f"admin to grant project-read access."
+            ) from e
         raise BoardConfigError(
             f"jira: {e.detail or e} (status={e.status_code})"
         ) from e

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -1011,6 +1011,103 @@ def cmd_push_board_config(args: argparse.Namespace) -> int:
     return 0
 
 
+def _apply_pulled_board_config(
+    data: dict[str, Any], pulled: dict[str, Any]
+) -> dict[str, Any]:
+    """In-place merge: overwrite `data['backend']['jira']` with the
+    pulled board config while preserving per-machine fields
+    (`agentAccountId`, `ap.registered`). Used by both the explicit
+    `pull-board-config` subcommand and the passive-sync entry point.
+    Returns the same `data` dict (mutated)."""
+    backend = data.setdefault("backend", {"driver": "jira"})
+    existing_cfg = dict(backend.get("jira") or {})
+
+    new_cfg = dict(pulled)
+    if existing_cfg.get("agentAccountId"):
+        new_cfg["agentAccountId"] = existing_cfg["agentAccountId"]
+    # Preserve the local AP roster on `ap.registered` (the on-Jira
+    # config carries fieldId/fieldName but not the registered list).
+    if (existing_cfg.get("ap") or {}).get("registered"):
+        new_cfg.setdefault("ap", {}).setdefault("registered", [])
+        new_cfg["ap"]["registered"] = list(existing_cfg["ap"]["registered"])
+        # If pulled `ap` was missing fieldId, fall back to existing.
+        if not new_cfg["ap"].get("fieldId") and (existing_cfg.get("ap") or {}).get("fieldId"):
+            new_cfg["ap"]["fieldId"] = existing_cfg["ap"]["fieldId"]
+            new_cfg["ap"]["fieldName"] = existing_cfg["ap"].get("fieldName", "")
+
+    backend["driver"] = "jira"
+    backend["jira"] = new_cfg
+    return data
+
+
+def _maybe_passive_sync_board_config(
+    p: Path, data: dict[str, Any]
+) -> dict[str, Any]:
+    """If the local board-config cache is stale, attempt a pull from
+    Jira and persist the result. Best-effort — failures print a stderr
+    warning and return the unchanged data so the caller can continue
+    with the (possibly stale) cache.
+
+    Skipped silently when:
+    - backend.driver != "jira" (no Jira to sync against)
+    - cache is fresh (within CACHE_TTL_HOURS of the last pull)
+    - no projectKey configured yet
+    - Jira credentials missing (no client to call)
+    - the property doesn't exist on Jira yet (404 — common when no one
+      has pushed yet; not a warning condition)
+
+    Returns the (possibly mutated) `data` dict.
+    """
+    from lib import board_config as _bc
+
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        return data
+    if not _bc.is_cache_stale(p.parent):
+        return data
+
+    cfg = backend.get("jira") or {}
+    project_key = cfg.get("projectKey")
+    if not project_key:
+        return data
+
+    client = _client_from_env_or_none()
+    if client is None:
+        # No credentials — silently skip. The user will see this when
+        # they run /kanban:whoami (token row reads "missing"); no need
+        # to nag here.
+        return data
+
+    try:
+        remote = _bc.pull(client, project_key)
+    except _bc.BoardConfigError as e:
+        if not getattr(e, "not_found", False):
+            # Permission denied / network / malformed — surface to
+            # stderr but don't fail the caller. Stale cache is fine.
+            sys.stderr.write(
+                f"warning: passive board-config sync failed "
+                f"({e}); continuing with local cache\n"
+            )
+        return data
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"warning: passive board-config sync failed "
+            f"({type(e).__name__}: {e}); continuing with local cache\n"
+        )
+        return data
+
+    _apply_pulled_board_config(data, remote)
+    try:
+        kanban_io.save(p, data)
+        _bc.mark_synced(p.parent)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"warning: board config pulled but persist failed "
+            f"({type(e).__name__}: {e})\n"
+        )
+    return data
+
+
 def cmd_pull_board_config(args: argparse.Namespace) -> int:
     """Pull the Jira project's `kanban-config` property and overwrite
     the local kanban.json's `backend.jira` block with it. Records the
@@ -1044,23 +1141,7 @@ def cmd_pull_board_config(args: argparse.Namespace) -> int:
     except _bc.BoardConfigError as e:
         return _fail(str(e), notFound=getattr(e, "not_found", False))
 
-    # Merge: the pulled config is authoritative for shared fields.
-    # Preserve the per-machine pieces that Jira-side doesn't carry.
-    new_cfg = dict(remote)
-    if existing_cfg.get("agentAccountId"):
-        new_cfg["agentAccountId"] = existing_cfg["agentAccountId"]
-    # Preserve the local AP roster on `ap.registered` (the on-Jira
-    # config carries fieldId/fieldName but not the registered list).
-    if (existing_cfg.get("ap") or {}).get("registered"):
-        new_cfg.setdefault("ap", {}).setdefault("registered", [])
-        new_cfg["ap"]["registered"] = list(existing_cfg["ap"]["registered"])
-        # If pulled `ap` was missing fieldId, fall back to existing.
-        if not new_cfg["ap"].get("fieldId") and (existing_cfg.get("ap") or {}).get("fieldId"):
-            new_cfg["ap"]["fieldId"] = existing_cfg["ap"]["fieldId"]
-            new_cfg["ap"]["fieldName"] = existing_cfg["ap"].get("fieldName", "")
-
-    backend["driver"] = "jira"
-    backend["jira"] = new_cfg
+    _apply_pulled_board_config(data, remote)
     kanban_io.save(p, data)
     _bc.mark_synced(p.parent)
 
@@ -1068,7 +1149,45 @@ def cmd_pull_board_config(args: argparse.Namespace) -> int:
         "ok": True,
         "projectKey": project_key,
         "propertyKey": _bc.PROPERTY_KEY,
-        "transitionsCount": len(new_cfg.get("transitions") or {}),
+        "transitionsCount": len(
+            ((data.get("backend") or {}).get("jira") or {}).get("transitions") or {}
+        ),
+    })
+    return 0
+
+
+def cmd_read_board_config_cache(args: argparse.Namespace) -> int:
+    """Tiny read-only helper — returns the local cache state for the
+    board-config property without making any Jira API call. Used by
+    /kanban:whoami to render a "Board config" row showing where the
+    config lives + how stale this machine's cache is.
+
+    Output: {ok, projectKey, propertyKey, cachedAt, cacheAgeHours,
+             stale}.
+    """
+    from lib import board_config as _bc
+
+    p = Path(args.kanban_path)
+    if not p.exists():
+        return _fail(f"kanban.json not found at {p}")
+    data = kanban_io.load(p)
+    backend = data.get("backend") or {}
+    if backend.get("driver") != "jira":
+        return _fail("backend.driver must be 'jira'")
+    cfg = backend.get("jira") or {}
+    project_key = cfg.get("projectKey") or ""
+
+    age = _bc.cache_age_hours(p.parent)
+    cached_at = _bc._read_cached_at(p.parent)  # internal; safe in same package
+
+    _emit({
+        "ok": True,
+        "projectKey": project_key,
+        "propertyKey": _bc.PROPERTY_KEY,
+        "cachedAt": cached_at,
+        "cacheAgeHours": (round(age, 2) if age is not None else None),
+        "stale": _bc.is_cache_stale(p.parent),
+        "ttlHours": _bc.CACHE_TTL_HOURS,
     })
     return 0
 
@@ -2418,7 +2537,13 @@ def _detect_unanswered_questions(
 
 
 def cmd_sync_summary(args: argparse.Namespace) -> int:
-    """Render an open-cards summary for the current repo's AP."""
+    """Render an open-cards summary for the current repo's AP.
+
+    Also the canonical entry point for passive board-config sync —
+    `/kanban:sync` runs at SessionStart, so we opportunistically check
+    the cache TTL and refresh from the Jira project property when
+    stale (>= 8h). Best-effort; failures don't block the summary.
+    """
     p = Path(args.kanban_path)
     if not p.exists():
         _fail(f"kanban.json not found at {p}")
@@ -2428,6 +2553,12 @@ def cmd_sync_summary(args: argparse.Namespace) -> int:
     if backend.get("driver") != "jira":
         _emit({"summary": "", "skip": "not in jira mode"})
         return 0
+
+    # Passive board-config sync — refresh local cache from Jira if
+    # stale. Returns the (possibly updated) data so subsequent driver
+    # construction sees the fresh transitions/conventions/etc.
+    data = _maybe_passive_sync_board_config(p, data)
+    backend = data.get("backend") or {}
 
     repo_ap = _read_repo_ap(p)
     cfg = backend.get("jira") or {}
@@ -3363,6 +3494,15 @@ def build_parser() -> argparse.ArgumentParser:
              "pull when the local cache is empty.",
     )
     s.set_defaults(func=cmd_pull_board_config)
+
+    s = sub.add_parser(
+        "read-board-config-cache",
+        help="Read-only metadata about the local board-config cache "
+             "(projectKey, cachedAt, cacheAgeHours, stale). No Jira API "
+             "call. Used by /kanban:whoami for the cache-age row.",
+    )
+    s.add_argument("--kanban-path", required=True)
+    s.set_defaults(func=cmd_read_board_config_cache)
 
     s = sub.add_parser(
         "read-board-config",

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
+for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31; do  # 8-28: code-AP / screens (#6) / blocked-by (#8) / conventions (#10) / mentions+reply / sync stale+Q / resolve-doc-link / import (#16+#18) / locale (#17) / self-approve+guardrail (#19+#20) / reconcile (#21) / locale+JQL+ADF (#17 reopen +#26 +#27) / health-oracle (#31) / create_task fixup (#35) / set-conventions append (#36) / list-doing (#33) / secret-safe token capture (session-reported) / precheck recent-comments (#42) / clickable URL link mark (session-reported) / REVIEW flavors (#45) / DONE→APPROVED rename (#48)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase18.py
+++ b/plugins/kanban/scripts/test_phase18.py
@@ -339,6 +339,12 @@ def test_sync_summary_appends_drift_reminder_when_present():
 
     with tempfile.TemporaryDirectory() as td:
         kp = _seed_kanban(td, with_agent_account=False)
+        # Mark board-config cache as freshly synced so cmd_sync_summary's
+        # passive-sync entry (added in 0.3.26) skips and the queue we
+        # set up below is consumed exactly by the reconcile path.
+        from datetime import datetime, timezone
+        from lib import board_config as _bc
+        _bc.mark_synced(pathlib.Path(td), datetime.now(timezone.utc))
         import drivers as _drv_mod
         d_orig = _drv_mod.get_driver
         _drv_mod.get_driver = lambda data, root: _StubDrv()
@@ -371,6 +377,9 @@ def test_sync_summary_omits_drift_reminder_when_clean():
 
     with tempfile.TemporaryDirectory() as td:
         kp = _seed_kanban(td, with_agent_account=False)
+        from datetime import datetime, timezone
+        from lib import board_config as _bc
+        _bc.mark_synced(pathlib.Path(td), datetime.now(timezone.utc))
         import drivers as _drv_mod
         d_orig = _drv_mod.get_driver
         _drv_mod.get_driver = lambda data, root: _StubDrv()
@@ -403,6 +412,9 @@ def test_sync_summary_drift_detection_silent_on_failure():
 
     with tempfile.TemporaryDirectory() as td:
         kp = _seed_kanban(td, with_agent_account=False)
+        from datetime import datetime, timezone
+        from lib import board_config as _bc
+        _bc.mark_synced(pathlib.Path(td), datetime.now(timezone.utc))
         import drivers as _drv_mod
         d_orig = _drv_mod.get_driver
         _drv_mod.get_driver = lambda data, root: _StubDrv()

--- a/plugins/kanban/scripts/test_phase31.py
+++ b/plugins/kanban/scripts/test_phase31.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Phase 31 regression checks for kanban v0.3.26 — board-config slash
+commands + passive sync (PR 2 of 3).
+
+Builds on PR 1 (phase 30, helper layer). PR 2 wires:
+- `_maybe_passive_sync_board_config` into `cmd_sync_summary` so
+  SessionStart-triggered `/kanban:sync` opportunistically refreshes
+  the cache when stale (≥ 8h since last pull)
+- `cmd_read_board_config_cache` for `/kanban:whoami` to render a
+  cache-age row without making any Jira call
+- Three slash commands: `push-board-config`, `pull-board-config`,
+  `show-board-config` (specs only — already exercised at the helper
+  layer in phase 30)
+
+Cases:
+  (a) `_maybe_passive_sync_board_config` no-ops on local-mode
+      kanban.json (passive sync is jira-only)
+  (b) Fresh cache (< 8h) — no Jira API call, no warnings, no kanban.json
+      mutation
+  (c) Stale cache + successful pull — overwrites local backend.jira
+      with the pulled config; preserves per-machine fields;
+      records cachedAt
+  (d) Stale cache + 404 (no config on Jira yet) — silent skip (no
+      warning to stderr; expected condition for fresh boards)
+  (e) Stale cache + 403 (permission denied) — warning to stderr; no
+      mutation; caller continues with stale cache
+  (f) Stale cache + missing credentials — silent skip (whoami's token
+      row already surfaces this; passive sync stays out of the way)
+  (g) `cmd_read_board_config_cache` — never-synced state
+  (h) `cmd_read_board_config_cache` — synced state with fresh cache
+  (i) `cmd_read_board_config_cache` — synced state past TTL → stale=true
+  (j) `cmd_sync_summary` end-to-end with stale cache: pulls fresh
+      config + then renders summary using the new transitions
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib import board_config as _bc  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    return rc, out, err
+
+
+def _mock_client(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return JiraClient("https://x", "a@b", "tok", transport=t,
+                      sleep=lambda _: None)
+
+
+def _seed_jira_kanban(td: pathlib.Path, *, project_key="AGENT") -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": {
+            "boardUrl": f"https://x/jira/projects/{project_key}/boards/1",
+            "boardId": 1, "projectKey": project_key,
+            "agentAccountId": "5e-bot",
+            "transitions": {
+                "TODO": {"status": "To Do"},
+                "DOING": {"status": "In Progress"},
+                "APPROVED": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent",
+                   "registered": ["agent-fin"]},
+        }},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "APPROVED", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _seed_local_kanban(td: pathlib.Path) -> pathlib.Path:
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "local"},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "APPROVED", "BLOCKED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+def _patch_client(client):
+    orig_full = _jira_setup._client_from_env
+    orig_opt = _jira_setup._client_from_env_or_none
+    _jira_setup._client_from_env = lambda: client
+    _jira_setup._client_from_env_or_none = lambda: client
+    return (orig_full, orig_opt)
+
+
+def _restore_client(originals):
+    _jira_setup._client_from_env, _jira_setup._client_from_env_or_none = originals
+
+
+# --- (a) local-mode no-op -----------------------------------------------
+
+
+def test_passive_sync_local_mode_noop():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_local_kanban(td)
+        original = kp.read_bytes()
+
+        from lib import kanban_io
+        data = kanban_io.load(kp)
+        out = _jira_setup._maybe_passive_sync_board_config(kp, data)
+        assert out is data  # same dict, no rewrite
+        # Should NOT have created .claude/kanban-agent.json
+        assert not (td / ".claude" / "kanban-agent.json").exists()
+        # File untouched
+        assert kp.read_bytes() == original
+
+
+# --- (b) fresh cache no-op ----------------------------------------------
+
+
+def test_passive_sync_fresh_cache_noop():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        # Mark synced 1h ago — fresh
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=1))
+        original = kp.read_bytes()
+
+        # No client should be needed because is_cache_stale returns False
+        # before reaching _client_from_env_or_none. Verify by patching
+        # the client to one that errors if called.
+        called = []
+        class _ExplodingClient:
+            def get_project_property(self, *a, **kw):
+                called.append("yes")
+                raise AssertionError("should not have been called")
+
+        orig = _patch_client(_ExplodingClient())
+        try:
+            from lib import kanban_io
+            data = kanban_io.load(kp)
+            _jira_setup._maybe_passive_sync_board_config(kp, data)
+        finally:
+            _restore_client(orig)
+
+        assert called == []
+        assert kp.read_bytes() == original
+
+
+# --- (c) stale cache + successful pull ----------------------------------
+
+
+def test_passive_sync_stale_pulls_and_overwrites():
+    remote = {
+        "key": "kanban-config",
+        "value": {
+            "boardId": 1, "projectKey": "AGENT",
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "transitions": {
+                "TODO": {"status": "Backlog"},  # <- changed!
+                "DOING": {"status": "In Progress"},
+                "APPROVED": {"status": "Done"},
+                "REVIEW": {"status": "REVIEW"},  # <- new
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent"},
+            "conventions": {"notes": ["new rule"], "blockedRequiresLink": True},
+        },
+    }
+    queue = [_Response(200, json.dumps(remote).encode(), {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        # Mark synced 10h ago — stale
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=10))
+
+        orig = _patch_client(client)
+        try:
+            from lib import kanban_io
+            data = kanban_io.load(kp)
+            out = _jira_setup._maybe_passive_sync_board_config(kp, data)
+        finally:
+            _restore_client(orig)
+
+        # New transitions reflected in data
+        cfg = (out.get("backend") or {}).get("jira") or {}
+        assert cfg["transitions"]["TODO"]["status"] == "Backlog"
+        assert "REVIEW" in cfg["transitions"]
+        # Per-machine preserved
+        assert cfg["agentAccountId"] == "5e-bot"
+        assert cfg["ap"]["registered"] == ["agent-fin"]
+        # On-disk
+        on_disk = json.loads(kp.read_text())
+        assert on_disk["backend"]["jira"]["transitions"]["TODO"]["status"] == "Backlog"
+        # cachedAt updated
+        agent_data = json.loads((td / ".claude" / "kanban-agent.json").read_text())
+        assert "boardConfigCachedAt" in agent_data
+        # Recent (within last minute)
+        recorded = datetime.fromisoformat(agent_data["boardConfigCachedAt"])
+        if recorded.tzinfo is None:
+            recorded = recorded.replace(tzinfo=timezone.utc)
+        assert (datetime.now(timezone.utc) - recorded).total_seconds() < 60
+
+
+# --- (d) stale + 404 silent skip ---------------------------------------
+
+
+def test_passive_sync_404_silent_skip():
+    """No `kanban-config` property on Jira yet — that's the common
+    state for fresh projects. Don't nag the user."""
+    queue = [_Response(404, b'{"errorMessages":["nope"]}', {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=10))
+        original = kp.read_bytes()
+
+        orig = _patch_client(client)
+        try:
+            from io import StringIO
+            old_err = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                from lib import kanban_io
+                data = kanban_io.load(kp)
+                _jira_setup._maybe_passive_sync_board_config(kp, data)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_err
+        finally:
+            _restore_client(orig)
+
+        # 404 is silent — no warning
+        assert err == "", err
+        # No mutation
+        assert kp.read_bytes() == original
+
+
+# --- (e) stale + 403 → warn but continue --------------------------------
+
+
+def test_passive_sync_403_warns_continues():
+    queue = [_Response(403, b'{"errorMessages":["denied"]}', {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=10))
+        original = kp.read_bytes()
+
+        orig = _patch_client(client)
+        try:
+            from io import StringIO
+            old_err = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                from lib import kanban_io
+                data = kanban_io.load(kp)
+                _jira_setup._maybe_passive_sync_board_config(kp, data)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_err
+        finally:
+            _restore_client(orig)
+
+        # Warning emitted
+        assert "passive board-config sync failed" in err
+        assert "permission denied" in err.lower()
+        # No mutation
+        assert kp.read_bytes() == original
+
+
+# --- (f) stale + no creds → silent ---------------------------------------
+
+
+def test_passive_sync_no_credentials_silent():
+    """Whoami's token row already surfaces missing creds; passive sync
+    stays out of the way."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=10))
+        original = kp.read_bytes()
+
+        # Patch client_from_env_or_none → None (the normal "no creds" path)
+        orig_opt = _jira_setup._client_from_env_or_none
+        _jira_setup._client_from_env_or_none = lambda: None
+        try:
+            from io import StringIO
+            old_err = sys.stderr
+            sys.stderr = StringIO()
+            try:
+                from lib import kanban_io
+                data = kanban_io.load(kp)
+                _jira_setup._maybe_passive_sync_board_config(kp, data)
+                err = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_err
+        finally:
+            _jira_setup._client_from_env_or_none = orig_opt
+
+        assert err == "", err  # no nag
+        assert kp.read_bytes() == original
+
+
+# --- (g) (h) (i) read-board-config-cache states -------------------------
+
+
+def test_read_cache_never_synced():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+
+        class A: kanban_path = str(kp)
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config_cache, A())
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["projectKey"] == "AGENT"
+        assert j["propertyKey"] == "kanban-config"
+        assert j["cachedAt"] is None
+        assert j["cacheAgeHours"] is None
+        assert j["stale"] is True
+        assert j["ttlHours"] == 8
+
+
+def test_read_cache_fresh():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=2))
+
+        class A: kanban_path = str(kp)
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config_cache, A())
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["ok"] is True
+        assert j["cachedAt"] is not None
+        assert 1.9 <= j["cacheAgeHours"] <= 2.1
+        assert j["stale"] is False
+
+
+def test_read_cache_stale():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=12))
+
+        class A: kanban_path = str(kp)
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config_cache, A())
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["stale"] is True
+        assert j["cacheAgeHours"] >= 11.9
+
+
+# --- (j) cmd_sync_summary integration with passive sync -----------------
+
+
+def test_sync_summary_pulls_when_stale_then_renders():
+    """End-to-end: cmd_sync_summary on a stale kanban.json triggers
+    a board-config pull; subsequent driver construction uses the
+    fresh transitions; the summary still renders normally."""
+    remote = {
+        "key": "kanban-config",
+        "value": {
+            "boardId": 1, "projectKey": "AGENT",
+            "boardUrl": "https://x/jira/projects/AGENT/boards/1",
+            "transitions": {
+                "TODO": {"status": "Backlog"},
+                "DOING": {"status": "In Progress"},
+                "BLOCKED": {"status": "In Progress",
+                            "addLabels": ["kanban:blocked"]},
+                "REVIEW": {"status": "REVIEW"},
+                "APPROVED": {"status": "Done"},
+            },
+            "ap": {"fieldId": "customfield_10042",
+                   "fieldName": "Claude Agent"},
+        },
+    }
+    queue = [
+        # (1) passive-sync pull
+        _Response(200, json.dumps(remote).encode(), {}),
+        # (2..5) driver.list_tasks for each open column
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+        # (6) reconcile query 1 (my-AP unmapped)
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+        # (7) reconcile query 2 (missing-AP)
+        _Response(200, json.dumps({"issues": []}).encode(), {}),
+    ]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        # Seed repo AP so list_tasks adds the AP filter
+        (td / ".claude").mkdir()
+        (td / ".claude" / "kanban-agent.json").write_text(
+            json.dumps({"ap": "agent-fin"})
+        )
+        # Stale cache → triggers passive sync
+        _bc.mark_synced(td, datetime.now(timezone.utc) - timedelta(hours=10))
+
+        orig = _patch_client(client)
+        try:
+            class A: kanban_path = str(kp)
+            rc, out, err = _capture(_jira_setup.cmd_sync_summary, A())
+        finally:
+            _restore_client(orig)
+
+        assert rc == 0, (out, err)
+        # The first call must be the board-config property GET
+        assert "/properties/kanban-config" in calls[0]["url"]
+        # Pulled config persisted
+        on_disk = json.loads(kp.read_text())
+        assert on_disk["backend"]["jira"]["transitions"]["TODO"]["status"] == "Backlog"
+
+
+def main() -> int:
+    cases = [
+        ("passive_sync_local_mode_noop",
+         test_passive_sync_local_mode_noop),
+        ("passive_sync_fresh_cache_noop",
+         test_passive_sync_fresh_cache_noop),
+        ("passive_sync_stale_pulls_and_overwrites",
+         test_passive_sync_stale_pulls_and_overwrites),
+        ("passive_sync_404_silent_skip",
+         test_passive_sync_404_silent_skip),
+        ("passive_sync_403_warns_continues",
+         test_passive_sync_403_warns_continues),
+        ("passive_sync_no_credentials_silent",
+         test_passive_sync_no_credentials_silent),
+        ("read_cache_never_synced", test_read_cache_never_synced),
+        ("read_cache_fresh", test_read_cache_fresh),
+        ("read_cache_stale", test_read_cache_stale),
+        ("sync_summary_pulls_when_stale_then_renders",
+         test_sync_summary_pulls_when_stale_then_renders),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase31: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase31: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

**PR 2 of 3** in the showjira-code → board-config replacement. Wires the helpers from PR 1 (#52, 0.3.25) into user-facing flows. Multi-machine teams now stay in sync without manual paste.

| PR | What lands |
|---|---|
| #52 (0.3.25) ✓ | helpers + tests only |
| **#53 (this PR)** | slash commands + passive sync + whoami extension |
| PR 3 | remove `showjira-code` / `import-jira-code` / `initjira-by-code`; ship migration command; docs sweep |

## What's new

### Three new slash commands

- **`/kanban:push-board-config`** — admin uploads this repo's `backend.jira` block to Jira project property `kanban-config`. Strips per-machine fields (`agentAccountId`, `ap.registered`) before pushing. Requires Jira **project-admin** role; non-admin pushes get a clear permission message.
- **`/kanban:pull-board-config [--project-key K]`** — anyone pulls latest from Jira. Overwrites local `backend.jira`; preserves per-machine fields; records `cachedAt` (resets the 8h TTL clock).
- **`/kanban:show-board-config`** — read-only inspection of the Jira-side payload. Doesn't touch local state or cache TTL.

### Passive sync at SessionStart

When the local board-config cache is older than `CACHE_TTL_HOURS` (8h), `/kanban:sync` opportunistically pulls before rendering open-cards. The pull result feeds the same session — fresh transitions / conventions are honored immediately.

Best-effort handling:
- **404** (no config on Jira yet) → silent skip; common during early adoption
- **403** (permission denied) → stderr warning; continue with stale cache
- **Missing credentials** → silent skip (whoami's token row already surfaces this)
- **Any other failure** → stderr warning; continue

### `/kanban:whoami` gains a `Board config:` row

```
Board config:  Jira project AGENT properties.kanban-config
               (synced 3h ago, fresh)
```

Or for never-synced state:

```
Board config:  Jira project AGENT properties.kanban-config
               (never synced — run /kanban:pull-board-config)
```

Backed by a tiny new `read-board-config-cache` helper subcommand that returns metadata only — no Jira API call.

### Drive-by fix

Latent bug in `JiraDriver.list_tasks` that referenced uninitialised `self.partial` / `self.label_fallback` (legacy v0.2 fields removed in `migrate_legacy`). Triggered when iterating columns whose canonical → Jira mapping was undefined. Defensive `getattr(..., False)` / `getattr(..., {})` lets the lookup fall through cleanly.

Plus `lib/board_config.pull` gains a 403 path for symmetry with `push`, distinct error message about project-read access.

## Coexistence

`/kanban:showjira-code`, `/kanban:import-jira-code`, `/kanban:initjira-by-code` continue to work unchanged in 0.3.26. PR 3 removes them along with their helper subcommands.

## Files

- **`plugins/kanban/commands/push-board-config.md`** (new)
- **`plugins/kanban/commands/pull-board-config.md`** (new)
- **`plugins/kanban/commands/show-board-config.md`** (new)
- **`plugins/kanban/commands/whoami.md`** — Board config row + helper call
- **`plugins/kanban/scripts/jira_setup.py`** — `_apply_pulled_board_config` (shared merge), `_maybe_passive_sync_board_config`, `cmd_read_board_config_cache`, `cmd_sync_summary` wires passive sync in, argparse for `read-board-config-cache`
- **`plugins/kanban/lib/board_config.py`** — `pull` gains 403 handling
- **`plugins/kanban/drivers/jira.py`** — defensive getattr on legacy `partial` / `label_fallback`
- **`plugins/kanban/scripts/test_phase31.py`** (new) — 10 cases
- **`plugins/kanban/scripts/test_phase18.py`** — 3 sync_summary tests pre-mark cache fresh
- Version bump 0.3.25 → 0.3.26, CHANGELOG entry

## Test plan

- [x] `bash plugins/kanban/scripts/test_all.sh` — all 31 phases green
- [x] **Phase 31 (10 cases)**: passive sync local-mode no-op; fresh-cache no-op (no Jira call); stale + pull happy (overwrites + preserves + records cachedAt); stale + 404 silent; stale + 403 warns + continues; stale + no-creds silent; `read-board-config-cache` never-synced / fresh / stale states; `cmd_sync_summary` end-to-end with stale cache (pull then summary)
- [x] Phase 18 sync_summary tests pre-mark cache fresh so passive sync doesn't consume their reconcile mock queue
- [ ] Manual: in repo with `agentAccountId` and `ap.registered` populated, run `/kanban:push-board-config`, verify Jira project property carries the stripped payload
- [ ] Manual: from a stale-cache repo (mark cache 10h old), run `/kanban:sync`, verify the passive sync pulls + applies the latest config and records `cachedAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)