### PR TITLE
feat(kanban): 0.3.29 — versioned board config (#57)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.27",
+      "version": "0.3.29",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,48 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-16 (kanban versioned board config — #57)
+
+### Added
+- **kanban 0.3.29** — `/kanban:push-board-config` and
+  `/kanban:pull-board-config` now carry a `_meta` block (version,
+  content hash, pushedAt, pushedByAccountId) on every push of the
+  `kanban-config` Jira project property. Closes the silent-clobber
+  gap exposed by `0.3.27`: two admins pushing without an intervening
+  pull no longer overwrite each other without warning.
+
+  **Behavior:**
+  - Push reads the current remote `_meta` first. The new payload
+    bumps `version` by 1 and stores the canonical sha256 of the
+    just-pushed content (canonicalization sorts keys, tight
+    separators, `_meta` itself excluded so the hash describes content).
+  - Push refuses by default when the remote `_meta.hash` doesn't
+    match what this machine last pulled or pushed (auto-`--if-match`).
+    Resolve by `/kanban:pull-board-config`, reconcile, push again.
+    `--force` bypasses the fence for intentional clobbers.
+  - Pull stores `_meta` into local `backend.jira._meta`, so the next
+    push on this machine can fence correctly without an explicit
+    flag. A successful push also writes the freshly-minted `_meta`
+    back into local for the same reason.
+  - `/kanban:show-board-config` with `--kanban-path` now emits a
+    `diff` block identifying one of four sync states: `in-sync`,
+    `remote-ahead`, `local-edits`, `diverged` (or `unknown` when
+    local has no cached `_meta` yet).
+
+  **Schema**: `backend.jira._meta` declared as optional (writers
+  maintain it; users shouldn't hand-edit). Old payloads without
+  `_meta` migrate automatically — pull treats them as
+  `{version: 0, hash: null}` and the next push initializes `v1`.
+
+  **Out of scope**: real ETag concurrency at the Atlassian API level
+  (they don't offer it on entity properties); per-field version
+  history / rollback.
+
+  Tests: `scripts/test_phase34.py` adds 15 cases covering canonical
+  hash stability, first-push init, version bump, `--if-match` fence
+  (refuse + force), `cmd_push` auto-fill, `_meta` round-trip through
+  pull/push, and all four diff states.
+
 ## 2026-05-08 (kanban paste-flow removal + initjira auto-detect — PR 3 of 3)
 
 ### Removed (BREAKING for ≤ 0.3.26 users mid-paste)

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/commands/pull-board-config.md
+++ b/plugins/kanban/commands/pull-board-config.md
@@ -50,6 +50,10 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py pull-board-config \
 - `boardUrl`, `boardId`, `projectKey`
 - `ap.fieldId`, `ap.fieldName`
 - `conventions`
+- `_meta` (version / hash / pushedAt / pushedByAccountId — #57). This
+  becomes the auto-`--if-match` value for the next
+  `/kanban:push-board-config`, so the team-shared "I expect remote to
+  still be at this hash" fence works without manual book-keeping.
 
 **Preserved** (per-machine state):
 - `agentAccountId` — your local Atlassian account binding

--- a/plugins/kanban/commands/push-board-config.md
+++ b/plugins/kanban/commands/push-board-config.md
@@ -34,22 +34,37 @@ admin role on this project — Jira UI: Project Settings → Permissions
   `/kanban:initjira` first.
 - Confirm `backend.driver == "jira"` and `backend.jira.transitions`
   is non-empty. The push payload comes from those local fields.
-- Warn the user this overwrites whatever's currently on the Jira
-  project property (last-writer-wins; Atlassian doesn't do ETag
-  versioning on properties). For routine pushes from a single source
-  repo this is the expected flow; for "sync from teammate" cases
-  consider `/kanban:pull-board-config` instead.
+- Each push attaches a `_meta` block (version, content hash, pushedAt,
+  pushedByAccountId — #57) so future pushes can detect "remote moved
+  since I pulled" without Atlassian-side ETag support. By default the
+  push is **fenced**: it refuses when remote's content hash doesn't
+  match the hash this machine last pulled or pushed. Pass `--force`
+  to bypass.
 
 ## 1. Push
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py push-board-config \
-  --kanban-path '<kanban.json path>'
+  --kanban-path '<kanban.json path>' \
+  [--force]
 ```
+
+Behavior:
+- The helper auto-fills `--if-match` from the local cached
+  `_meta.hash` (set by the last successful pull or push). First push
+  on a project with no remote `_meta` yet has no fence — it just
+  initializes `version: 1`.
+- If a teammate pushed since your last pull, the push is refused and
+  the response carries the remote's current `_meta` so you can see
+  who pushed, when, and at what hash. Resolve by running
+  `/kanban:pull-board-config`, reconciling any local edits, then
+  pushing again.
+- `--force` skips the fence — use only when intentionally clobbering.
 
 | Response | Action |
 |---|---|
-| `{ok: true, projectKey, propertyKey, fieldsPushed}` | print `✓ Pushed <fieldsPushed.length> fields to Jira project <projectKey> properties.<propertyKey>`; mention all teammates' next `/kanban:sync` will pick this up |
+| `{ok: true, projectKey, propertyKey, fieldsPushed, meta}` | print `✓ Pushed <fieldsPushed.length> fields to Jira project <projectKey> properties.<propertyKey> (v<meta.version>)`; mention all teammates' next `/kanban:sync` will pick this up |
+| `{ok: false, error, ifMatchMismatch: true, remoteMeta, expectedHash}` | surface verbatim; recommend `/kanban:pull-board-config` to fetch the new version, reconcile any local edits, then re-push |
 | `{ok: false, error}` mentioning `permission denied` | surface verbatim; explain admin role is required |
 | `{ok: false, error}` mentioning network / 4xx / 5xx | surface verbatim |
 
@@ -59,9 +74,11 @@ The agent strips per-machine fields before pushing:
 - `agentAccountId` — per-Atlassian-account, not per-board
 - `ap.registered` — local hint for the AP roster; Jira itself is the
   source of truth (read live via `/kanban:live-list-aps`)
+- `_meta` from local — push always regenerates `_meta` from the
+  freshly-fetched remote version + the new content hash.
 
 Pushed fields: `boardUrl`, `boardId`, `projectKey`, `transitions`,
-`ap.fieldId`, `ap.fieldName`, `conventions`.
+`ap.fieldId`, `ap.fieldName`, `conventions`, plus a fresh `_meta`.
 
 ## Absolute rules
 
@@ -70,8 +87,11 @@ Pushed fields: `boardUrl`, `boardId`, `projectKey`, `transitions`,
   clobbering theirs.
 - Never mock up the config — only push the actual `backend.jira`
   block from this repo's `kanban.json`.
-- Never write to `kanban.json` from this command (push is a one-way
-  upload to Jira; doesn't mutate the local cache except marking it
-  freshly synced).
+- The command writes the just-pushed `_meta` back into local
+  `kanban.json#backend.jira._meta` so the next push on this machine
+  can auto-fill `--if-match` without an intervening pull. Nothing
+  else in the local cache is mutated.
 - If push fails on permission, do NOT retry with a different account
   or workaround — the right move is to ask a project admin.
+- If push fails with `ifMatchMismatch: true`, do NOT auto-retry with
+  `--force` — that's the clobber path. Pull first, reconcile, push.

--- a/plugins/kanban/commands/show-board-config.md
+++ b/plugins/kanban/commands/show-board-config.md
@@ -40,9 +40,35 @@ python3 ${CLAUDE_PLUGIN_ROOT}/scripts/jira_setup.py read-board-config \
 
 | Response | Action |
 |---|---|
-| `{ok: true, projectKey, propertyKey, config}` | pretty-print the `config` block (transitions, ap, conventions, etc.). Optionally diff against the local `backend.jira` from `kanban.json` and call out any drifted fields. |
+| `{ok: true, projectKey, propertyKey, config, diff}` | pretty-print the `config` block (transitions, ap, conventions, etc.). When `diff` is present (set whenever `--kanban-path` was provided), also render the sync state — see the table below. |
 | `{ok: false, notFound: true, error}` | print "no board config published on Jira project <projectKey> yet"; if the user has the canonical config locally, suggest `/kanban:push-board-config` |
 | `{ok: false, error}` mentioning permission / network | surface verbatim |
+
+## 2. Reading the diff (#57)
+
+When `--kanban-path` is given, the response carries a `diff` block:
+
+```
+diff: {
+  state: "in-sync" | "remote-ahead" | "local-edits" | "diverged" | "unknown",
+  localMeta:   { version, hash, pushedAt, pushedByAccountId } | null,
+  remoteMeta:  { version, hash, pushedAt, pushedByAccountId } | null,
+  localHash:   "sha256:..."   // current local content
+  remoteHash:  "sha256:..."   // current remote content
+  cachedHash:  "sha256:..."   // hash this machine last pulled/pushed
+  cachedVersion, remoteVersion
+}
+```
+
+Render guidance:
+
+| State | What it means | What to tell the user |
+|---|---|---|
+| `in-sync` | Local content unchanged since pull; remote unchanged too. | `✓ in sync (v<remoteVersion>)` |
+| `remote-ahead` | Local untouched; teammate pushed since your pull. | `⚠ remote ahead (you are at v<cachedVersion>, remote v<remoteVersion>). Run /kanban:pull-board-config to update.` |
+| `local-edits` | You edited local since the last pull; remote hasn't moved. | `⚠ uncommitted local changes. Push them with /kanban:push-board-config (or revert by re-pulling).` |
+| `diverged` | Both moved — manual reconciliation needed. | `‼ diverged: remote moved AND you have local edits. Pull, reconcile, push.` |
+| `unknown` | Local has no cached `_meta` yet (never pulled/pushed). | `(no local _meta — first push will initialize v1)` |
 
 ## Absolute rules
 

--- a/plugins/kanban/lib/board_config.py
+++ b/plugins/kanban/lib/board_config.py
@@ -40,6 +40,7 @@ optimistic concurrency.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -59,16 +60,60 @@ CACHE_TTL_HOURS = 8
 # of the most recent successful pull.
 _CACHED_AT_FIELD = "boardConfigCachedAt"
 
+# Key, inside the pushed/pulled config dict, that carries push/pull
+# metadata (#57). Sibling of `transitions`/`ap`/`conventions`. Excluded
+# from the canonical hash so the hash represents the *content* and is
+# stable across re-pushes that only bump `_meta`.
+META_KEY = "_meta"
+
 
 class BoardConfigError(RuntimeError):
     """Raised when a push/pull operation fails in a way the caller
     should surface to the user (permission denied, malformed payload,
     Jira unreachable). Distinct from JiraError so callers can
     differentiate config-layer failures from underlying HTTP errors.
+
+    Optional attributes set on specific instances:
+      - `not_found` (True for 404 on pull)
+      - `if_match_mismatch` (True when push refused due to --if-match)
+      - `remote_meta` (the remote `_meta` snapshot on if-match failure,
+        so callers can format actionable error output)
     """
 
 
-def push(client: Any, project_key: str, config: dict[str, Any]) -> None:
+def canonical_hash(config: dict[str, Any]) -> str:
+    """Return `sha256:<hex>` of the canonical JSON of `config` with
+    `_meta` stripped (#57).
+
+    Canonicalization rules:
+      - `_meta` key is excluded so the hash describes the *content*,
+        not the version/pushedAt metadata wrapping it.
+      - keys are sorted at every level (`sort_keys=True`) so two
+        semantically-identical dicts that differ only in key order
+        produce the same hash.
+      - separators are tight (`,`/`:`) so whitespace differences in
+        upstream serializers don't change the hash.
+      - encoded as UTF-8 (ensures non-ASCII content roundtrips
+        deterministically; `ensure_ascii=False` keeps the JSON small
+        but the bytes are still UTF-8 and reproducible).
+    """
+    body = {k: v for k, v in config.items() if k != META_KEY}
+    canonical = json.dumps(
+        body, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def push(
+    client: Any,
+    project_key: str,
+    config: dict[str, Any],
+    *,
+    account_id: str | None = None,
+    if_match: str | None = None,
+    force: bool = False,
+    now: datetime | None = None,
+) -> dict[str, Any]:
     """Write `config` to the Jira project's `kanban-config` property.
 
     `config` is the canonical JSON the team agrees on — typically the
@@ -76,9 +121,26 @@ def push(client: Any, project_key: str, config: dict[str, Any]) -> None:
     per-machine fields (`agentAccountId` is per-Atlassian-account, but
     the rest of the block is per-board and should round-trip).
 
-    Raises BoardConfigError on permission failure (403) or other
-    non-retryable issues with a readable message. Other HTTP errors
-    surface from the underlying client.
+    Versioning (#57):
+      - Before writing, the remote `_meta` is fetched. If it carries a
+        `hash` and the caller passed `if_match`, the two must match —
+        otherwise the push is refused with `BoardConfigError`
+        (`if_match_mismatch=True`, `remote_meta=<dict>`). Pass
+        `force=True` to bypass.
+      - A new `_meta` block is attached to the pushed payload with the
+        next `version` (monotonic counter, starts at 1), the content
+        `hash` (canonical_hash of the payload minus `_meta`), the
+        push timestamp, and (when `account_id` is given) the Atlassian
+        accountId of the pushing admin.
+
+    Any `_meta` already in `config` is ignored — push always
+    regenerates the block from the just-pulled remote version.
+
+    Returns the new `_meta` dict so callers can persist it into the
+    local cache.
+
+    Raises BoardConfigError on permission failure (403), `--if-match`
+    mismatch, or other non-retryable issues.
     """
     if not isinstance(config, dict) or not config:
         raise BoardConfigError("config must be a non-empty JSON object")
@@ -90,8 +152,60 @@ def push(client: Any, project_key: str, config: dict[str, Any]) -> None:
     # pay that import cost).
     from lib.jira_client import JiraError
 
+    # Read remote `_meta` so we can (a) honor --if-match and (b) pick
+    # the next version. Treat a 404 as "first push" — version starts
+    # at 1, no if-match check possible.
+    remote_meta: dict[str, Any] | None = None
     try:
-        client.set_project_property(project_key, PROPERTY_KEY, config)
+        remote = pull(client, project_key)
+    except BoardConfigError as e:
+        if not getattr(e, "not_found", False):
+            raise
+        remote = None
+    if isinstance(remote, dict):
+        m = remote.get(META_KEY)
+        if isinstance(m, dict):
+            remote_meta = m
+
+    remote_hash = (remote_meta or {}).get("hash")
+    if if_match is not None and not force:
+        # `if_match` is the hash the caller expected remote to still be
+        # at. If remote moved (someone else pushed since the caller
+        # pulled), refuse and hand the caller enough context to render
+        # an actionable error.
+        if remote_hash != if_match:
+            err = BoardConfigError(
+                f"remote board config moved since your last pull on "
+                f"project {project_key!r}: expected hash {if_match!r} but "
+                f"remote is {remote_hash!r} "
+                f"(remote version={(remote_meta or {}).get('version')}). "
+                f"Run /kanban:pull-board-config to fetch the new version, "
+                f"reconcile your changes, then push again — or pass "
+                f"--force to clobber."
+            )
+            err.if_match_mismatch = True  # type: ignore[attr-defined]
+            err.remote_meta = remote_meta or {}  # type: ignore[attr-defined]
+            raise err
+
+    prev_version = 0
+    if remote_meta is not None:
+        v = remote_meta.get("version")
+        if isinstance(v, int) and v > 0:
+            prev_version = v
+
+    body = {k: v for k, v in config.items() if k != META_KEY}
+    new_meta: dict[str, Any] = {
+        "version": prev_version + 1,
+        "hash": canonical_hash(body),
+        "pushedAt": (now or _utcnow()).isoformat(timespec="seconds"),
+    }
+    if account_id:
+        new_meta["pushedByAccountId"] = account_id
+
+    payload = {META_KEY: new_meta, **body}
+
+    try:
+        client.set_project_property(project_key, PROPERTY_KEY, payload)
     except JiraError as e:
         if e.status_code == 403:
             raise BoardConfigError(
@@ -104,6 +218,8 @@ def push(client: Any, project_key: str, config: dict[str, Any]) -> None:
         raise BoardConfigError(
             f"jira: {e.detail or e} (status={e.status_code})"
         ) from e
+
+    return new_meta
 
 
 def pull(client: Any, project_key: str) -> dict[str, Any]:

--- a/plugins/kanban/scripts/jira_setup.py
+++ b/plugins/kanban/scripts/jira_setup.py
@@ -948,9 +948,14 @@ def cmd_push_board_config(args: argparse.Namespace) -> int:
     `kanban-jira-code` flow that lived in 0.3.0–0.3.26).
 
     What gets pushed: transitions DSL, ap.fieldId/fieldName, boardId,
-    boardUrl, projectKey, conventions. Per-machine fields
-    (`agentAccountId`, `ap.registered`) are stripped so two machines
-    pushing don't fight over them.
+    boardUrl, projectKey, conventions, plus a `_meta` block managed by
+    push/pull (version, content hash, pushedAt, pushedByAccountId — see
+    #57). Per-machine fields (`agentAccountId`, `ap.registered`) are
+    stripped so two machines pushing don't fight over them.
+
+    Optimistic concurrency (#57): if `--if-match <hash>` is given (or
+    the local cache carries `backend.jira._meta.hash`), the push refuses
+    when remote moved since that hash. `--force` clobbers anyway.
 
     Requires Jira project-admin role on the agent's account; non-admin
     pushes return a clear permission-error message.
@@ -976,37 +981,67 @@ def cmd_push_board_config(args: argparse.Namespace) -> int:
     # Strip per-machine / per-account fields. The shared canonical
     # config is everything that should be identical across teammates;
     # `agentAccountId` and `ap.registered` are local state.
-    payload = {
-        "boardUrl": cfg.get("boardUrl"),
-        "boardId": cfg.get("boardId"),
-        "projectKey": project_key,
-        "transitions": cfg.get("transitions"),
-    }
-    ap = cfg.get("ap") or {}
-    if ap.get("fieldId"):
-        payload["ap"] = {
-            "fieldId": ap["fieldId"],
-            "fieldName": ap.get("fieldName", ""),
-        }
-    payload["conventions"] = _cv.normalize(cfg.get("conventions"))
-    # Drop nulls so the on-Jira blob stays minimal.
-    payload = {k: v for k, v in payload.items() if v is not None}
+    payload = _canonical_share(cfg)
 
+    # Decide which hash, if any, to pass to push as --if-match. The
+    # rare slash-command override is `--force`; otherwise the auto-fill
+    # uses the cached `_meta.hash` from the last pull (or last push).
+    # No cached hash + no explicit --if-match means first push — push
+    # proceeds without a fence (acceptable: no prior version to clobber).
+    force = bool(getattr(args, "force", False))
+    if_match = getattr(args, "if_match", None)
+    if if_match is None and not force:
+        existing_meta = cfg.get(_bc.META_KEY)
+        if isinstance(existing_meta, dict):
+            cached = existing_meta.get("hash")
+            if isinstance(cached, str) and cached:
+                if_match = cached
+
+    # Resolve the pushing admin's accountId for audit purposes. Prefer
+    # the locally-cached value (cheaper, populated by /kanban:initjira);
+    # fall back to a live /myself lookup so the trail is never empty.
+    account_id = cfg.get("agentAccountId") or None
     client = _client_from_env()
-    try:
-        _bc.push(client, project_key, payload)
-    except _bc.BoardConfigError as e:
-        return _fail(str(e))
+    if not account_id:
+        try:
+            me = client.get_myself()
+            account_id = me.get("accountId") or None
+        except Exception:  # noqa: BLE001
+            # /myself shouldn't be the reason a push fails; pushedBy
+            # gets omitted in this edge case and the rest of `_meta`
+            # still goes through.
+            account_id = None
 
-    # Mark this machine's cache as freshly synced too — the local
-    # kanban.json content matches what we just pushed, so no immediate
-    # passive sync is needed.
+    try:
+        new_meta = _bc.push(
+            client, project_key, payload,
+            account_id=account_id,
+            if_match=if_match,
+            force=force,
+        )
+    except _bc.BoardConfigError as e:
+        extras: dict[str, Any] = {}
+        if getattr(e, "if_match_mismatch", False):
+            extras["ifMatchMismatch"] = True
+            extras["remoteMeta"] = getattr(e, "remote_meta", {}) or {}
+            extras["expectedHash"] = if_match
+        return _fail(str(e), **extras)
+
+    # Mirror the just-pushed `_meta` back into the local cache so the
+    # *next* push on this machine can auto-fill --if-match without
+    # needing an intervening pull. Same reason `mark_synced` is called:
+    # we're treating "successful push" as "this machine is in sync".
+    new_cfg = dict(cfg)
+    new_cfg[_bc.META_KEY] = new_meta
+    backend["jira"] = new_cfg
+    kanban_io.save(p, data)
     _bc.mark_synced(p.parent)
     _emit({
         "ok": True,
         "projectKey": project_key,
         "propertyKey": _bc.PROPERTY_KEY,
         "fieldsPushed": sorted(payload.keys()),
+        "meta": new_meta,
     })
     return 0
 
@@ -1163,7 +1198,13 @@ def cmd_read_board_config_cache(args: argparse.Namespace) -> int:
     config lives + how stale this machine's cache is.
 
     Output: {ok, projectKey, propertyKey, cachedAt, cacheAgeHours,
-             stale}.
+             stale, meta, localHash, localMatchesMeta}.
+
+    `meta` is the cached `_meta` block from the last pull/push (#57);
+    `localHash` is the canonical hash of the current
+    `backend.jira` minus _meta — when it differs from `meta.hash`, the
+    local config has been edited since the cached pull/push and the
+    next push will create a new version.
     """
     from lib import board_config as _bc
 
@@ -1180,6 +1221,13 @@ def cmd_read_board_config_cache(args: argparse.Namespace) -> int:
     age = _bc.cache_age_hours(p.parent)
     cached_at = _bc._read_cached_at(p.parent)  # internal; safe in same package
 
+    meta = cfg.get(_bc.META_KEY) if isinstance(cfg.get(_bc.META_KEY), dict) else None
+    local_hash = _bc.canonical_hash(_canonical_share(cfg))
+    local_matches_meta = (
+        bool(meta) and isinstance(meta.get("hash"), str)
+        and meta.get("hash") == local_hash
+    )
+
     _emit({
         "ok": True,
         "projectKey": project_key,
@@ -1188,8 +1236,39 @@ def cmd_read_board_config_cache(args: argparse.Namespace) -> int:
         "cacheAgeHours": (round(age, 2) if age is not None else None),
         "stale": _bc.is_cache_stale(p.parent),
         "ttlHours": _bc.CACHE_TTL_HOURS,
+        "meta": meta,
+        "localHash": local_hash,
+        "localMatchesMeta": local_matches_meta,
     })
     return 0
+
+
+def _canonical_share(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Build the shared-canonical view of a `backend.jira` block — the
+    same shape `cmd_push_board_config` would push. Per-machine fields
+    (`agentAccountId`, `ap.registered`, `_meta`) are stripped so the
+    hash compares apples-to-apples against the remote `_meta.hash`.
+
+    Kept separate from `cmd_push_board_config` so callers that only
+    want to *inspect* the canonical content (e.g. cache/diff renderers)
+    don't have to duplicate the strip rules.
+    """
+    from lib import board_config as _bc
+
+    payload: dict[str, Any] = {
+        "boardUrl": cfg.get("boardUrl"),
+        "boardId": cfg.get("boardId"),
+        "projectKey": cfg.get("projectKey"),
+        "transitions": cfg.get("transitions"),
+    }
+    ap = cfg.get("ap") or {}
+    if ap.get("fieldId"):
+        payload["ap"] = {
+            "fieldId": ap["fieldId"],
+            "fieldName": ap.get("fieldName", ""),
+        }
+    payload["conventions"] = _cv.normalize(cfg.get("conventions"))
+    return {k: v for k, v in payload.items() if v is not None}
 
 
 def cmd_read_board_config(args: argparse.Namespace) -> int:
@@ -1197,24 +1276,35 @@ def cmd_read_board_config(args: argparse.Namespace) -> int:
     touching local state. Used by /kanban:show-board-config for
     discovery — humans inspect what's currently published on Jira
     without disturbing the local cache.
+
+    When `--kanban-path` is given alongside, the emitted output also
+    carries a `diff` block (#57) the slash command renders into one of
+    four states (in-sync / remote-ahead / local-edits / diverged).
     """
     from lib import board_config as _bc
 
     project_key = args.project_key
+    local_cfg: dict[str, Any] | None = None
     if not project_key:
         # Fall through to reading from kanban.json for convenience.
         if args.kanban_path:
             p = Path(args.kanban_path)
             if p.exists():
                 data = kanban_io.load(p)
-                project_key = (
-                    (data.get("backend") or {}).get("jira") or {}
-                ).get("projectKey")
+                local_cfg = (data.get("backend") or {}).get("jira") or {}
+                project_key = local_cfg.get("projectKey")
         if not project_key:
             return _fail(
                 "--project-key required (or pass --kanban-path to read it "
                 "from backend.jira.projectKey)"
             )
+    elif args.kanban_path:
+        # `--project-key` and `--kanban-path` both given — still load the
+        # local block so we can compute the diff against remote.
+        p = Path(args.kanban_path)
+        if p.exists():
+            data = kanban_io.load(p)
+            local_cfg = (data.get("backend") or {}).get("jira") or {}
 
     client = _client_from_env()
     try:
@@ -1222,13 +1312,64 @@ def cmd_read_board_config(args: argparse.Namespace) -> int:
     except _bc.BoardConfigError as e:
         return _fail(str(e), notFound=getattr(e, "not_found", False))
 
-    _emit({
+    payload: dict[str, Any] = {
         "ok": True,
         "projectKey": project_key,
         "propertyKey": _bc.PROPERTY_KEY,
         "config": config,
-    })
+    }
+    if local_cfg is not None:
+        payload["diff"] = _diff_meta(local_cfg, config)
+    _emit(payload)
     return 0
+
+
+def _diff_meta(local_cfg: dict[str, Any], remote_cfg: dict[str, Any]) -> dict[str, Any]:
+    """Compare the local `backend.jira` block against a freshly-pulled
+    remote config. Returns the structured snapshot the show-board-config
+    slash command renders.
+
+    The four states from the #57 design table:
+      in-sync             — local content unchanged since pull, remote unchanged.
+      remote-ahead        — local content unchanged, remote has a newer version.
+      local-edits         — local content changed, remote unchanged since pull.
+      diverged            — both moved; manual reconciliation needed.
+      unknown             — local has no cached _meta yet (never pulled/pushed).
+    """
+    from lib import board_config as _bc
+
+    local_meta = local_cfg.get(_bc.META_KEY) if isinstance(local_cfg.get(_bc.META_KEY), dict) else None
+    remote_meta = remote_cfg.get(_bc.META_KEY) if isinstance(remote_cfg.get(_bc.META_KEY), dict) else None
+    local_hash = _bc.canonical_hash(_canonical_share(local_cfg))
+    remote_hash = _bc.canonical_hash(remote_cfg)
+    cached_hash = (local_meta or {}).get("hash")
+    cached_version = (local_meta or {}).get("version")
+    remote_version = (remote_meta or {}).get("version")
+
+    if not local_meta or not isinstance(cached_hash, str):
+        state = "unknown"
+    else:
+        local_clean = (local_hash == cached_hash)
+        remote_moved = (remote_hash != cached_hash)
+        if local_clean and not remote_moved:
+            state = "in-sync"
+        elif local_clean and remote_moved:
+            state = "remote-ahead"
+        elif (not local_clean) and not remote_moved:
+            state = "local-edits"
+        else:
+            state = "diverged"
+
+    return {
+        "state": state,
+        "localMeta": local_meta,
+        "remoteMeta": remote_meta,
+        "localHash": local_hash,
+        "remoteHash": remote_hash,
+        "cachedHash": cached_hash,
+        "cachedVersion": cached_version,
+        "remoteVersion": remote_version,
+    }
 
 
 def cmd_set_conventions(args: argparse.Namespace) -> int:
@@ -3613,6 +3754,19 @@ def build_parser() -> argparse.ArgumentParser:
              "(kanban-config); requires project-admin on Jira",
     )
     s.add_argument("--kanban-path", required=True)
+    s.add_argument(
+        "--if-match",
+        help="Refuse the push when the remote `_meta.hash` doesn't "
+             "equal this value. Omitted ⇒ auto-fill from the local "
+             "cached _meta.hash (the last hash this machine pulled or "
+             "pushed); no cache ⇒ first push, no fence.",
+    )
+    s.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass the --if-match fence. Use when you intentionally "
+             "want to clobber whatever's currently on Jira.",
+    )
     s.set_defaults(func=cmd_push_board_config)
 
     s = sub.add_parser(

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33; do  # …32: paste-flow removal + initjira auto-detect (#54), 33: mutation primitives (#55)
+for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34; do  # …33: mutation primitives (#55), 34: versioned board config (#57)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase30.py
+++ b/plugins/kanban/scripts/test_phase30.py
@@ -129,7 +129,11 @@ def _seed_jira_kanban(td: pathlib.Path, *,
 
 
 def test_push_happy_path_calls_set_project_property():
-    queue = [_Response(204, b"", {})]
+    # push() reads the remote _meta first (404 → first push), then PUTs.
+    queue = [
+        _Response(404, b'{"errorMessages":["not found"]}', {}),
+        _Response(204, b"", {}),
+    ]
     calls: list[dict] = []
     client = _mock_client(queue, calls)
 
@@ -140,16 +144,28 @@ def test_push_happy_path_calls_set_project_property():
     }
     _bc.push(client, "AGENT", config)
 
-    assert len(calls) == 1
-    c = calls[0]
+    assert len(calls) == 2
+    assert calls[0]["method"] == "GET"
+    c = calls[1]
     assert c["method"] == "PUT"
     assert "/rest/api/3/project/AGENT/properties/kanban-config" in c["url"]
     body = json.loads((c["body"] or b"").decode())
+    # Caller's config is preserved verbatim, plus push() attaches _meta.
+    meta = body.pop("_meta")
     assert body == config
+    assert meta["version"] == 1
+    assert meta["hash"].startswith("sha256:") and len(meta["hash"]) == 7 + 64
+    assert meta["pushedAt"]
+    # No pushedByAccountId when not provided.
+    assert "pushedByAccountId" not in meta
 
 
 def test_push_403_raises_permission_denied_with_admin_hint():
-    queue = [_Response(403, b'{"errorMessages":["nope"]}', {})]
+    # GET (read remote meta) -> 404, then PUT -> 403.
+    queue = [
+        _Response(404, b'{"errorMessages":["not found"]}', {}),
+        _Response(403, b'{"errorMessages":["nope"]}', {}),
+    ]
     calls: list[dict] = []
     client = _mock_client(queue, calls)
 
@@ -285,18 +301,27 @@ def test_cmd_push_strips_per_machine_fields():
         td = pathlib.Path(raw)
         kp = _seed_jira_kanban(td, with_ap_registered=True,
                                with_agent_account=True)
-        queue = [_Response(204, b"", {})]
+        # push() does a GET first to read remote _meta (404 ⇒ first
+        # push, no fence), then PUTs the payload.
+        queue = [
+            _Response(404, b'{"errorMessages":["not found"]}', {}),
+            _Response(204, b"", {}),
+        ]
         calls: list[dict] = []
         client = _mock_client(queue, calls)
         orig = _patch_client_from_env(client)
         try:
-            class A: kanban_path = str(kp)
+            class A:
+                kanban_path = str(kp)
+                if_match = None
+                force = False
             rc, out, err = _capture(_jira_setup.cmd_push_board_config, A())
         finally:
             _restore_client_from_env(orig)
 
         assert rc == 0, (out, err)
-        body = json.loads((calls[0]["body"] or b"").decode())
+        put_call = next(c for c in calls if c["method"] == "PUT")
+        body = json.loads((put_call["body"] or b"").decode())
         # Per-machine fields stripped
         assert "agentAccountId" not in body
         assert "registered" not in (body.get("ap") or {})
@@ -304,6 +329,10 @@ def test_cmd_push_strips_per_machine_fields():
         assert body["projectKey"] == "AGENT"
         assert body["transitions"]
         assert body["ap"]["fieldId"] == "customfield_10042"
+        # _meta block attached
+        assert body["_meta"]["version"] == 1
+        # pushedByAccountId carries the seeded agentAccountId (5e-bot).
+        assert body["_meta"]["pushedByAccountId"] == "5e-bot"
 
 
 # --- (i) pull command preserves per-machine fields ----------------------

--- a/plugins/kanban/scripts/test_phase34.py
+++ b/plugins/kanban/scripts/test_phase34.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Phase 34 regression checks for kanban v0.3.29 — versioned board
+config (#57).
+
+PR adds `_meta` (version, content hash, pushedAt, pushedByAccountId)
+to every push of the `kanban-config` Jira project property, and uses
+the hash as an optimistic-concurrency fence (`push --if-match`). Pull
+captures `_meta` into the local cache so subsequent pushes can
+auto-fill `--if-match` without manual book-keeping.
+
+Cases:
+  (a) `canonical_hash` is order- and whitespace-stable: two configs
+      that differ only in key order produce the same hash; the hash
+      excludes `_meta`.
+  (b) First push (remote 404) initializes `_meta.version = 1` and
+      attaches a hash + pushedAt; `pushedByAccountId` carries
+      account_id when provided.
+  (c) Second push (remote has v1) bumps to `_meta.version = 2`.
+  (d) Push with `if_match=<wrong>` is refused with
+      `if_match_mismatch=True` and `remote_meta` populated; no PUT
+      goes through.
+  (e) Push with `if_match=<wrong>` and `force=True` clobbers anyway.
+  (f) Push with no `_meta` cache on remote AND `if_match=None`
+      proceeds without a fence (first push).
+  (g) `cmd_push_board_config` auto-fills `--if-match` from local
+      cached `_meta.hash`; a mismatch with remote is reported with
+      `ifMatchMismatch=True` in the JSON output and a non-zero rc.
+  (h) `cmd_push_board_config` writes the just-pushed `_meta` back
+      into local `kanban.json#backend.jira._meta` so the *next* push
+      on this machine carries that hash forward.
+  (i) `cmd_pull_board_config` captures remote `_meta` into local
+      `backend.jira._meta` verbatim.
+  (j) `cmd_read_board_config_cache` reports `meta`, `localHash`, and
+      `localMatchesMeta=True` when the local config hasn't been
+      edited since the last pull.
+  (k) `cmd_read_board_config` with --kanban-path emits a `diff` block
+      whose `state` correctly identifies in-sync / remote-ahead /
+      local-edits / diverged.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib import board_config as _bc  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location(
+    "jira_setup_mod", str(PLUGIN / "scripts" / "jira_setup.py")
+)
+_jira_setup = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_jira_setup)  # type: ignore[union-attr]
+
+
+def _capture(fn, args):
+    from io import StringIO
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout = StringIO()
+    sys.stderr = StringIO()
+    try:
+        try:
+            rc = fn(args)
+        except SystemExit as e:
+            rc = e.code
+        out = sys.stdout.getvalue()
+        err = sys.stderr.getvalue()
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    return rc, out, err
+
+
+def _mock_client(queue, calls):
+    def t(method, url, headers, body):
+        calls.append({"method": method, "url": url, "body": body})
+        if not queue:
+            raise AssertionError(f"queue empty for {method} {url}")
+        return queue.pop(0)
+    return JiraClient("https://x", "a@b", "tok", transport=t,
+                      sleep=lambda _: None)
+
+
+def _patch_client_from_env(client):
+    orig = _jira_setup._client_from_env
+    _jira_setup._client_from_env = lambda: client
+    return orig
+
+
+def _restore_client_from_env(orig):
+    _jira_setup._client_from_env = orig
+
+
+def _seed_jira_kanban(td: pathlib.Path, *, meta: dict | None = None,
+                      transitions: dict | None = None) -> pathlib.Path:
+    cfg = {
+        "boardUrl": "https://x.atlassian.net/jira/projects/AGENT/boards/1",
+        "boardId": 1,
+        "projectKey": "AGENT",
+        "transitions": transitions or {
+            "TODO": {"status": "To Do"},
+            "DOING": {"status": "In Progress"},
+            "APPROVED": {"status": "Done"},
+        },
+        "ap": {"fieldId": "customfield_10042",
+               "fieldName": "Claude Agent",
+               "registered": ["agent-fin"]},
+        "agentAccountId": "5e-bot",
+        "conventions": {"notes": [], "blockedRequiresLink": False},
+    }
+    if meta is not None:
+        cfg["_meta"] = meta
+    p = td / "kanban.json"
+    p.write_text(json.dumps({
+        "version": "0.2",
+        "backend": {"driver": "jira", "jira": cfg},
+        "meta": {"priorities": ["P0"], "categories": [],
+                 "columns": ["TODO", "DOING", "BLOCKED", "REVIEW",
+                             "APPROVED", "CANCELLED"],
+                 "created_at": "x", "updated_at": "x"},
+        "tasks": [],
+    }))
+    return p
+
+
+# --- (a) canonical_hash --------------------------------------------------
+
+
+def test_canonical_hash_is_order_stable_and_strips_meta():
+    a = {
+        "transitions": {"DOING": {"status": "In Progress"}, "TODO": {"status": "To Do"}},
+        "projectKey": "AGENT",
+        "_meta": {"version": 7, "hash": "sha256:old"},
+    }
+    b = {
+        "_meta": {"version": 999, "hash": "sha256:totally-different"},
+        "projectKey": "AGENT",
+        "transitions": {"TODO": {"status": "To Do"}, "DOING": {"status": "In Progress"}},
+    }
+    h_a = _bc.canonical_hash(a)
+    h_b = _bc.canonical_hash(b)
+    assert h_a == h_b, (h_a, h_b)
+    assert h_a.startswith("sha256:") and len(h_a) == 7 + 64
+
+    # Different content → different hash.
+    c = dict(a)
+    c["projectKey"] = "OTHER"
+    assert _bc.canonical_hash(c) != h_a
+
+
+# --- (b) (c) (f) version bump + first-push behavior ---------------------
+
+
+def test_push_first_time_initializes_v1():
+    queue = [
+        _Response(404, b'{"errorMessages":["not found"]}', {}),
+        _Response(204, b"", {}),
+    ]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    config = {
+        "projectKey": "AGENT",
+        "transitions": {"DOING": {"status": "In Progress"}},
+    }
+    meta = _bc.push(client, "AGENT", config, account_id="5e-bot")
+    assert meta["version"] == 1
+    assert meta["hash"] == _bc.canonical_hash(config)
+    assert meta["pushedByAccountId"] == "5e-bot"
+    assert "pushedAt" in meta
+
+    put = next(c for c in calls if c["method"] == "PUT")
+    body = json.loads((put["body"] or b"").decode())
+    assert body["_meta"] == meta
+
+
+def test_push_second_time_bumps_version():
+    # Remote already has v3.
+    remote = {
+        "key": "kanban-config",
+        "value": {
+            "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+            "_meta": {"version": 3, "hash": "sha256:old",
+                      "pushedAt": "2026-05-01T00:00:00+00:00"},
+        },
+    }
+    queue = [
+        _Response(200, json.dumps(remote).encode(), {}),
+        _Response(204, b"", {}),
+    ]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    config = {
+        "projectKey": "AGENT",
+        "transitions": {"DOING": {"status": "In Review"}},
+    }
+    meta = _bc.push(client, "AGENT", config, force=True)
+    assert meta["version"] == 4
+
+
+def test_push_first_time_no_fence_check():
+    """Remote 404 + caller passed `if_match=None` ⇒ no fence, push
+    proceeds normally. Covers the bootstrap path."""
+    queue = [
+        _Response(404, b'{"errorMessages":["not found"]}', {}),
+        _Response(204, b"", {}),
+    ]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+    meta = _bc.push(client, "AGENT",
+                    {"projectKey": "AGENT", "transitions": {}},
+                    if_match=None)
+    assert meta["version"] == 1
+
+
+# --- (d) (e) --if-match fence -------------------------------------------
+
+
+def test_push_if_match_mismatch_refused_without_force():
+    remote = {
+        "key": "kanban-config",
+        "value": {
+            "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+            "_meta": {"version": 5, "hash": "sha256:remote-current",
+                      "pushedAt": "2026-05-10T00:00:00+00:00",
+                      "pushedByAccountId": "alice-id"},
+        },
+    }
+    queue = [_Response(200, json.dumps(remote).encode(), {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    try:
+        _bc.push(client, "AGENT",
+                 {"projectKey": "AGENT", "transitions": {}},
+                 if_match="sha256:i-pulled-this-stale-one")
+    except _bc.BoardConfigError as e:
+        assert getattr(e, "if_match_mismatch", False) is True
+        rm = getattr(e, "remote_meta", None) or {}
+        assert rm.get("version") == 5
+        assert rm.get("pushedByAccountId") == "alice-id"
+        # No PUT was issued — only the GET to read remote meta.
+        assert all(c["method"] != "PUT" for c in calls)
+        return
+    raise AssertionError("expected BoardConfigError(if_match_mismatch)")
+
+
+def test_push_if_match_mismatch_force_clobbers():
+    remote = {
+        "key": "kanban-config",
+        "value": {
+            "projectKey": "AGENT",
+            "transitions": {"DOING": {"status": "In Progress"}},
+            "_meta": {"version": 5, "hash": "sha256:remote-current"},
+        },
+    }
+    queue = [
+        _Response(200, json.dumps(remote).encode(), {}),
+        _Response(204, b"", {}),
+    ]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+
+    meta = _bc.push(client, "AGENT",
+                    {"projectKey": "AGENT", "transitions": {}},
+                    if_match="sha256:wrong-on-purpose", force=True)
+    assert meta["version"] == 6
+    # PUT did fire.
+    assert any(c["method"] == "PUT" for c in calls)
+
+
+# --- (g) (h) cmd_push_board_config auto-fills --if-match ----------------
+
+
+def test_cmd_push_auto_fills_if_match_from_local_meta_and_refuses_mismatch():
+    """Local `_meta.hash` (= what this machine last pulled) is passed as
+    `--if-match` automatically. Remote returns a different hash ⇒ push
+    refuses; no PUT occurs."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        local_meta = {
+            "version": 5,
+            "hash": "sha256:my-cached-stale-hash",
+            "pushedAt": "2026-05-10T00:00:00+00:00",
+        }
+        kp = _seed_jira_kanban(td, meta=local_meta)
+        # Remote moved since: hash differs.
+        remote = {
+            "key": "kanban-config",
+            "value": {
+                "projectKey": "AGENT",
+                "transitions": {"DOING": {"status": "In Progress"}},
+                "_meta": {"version": 7, "hash": "sha256:remote-moved",
+                          "pushedAt": "2026-05-15T00:00:00+00:00",
+                          "pushedByAccountId": "alice-id"},
+            },
+        }
+        queue = [_Response(200, json.dumps(remote).encode(), {})]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A:
+                kanban_path = str(kp)
+                if_match = None
+                force = False
+            rc, out, err = _capture(_jira_setup.cmd_push_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc != 0, out
+        j = json.loads(out)
+        assert j["ok"] is False
+        assert j.get("ifMatchMismatch") is True
+        assert j.get("expectedHash") == "sha256:my-cached-stale-hash"
+        assert (j.get("remoteMeta") or {}).get("version") == 7
+        # No PUT.
+        assert all(c["method"] != "PUT" for c in calls)
+        # Local file untouched.
+        on_disk = json.loads(kp.read_text())
+        assert on_disk["backend"]["jira"]["_meta"] == local_meta
+
+
+def test_cmd_push_writes_new_meta_back_into_local():
+    """A successful push lands the just-pushed `_meta` back on disk so
+    the next push from this machine auto-fills `--if-match` correctly."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        local_meta = {
+            "version": 5,
+            "hash": "sha256:my-cached-hash",
+            "pushedAt": "2026-05-10T00:00:00+00:00",
+        }
+        kp = _seed_jira_kanban(td, meta=local_meta)
+        # Remote at the same hash (no drift) — push proceeds, increments
+        # to v6.
+        remote = {
+            "key": "kanban-config",
+            "value": {
+                "projectKey": "AGENT",
+                "transitions": {"DOING": {"status": "In Progress"}},
+                "_meta": {"version": 5, "hash": "sha256:my-cached-hash"},
+            },
+        }
+        # Make remote's hash match what local _canonical_share will
+        # compute, so if_match auto-fill succeeds.
+        # Build local payload and compute its canonical hash first.
+        data = json.loads(kp.read_text())
+        local_cfg = data["backend"]["jira"]
+        canonical = _jira_setup._canonical_share(local_cfg)
+        canonical_hash = _bc.canonical_hash(canonical)
+        # Patch local meta + remote meta to that hash.
+        local_meta["hash"] = canonical_hash
+        local_cfg["_meta"] = local_meta
+        kp.write_text(json.dumps(data))
+        remote["value"]["_meta"]["hash"] = canonical_hash
+
+        queue = [
+            _Response(200, json.dumps(remote).encode(), {}),
+            _Response(204, b"", {}),
+        ]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A:
+                kanban_path = str(kp)
+                if_match = None
+                force = False
+            rc, out, err = _capture(_jira_setup.cmd_push_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["meta"]["version"] == 6
+
+        on_disk = json.loads(kp.read_text())
+        cfg = on_disk["backend"]["jira"]
+        assert cfg["_meta"]["version"] == 6
+        assert cfg["_meta"]["hash"] == canonical_hash
+        # Per-machine fields survived.
+        assert cfg["agentAccountId"] == "5e-bot"
+        assert cfg["ap"]["registered"] == ["agent-fin"]
+
+
+# --- (i) cmd_pull_board_config captures remote _meta into local --------
+
+
+def test_cmd_pull_captures_remote_meta():
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)  # local has no _meta yet
+        remote = {
+            "key": "kanban-config",
+            "value": {
+                "projectKey": "AGENT",
+                "boardId": 1,
+                "boardUrl": "https://x.atlassian.net/jira/projects/AGENT/boards/1",
+                "transitions": {
+                    "TODO": {"status": "To Do"},
+                    "DOING": {"status": "In Progress"},
+                    "APPROVED": {"status": "Done"},
+                },
+                "ap": {"fieldId": "customfield_10042",
+                       "fieldName": "Claude Agent"},
+                "conventions": {"notes": [], "blockedRequiresLink": False},
+                "_meta": {
+                    "version": 12,
+                    "hash": "sha256:remote-hash-1234",
+                    "pushedAt": "2026-05-15T11:22:33+00:00",
+                    "pushedByAccountId": "alice-id",
+                },
+            },
+        }
+        queue = [_Response(200, json.dumps(remote).encode(), {})]
+        calls: list[dict] = []
+        client = _mock_client(queue, calls)
+        orig = _patch_client_from_env(client)
+        try:
+            class A:
+                kanban_path = str(kp)
+                project_key = None
+            rc, out, err = _capture(_jira_setup.cmd_pull_board_config, A())
+        finally:
+            _restore_client_from_env(orig)
+
+        assert rc == 0, (out, err)
+        on_disk = json.loads(kp.read_text())
+        cfg = on_disk["backend"]["jira"]
+        assert cfg["_meta"]["version"] == 12
+        assert cfg["_meta"]["hash"] == "sha256:remote-hash-1234"
+        assert cfg["_meta"]["pushedByAccountId"] == "alice-id"
+
+
+# --- (j) cmd_read_board_config_cache reports meta + localHash ----------
+
+
+def test_cmd_read_cache_reports_local_matches_meta_after_pull():
+    """Right after a pull, `localHash == cachedHash` (no edits) ⇒
+    `localMatchesMeta=True`."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        # Seed a kanban.json whose local _meta.hash equals the
+        # canonical_hash of its content — i.e. "just pulled, untouched."
+        kp = _seed_jira_kanban(td)
+        data = json.loads(kp.read_text())
+        canonical = _jira_setup._canonical_share(data["backend"]["jira"])
+        h = _bc.canonical_hash(canonical)
+        data["backend"]["jira"]["_meta"] = {
+            "version": 4, "hash": h,
+            "pushedAt": "2026-05-15T00:00:00+00:00",
+        }
+        kp.write_text(json.dumps(data))
+
+        class A: kanban_path = str(kp)
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config_cache, A())
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["meta"]["version"] == 4
+        assert j["localHash"] == h
+        assert j["localMatchesMeta"] is True
+
+
+def test_cmd_read_cache_detects_local_edits():
+    """A local edit makes `localHash != cachedHash` ⇒
+    `localMatchesMeta=False`."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp = _seed_jira_kanban(td)
+        data = json.loads(kp.read_text())
+        canonical = _jira_setup._canonical_share(data["backend"]["jira"])
+        h = _bc.canonical_hash(canonical)
+        data["backend"]["jira"]["_meta"] = {"version": 4, "hash": h,
+                                            "pushedAt": "x"}
+        # Mutate transitions ⇒ local hash drifts from cached hash.
+        data["backend"]["jira"]["transitions"]["DOING"] = {"status": "Reviewing"}
+        kp.write_text(json.dumps(data))
+
+        class A: kanban_path = str(kp)
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config_cache, A())
+        assert rc == 0, (out, err)
+        j = json.loads(out)
+        assert j["localMatchesMeta"] is False
+        assert j["localHash"] != j["meta"]["hash"]
+
+
+# --- (k) cmd_read_board_config emits diff with correct state -----------
+
+
+def _run_show_diff(kp, remote_value):
+    """Invoke cmd_read_board_config with a single remote response and
+    return the parsed JSON output. The slash command always sends
+    `--kanban-path`, which triggers the diff block."""
+    remote = {"key": "kanban-config", "value": remote_value}
+    queue = [_Response(200, json.dumps(remote).encode(), {})]
+    calls: list[dict] = []
+    client = _mock_client(queue, calls)
+    orig = _patch_client_from_env(client)
+    try:
+        class A:
+            kanban_path = str(kp)
+            project_key = None
+        rc, out, err = _capture(_jira_setup.cmd_read_board_config, A())
+    finally:
+        _restore_client_from_env(orig)
+    assert rc == 0, (out, err)
+    return json.loads(out)
+
+
+def _diff_setup(td: pathlib.Path):
+    """Returns (kp, local_cfg_view, baseline_hash) where local_cfg_view
+    is the canonical-shared view of the seeded `backend.jira` block,
+    and baseline_hash is its canonical hash.
+
+    Callers then mutate kp and/or build a remote payload from
+    local_cfg_view to drive the four diff-state cases."""
+    kp = _seed_jira_kanban(td)
+    data = json.loads(kp.read_text())
+    canonical = _jira_setup._canonical_share(data["backend"]["jira"])
+    baseline_hash = _bc.canonical_hash(canonical)
+    # Set local `_meta.hash` to baseline → "just pulled, untouched."
+    data["backend"]["jira"]["_meta"] = {
+        "version": 3, "hash": baseline_hash, "pushedAt": "2026-05-15T00:00:00+00:00",
+    }
+    kp.write_text(json.dumps(data))
+    return kp, canonical, baseline_hash
+
+
+def test_cmd_read_diff_state_in_sync():
+    """local untouched + remote content equals baseline ⇒ in-sync."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp, canonical, baseline_hash = _diff_setup(td)
+        # Remote payload = baseline canonical content + _meta.
+        remote_value = {**canonical, "_meta": {
+            "version": 3, "hash": baseline_hash, "pushedAt": "x"}}
+        j = _run_show_diff(kp, remote_value)
+        assert j["diff"]["state"] == "in-sync", j["diff"]
+
+
+def test_cmd_read_diff_state_remote_ahead():
+    """local untouched + remote content differs ⇒ remote-ahead."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp, canonical, _ = _diff_setup(td)
+        # Mutate remote so its canonical content differs.
+        remote_content = dict(canonical)
+        remote_content["transitions"] = {
+            **remote_content["transitions"],
+            "REVIEW": {"status": "REVIEW"},
+        }
+        remote_value = {**remote_content,
+                        "_meta": {"version": 4, "hash": "sha256:remote-newer", "pushedAt": "y"}}
+        j = _run_show_diff(kp, remote_value)
+        assert j["diff"]["state"] == "remote-ahead", j["diff"]
+
+
+def test_cmd_read_diff_state_local_edits():
+    """local edited + remote unchanged from baseline ⇒ local-edits."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp, canonical, baseline_hash = _diff_setup(td)
+        # Mutate local content; cached _meta.hash stays at baseline.
+        data = json.loads(kp.read_text())
+        data["backend"]["jira"]["transitions"]["DOING"] = {"status": "Reviewing"}
+        kp.write_text(json.dumps(data))
+        # Remote stays at baseline.
+        remote_value = {**canonical,
+                        "_meta": {"version": 3, "hash": baseline_hash, "pushedAt": "x"}}
+        j = _run_show_diff(kp, remote_value)
+        assert j["diff"]["state"] == "local-edits", j["diff"]
+
+
+def test_cmd_read_diff_state_diverged():
+    """local edited + remote also moved ⇒ diverged."""
+    with tempfile.TemporaryDirectory() as raw:
+        td = pathlib.Path(raw)
+        kp, canonical, _ = _diff_setup(td)
+        # Mutate local.
+        data = json.loads(kp.read_text())
+        data["backend"]["jira"]["transitions"]["DOING"] = {"status": "Reviewing"}
+        kp.write_text(json.dumps(data))
+        # Mutate remote differently.
+        remote_content = dict(canonical)
+        remote_content["transitions"] = {
+            **remote_content["transitions"],
+            "DOING": {"status": "On Hold"},
+        }
+        remote_value = {**remote_content,
+                        "_meta": {"version": 4, "hash": "sha256:remote-different", "pushedAt": "y"}}
+        j = _run_show_diff(kp, remote_value)
+        assert j["diff"]["state"] == "diverged", j["diff"]
+
+
+def main() -> int:
+    cases = [
+        ("canonical_hash_is_order_stable_and_strips_meta",
+         test_canonical_hash_is_order_stable_and_strips_meta),
+        ("push_first_time_initializes_v1",
+         test_push_first_time_initializes_v1),
+        ("push_second_time_bumps_version",
+         test_push_second_time_bumps_version),
+        ("push_first_time_no_fence_check",
+         test_push_first_time_no_fence_check),
+        ("push_if_match_mismatch_refused_without_force",
+         test_push_if_match_mismatch_refused_without_force),
+        ("push_if_match_mismatch_force_clobbers",
+         test_push_if_match_mismatch_force_clobbers),
+        ("cmd_push_auto_fills_if_match_from_local_meta_and_refuses_mismatch",
+         test_cmd_push_auto_fills_if_match_from_local_meta_and_refuses_mismatch),
+        ("cmd_push_writes_new_meta_back_into_local",
+         test_cmd_push_writes_new_meta_back_into_local),
+        ("cmd_pull_captures_remote_meta",
+         test_cmd_pull_captures_remote_meta),
+        ("cmd_read_cache_reports_local_matches_meta_after_pull",
+         test_cmd_read_cache_reports_local_matches_meta_after_pull),
+        ("cmd_read_cache_detects_local_edits",
+         test_cmd_read_cache_detects_local_edits),
+        ("cmd_read_diff_state_in_sync", test_cmd_read_diff_state_in_sync),
+        ("cmd_read_diff_state_remote_ahead", test_cmd_read_diff_state_remote_ahead),
+        ("cmd_read_diff_state_local_edits", test_cmd_read_diff_state_local_edits),
+        ("cmd_read_diff_state_diverged", test_cmd_read_diff_state_diverged),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase34: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase34: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kanban/templates/kanban.schema.json
+++ b/plugins/kanban/templates/kanban.schema.json
@@ -38,6 +38,17 @@
             "boardId": { "type": "integer", "minimum": 1 },
             "projectKey": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+$" },
             "agentAccountId": { "type": "string" },
+            "_meta": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Push/pull metadata for the kanban-config Jira project property (#57). Managed by /kanban:push-board-config and /kanban:pull-board-config — users shouldn't hand-edit. `version` is a monotonic counter incremented on each push; `hash` is the canonical sha256 of the on-Jira config with `_meta` itself stripped, used as the optimistic-concurrency fence for `push --if-match`.",
+              "properties": {
+                "version": { "type": "integer", "minimum": 1 },
+                "hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+                "pushedAt": { "type": "string", "format": "date-time" },
+                "pushedByAccountId": { "type": "string" }
+              }
+            },
             "transitions": {
               "type": "object",
               "description": "Canonical column -> compound transition spec. Each canonical column maps to a Jira status plus optional label add/remove and assignee. Multiple canonicals may share the same Jira status; reader disambiguates by labels (most-specific match wins).",


### PR DESCRIPTION
Closes #57.

## Summary
- Adds a `_meta` block (`version`, `hash`, `pushedAt`, `pushedByAccountId`) to every push of the `kanban-config` Jira project property.
- `/kanban:push-board-config` now uses the cached `_meta.hash` as an automatic `--if-match` fence, refusing to clobber when remote moved since the last pull. `--force` bypasses.
- `/kanban:pull-board-config` captures remote `_meta` into local `backend.jira._meta`. A successful push writes the freshly-minted `_meta` back into local for the same reason.
- `/kanban:show-board-config` (with `--kanban-path`) now emits a `diff` block identifying one of `in-sync` / `remote-ahead` / `local-edits` / `diverged` / `unknown`.

## Files
- `lib/board_config.py` — `canonical_hash()`, `push()` reads-then-writes with `if_match` + `force`, returns the new `_meta`.
- `scripts/jira_setup.py` — `cmd_push_board_config` auto-fills `--if-match`, resolves `pushedByAccountId`, writes the new `_meta` back into kanban.json; `cmd_read_board_config_cache` surfaces `meta`, `localHash`, `localMatchesMeta`; `cmd_read_board_config` emits a `diff` block when `--kanban-path` is given.
- `templates/kanban.schema.json` — declares `backend.jira._meta` (optional, read-only).
- Slash-command docs updated (push / pull / show).
- `scripts/test_phase34.py` — 15 new cases (hash stability, first-push, bump, `--if-match` fence, force-clobber, auto-fill, meta round-trip, four diff states).
- Phase 30 push tests updated to seed the new GET-before-PUT order.
- `plugin.json` + `marketplace.json` → `0.3.29`.

## Migration
Backwards-compatible — pull treats absent `_meta` as `{version: 0, hash: null}`; first push after this lands initializes `v1`.

## Test plan
- [x] `bash plugins/kanban/scripts/test_all.sh` — all 34 phases pass
- [ ] Manual: on a real Jira project, exercise the four flows: first push initializes v1; second push bumps to v2; a stale-cache push is refused with `ifMatchMismatch: true`; `--force` clobbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)