### PR TITLE
fix(kanban): 0.3.30 — render agent-emitted markdown in Jira

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.29",
+      "version": "0.3.30",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,51 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+## 2026-05-16 (kanban markdown → ADF — bug after #57)
+
+### Fixed
+- **kanban 0.3.30** — agent-emitted markdown now renders correctly in
+  Jira. Previously, `text_to_adf` wrapped any body in a single flat
+  paragraph, so a comment or description containing `## Heading`,
+  `- bullets`, or ``` ```code``` ``` showed up in the Jira UI with
+  the literal markdown source instead of styled blocks.
+
+  New `lib/markdown_adf.py` parses a markdown subset into proper ADF
+  nodes:
+  - Headings `#`..`######` (h1–h6); requires a space after the hashes
+    so `#123` stays a plain issue ref rather than an h1.
+  - Bold (`**...**` / `__...__`), italic (`*...*` / `_..._`), inline
+    code (`` `...` ``), explicit links `[text](url)`.
+  - Bare URLs still auto-linkify (pre-fix behavior preserved).
+  - Fenced code blocks (triple-backtick), with optional language tag
+    → `codeBlock` with `attrs.language`.
+  - Bullet lists (`-`/`*`/`+`) and ordered lists (`N.`) →
+    `bulletList`/`orderedList` of `listItem`s.
+  - Blockquotes (`>`) wrap inner paragraph(s).
+
+  Call-site impact:
+  - `text_to_adf()` now routes through `markdown_to_adf()`. All
+    existing callers (`drivers/jira.py` create / update description,
+    add comment) benefit automatically. Plain-text inputs round-trip
+    to the same single-paragraph + URL-auto-link shape as before, so
+    non-markdown payloads see zero regression.
+  - `text_to_adf_with_mention()` body now markdown-parses too.
+    Single-paragraph bodies still inline next to the @mention chip
+    (preserves the chat-bubble look); multi-block bodies put the
+    mention on its own paragraph and emit body blocks as siblings so
+    headings/lists/code-fences render correctly.
+  - The SPEC §9 prefix (#27) intentionally stays literal — it's a
+    fixed-shape label rendered bold via an ADF `strong` mark, not
+    user-supplied markdown.
+
+  Out of scope (would need a real CommonMark parser): tables,
+  setext-style headings, reference links, nested lists, escape
+  sequences, HTML passthrough.
+
+  Tests: `scripts/test_phase35.py` adds 22 cases covering every
+  supported markdown construct, plain-text round-trip equivalence,
+  mention single-line vs multi-block routing, and prefix-stays-literal.
+
 ## 2026-05-16 (kanban versioned board config — #57)
 
 ### Added

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/lib/jira_client.py
+++ b/plugins/kanban/lib/jira_client.py
@@ -489,21 +489,24 @@ def _text_to_inline_nodes(text: str) -> list[dict[str, Any]]:
 
 
 def text_to_adf(text: str) -> dict[str, Any]:
-    """Wrap a plain-text body in Atlassian Document Format.
+    """Wrap a markdown-or-plain body in Atlassian Document Format.
 
-    Used for comments and issue descriptions. URLs in the body are
-    detected and wrapped in ADF `link` marks so they render clickable
-    in Jira UI; non-URL spans stay as plain text. SPEC §9 prefix is
-    added at the driver layer.
+    Used for comments and issue descriptions. The body is parsed as a
+    markdown subset (headings, bold/italic, code spans + fences,
+    bullet/ordered lists, blockquotes, ``[text](url)`` links) and
+    emitted as proper ADF nodes; bare URLs in text are still
+    auto-linkified so plain-text payloads round-trip unchanged. The
+    SPEC §9 prefix is added at the driver layer.
+
+    Markdown support was added after #57 to fix the "agent emits
+    ``## Heading`` and Jira shows the literal hashes" bug. See
+    ``lib/markdown_adf.py`` for the supported subset.
     """
-    nodes = _text_to_inline_nodes(text) or [{"type": "text", "text": ""}]
-    return {
-        "type": "doc",
-        "version": 1,
-        "content": [
-            {"type": "paragraph", "content": nodes},
-        ],
-    }
+    # Local import — markdown_adf is a sibling lib module. Imported at
+    # call time so the import graph stays acyclic if either module
+    # grows additional cross-references later.
+    from lib.markdown_adf import markdown_to_adf
+    return markdown_to_adf(text or "")
 
 
 def adf_to_text(adf: dict[str, Any] | None) -> str:
@@ -577,14 +580,24 @@ def text_to_adf_with_mention(
 ) -> dict[str, Any]:
     """Build an ADF doc that prepends `prefix_text` (as its own paragraph,
     rendered bold) then a paragraph that begins with an @-mention node
-    followed by ` body_text`.
+    followed by the reply body.
 
     Used by /kanban:reply so the bot's reply notifies the human via Jira's
     native mention plumbing. Empty `prefix_text` collapses the prefix
     paragraph (used when caller already wrapped the prefix elsewhere). The
-    prefix renders as bold via an ADF `strong` mark — ADF doesn't parse
-    markdown, so emitting `**...**` literals would render verbatim (#27).
+    prefix renders as bold via an ADF `strong` mark — markdown in
+    `prefix_text` is intentionally NOT parsed because the SPEC §9 prefix
+    text is fixed-shape and rendering ``**...**`` literally there would
+    show stars instead of bold (#27).
+
+    The reply body, by contrast, IS parsed as markdown (subset documented
+    in `lib/markdown_adf.py`). When the body is a single paragraph it
+    sits inline with the @mention chip — preserving the chat-bubble
+    look. Multi-paragraph / list / code-fence bodies put the mention on
+    its own paragraph and emit the body's blocks as siblings, so
+    structured replies render correctly.
     """
+    from lib.markdown_adf import markdown_to_adf
     content: list[dict[str, Any]] = []
     if prefix_text:
         content.append({
@@ -595,31 +608,41 @@ def text_to_adf_with_mention(
                 "marks": [{"type": "strong"}],
             }],
         })
-    body_para: dict[str, Any] = {
-        "type": "paragraph",
-        "content": [
-            {
-                "type": "mention",
-                "attrs": {
-                    "id": mention_account_id,
-                    "text": f"@{mention_display}" if mention_display else "@",
-                },
-            },
-        ],
+    mention_node = {
+        "type": "mention",
+        "attrs": {
+            "id": mention_account_id,
+            "text": f"@{mention_display}" if mention_display else "@",
+        },
     }
-    if body_text:
-        # Leading space separates the mention chip from the body text.
-        # Merge it into the first plain-text inline node when possible
-        # (avoids fragmenting ADF into [" ", text] when [" text"] is
-        # equivalent and matches existing test expectations); fall back
-        # to a standalone space node when the body starts with a
-        # link-marked URL.
-        nodes = _text_to_inline_nodes(body_text)
-        if nodes and not nodes[0].get("marks"):
-            nodes[0]["text"] = " " + nodes[0]["text"]
-            body_para["content"].extend(nodes)
-        elif nodes:
-            body_para["content"].append({"type": "text", "text": " "})
-            body_para["content"].extend(nodes)
-    content.append(body_para)
+    if not body_text:
+        content.append({"type": "paragraph", "content": [mention_node]})
+        return {"type": "doc", "version": 1, "content": content}
+
+    body_doc = markdown_to_adf(body_text)
+    body_blocks = body_doc.get("content") or []
+    first = body_blocks[0] if body_blocks else None
+
+    if first and first.get("type") == "paragraph" and len(body_blocks) == 1:
+        # Single-paragraph reply — inline next to the mention chip with
+        # a leading space. Merge the space into the first inline text
+        # node when possible (avoids fragmenting ADF into [" ", text]
+        # for the common single-line case).
+        inline_nodes = list(first.get("content") or [])
+        merged: list[dict[str, Any]] = [mention_node]
+        if inline_nodes and inline_nodes[0].get("type") == "text" and not inline_nodes[0].get("marks"):
+            inline_nodes[0] = dict(inline_nodes[0])
+            inline_nodes[0]["text"] = " " + inline_nodes[0]["text"]
+            merged.extend(inline_nodes)
+        else:
+            merged.append({"type": "text", "text": " "})
+            merged.extend(inline_nodes)
+        content.append({"type": "paragraph", "content": merged})
+    else:
+        # Multi-block reply (lists, code fences, multiple paragraphs).
+        # Put the mention alone, then emit body blocks as siblings so
+        # each renders with its proper ADF shape.
+        content.append({"type": "paragraph", "content": [mention_node]})
+        content.extend(body_blocks)
+
     return {"type": "doc", "version": 1, "content": content}

--- a/plugins/kanban/lib/markdown_adf.py
+++ b/plugins/kanban/lib/markdown_adf.py
@@ -1,0 +1,436 @@
+"""Convert a markdown subset to Atlassian Document Format (ADF) — fix
+for the "agent writes markdown, Jira shows raw `##`" bug filed after
+#57.
+
+Why this exists
+---------------
+
+Jira Cloud renders the Atlassian Document Format (ADF), not markdown.
+Posting ``"## Heading"`` as the body of a comment or description shows
+literal ``"## Heading"`` text — the user sees the markdown source
+instead of a styled heading. Claude-Code agents emit markdown freely
+(headings, lists, code fences), so the kanban plugin needs to translate
+that to ADF before posting.
+
+Earlier flows side-stepped this by ADF-encoding only specific known
+chunks — for example, the SPEC §9 prefix on replies was wrapped in
+``strong`` marks server-side (#27) precisely because ``**...**``
+literals would render verbatim. This module generalizes that fix to
+the entire body.
+
+Supported subset
+----------------
+
+* Headings: ``#`` … ``######`` (h1–h6). The hash chars + a single
+  required space, then the heading text.
+* Paragraphs (default for any non-block text).
+* Inline marks:
+
+  - Bold: ``**text**`` or ``__text__``
+  - Italic: ``*text*`` or ``_text_``
+  - Inline code: ``\`text\``` (single backticks)
+  - Links: ``[text](https://url)``
+  - Bare URLs in text are still auto-linkified (so ``"see
+    https://x.com"`` produces a clickable link, matching pre-bugfix
+    behavior).
+
+* Fenced code blocks: triple backticks, optional language tag on the
+  opener (``` ```python ``` ``` … ``` ``` ``` ```).
+* Bullet lists: lines starting with ``- ``, ``* ``, or ``+ ``.
+* Ordered lists: lines starting with ``N. ``.
+* Blockquotes: lines starting with ``> ``.
+
+Out of scope (would require a real CommonMark parser)
+-----------------------------------------------------
+
+* Tables, setext-style headings, reference links, HTML passthrough,
+  escape sequences (``\\*``), thematic breaks (``---``).
+* Nested lists — a sub-list indents back to top level. Agents that
+  need indented structure should use multi-paragraph items.
+* Hard breaks via trailing whitespace — newlines inside a paragraph
+  are joined with a single space (matches how most markdown renderers
+  treat a soft break).
+
+Inputs that contain no markdown markers fall through as a single
+paragraph with URL auto-linkification — the same shape ``text_to_adf``
+emitted before this module existed, so the upgrade is invisible to
+plain-text callers.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# URL detector — identical to the one in jira_client._text_to_inline_nodes
+# so bare-URL auto-linkification stays consistent across both module
+# boundaries. Conservative on tail punctuation: a URL at end of sentence
+# ("see https://x.com.") doesn't swallow the period; a URL inside parens
+# or quotes doesn't pull the closing bracket in.
+_URL_RE = re.compile(r"https?://[^\s<>\"\)\]]+")
+
+# Heading: 1–6 leading hashes, then a space, then content. The trailing
+# `\s*` lets us tolerate a stray training space on the line. Skipping
+# the "no space after hashes" form (`#foo`) is intentional — it matches
+# CommonMark and avoids treating `#1` (which agents use as an issue
+# anchor) as a heading.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+
+# List markers. Bullet markers accept any of `-`, `*`, `+`; ordered
+# markers accept `N.` for any positive integer (we don't preserve the
+# starting number in the rendered list — ADF orderedList re-numbers
+# from 1 anyway).
+_BULLET_RE = re.compile(r"^(\s*)([-*+])\s+(.*)$")
+_ORDERED_RE = re.compile(r"^(\s*)(\d+)\.\s+(.*)$")
+
+# Blockquote: `>` optionally followed by a space and content. Empty `>`
+# is allowed (paragraph separator inside a quote).
+_BLOCKQUOTE_RE = re.compile(r"^>\s?(.*)$")
+
+# Fenced code block opener / closer. We accept three or more backticks
+# and an optional language tag. The closing fence must match the same
+# fence char and have at least as many of them.
+_FENCE_RE = re.compile(r"^(```+)\s*([^\s`]*)\s*$")
+
+# Inline patterns. Tried in priority order; first match (closest to the
+# scan cursor) wins. Code is highest priority because backticks suppress
+# all other formatting inside them. Link beats emphasis because `[**x**]`
+# should still produce a link, not bold-then-bracketed.
+_INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
+_INLINE_LINK_RE = re.compile(r"\[([^\]\n]+)\]\(([^)\s]+)\)")
+_INLINE_STRONG_RE = re.compile(r"\*\*([^*\n]+?)\*\*")
+_INLINE_STRONG_US_RE = re.compile(r"__([^_\n]+?)__")
+_INLINE_EM_RE = re.compile(r"(?<![*\w])\*([^*\n]+?)\*(?!\w)")
+_INLINE_EM_US_RE = re.compile(r"(?<![_\w])_([^_\n]+?)_(?!\w)")
+
+
+# --- public surface -----------------------------------------------------
+
+
+def markdown_to_adf(text: str) -> dict[str, Any]:
+    """Parse `text` as a markdown subset and return a full ADF doc.
+
+    Always returns a well-formed doc — empty input produces a doc with
+    a single empty paragraph (matches the pre-bugfix shape so the API
+    surface is consistent).
+    """
+    blocks = _parse_blocks(text or "")
+    content = [_block_to_adf(b) for b in blocks]
+    if not content:
+        content = [{"type": "paragraph", "content": [{"type": "text", "text": ""}]}]
+    return {"type": "doc", "version": 1, "content": content}
+
+
+def inline_to_adf(text: str) -> list[dict[str, Any]]:
+    """Parse `text` as inline-only markdown and return a list of ADF
+    inline nodes (text + link/strong/em/code marks).
+
+    Used when the caller has already built the surrounding block
+    structure — for example, the body of a /kanban:reply lives in the
+    same paragraph as the @mention chip, so it can't introduce its own
+    block-level nodes. Newlines collapse to spaces in this mode.
+    """
+    flat = " ".join(line.strip() for line in (text or "").splitlines() if line.strip())
+    return _inline_to_nodes(flat)
+
+
+# --- block parsing ------------------------------------------------------
+
+
+def _parse_blocks(text: str) -> list[tuple[str, Any]]:
+    """Walk `text` line-by-line, grouping lines into block descriptors.
+
+    Each descriptor is a tuple ``(kind, payload)`` consumed by
+    `_block_to_adf`. We do block parsing as a separate pass from ADF
+    generation so the inline parser doesn't have to re-discover block
+    boundaries.
+    """
+    lines = text.split("\n")
+    i = 0
+    blocks: list[tuple[str, Any]] = []
+    while i < len(lines):
+        line = lines[i]
+
+        # Blank lines are paragraph/block separators — skip them.
+        if not line.strip():
+            i += 1
+            continue
+
+        # Fenced code block. Capture until the matching closer; if no
+        # closer found, treat all remaining text as the block (matches
+        # how renderers behave on truncated fences).
+        fence = _FENCE_RE.match(line)
+        if fence:
+            fence_chars, lang = fence.group(1), fence.group(2)
+            i += 1
+            code_lines: list[str] = []
+            while i < len(lines):
+                if lines[i].startswith(fence_chars):
+                    i += 1
+                    break
+                code_lines.append(lines[i])
+                i += 1
+            blocks.append(("code_block", {"lang": lang, "code": "\n".join(code_lines)}))
+            continue
+
+        # Heading (single line).
+        m = _HEADING_RE.match(line)
+        if m:
+            level = len(m.group(1))
+            blocks.append(("heading", {"level": level, "text": m.group(2)}))
+            i += 1
+            continue
+
+        # Blockquote — gather contiguous `>`-prefixed lines.
+        if _BLOCKQUOTE_RE.match(line):
+            quote_lines: list[str] = []
+            while i < len(lines):
+                qm = _BLOCKQUOTE_RE.match(lines[i])
+                if not qm:
+                    break
+                quote_lines.append(qm.group(1))
+                i += 1
+            blocks.append(("blockquote", "\n".join(quote_lines)))
+            continue
+
+        # Bullet list — gather contiguous bullet items at the same
+        # (top-level) indent. Indented sub-items get folded into the
+        # parent item's text (we don't model nested lists in v1).
+        if _BULLET_RE.match(line):
+            items, i = _collect_list(lines, i, _BULLET_RE)
+            blocks.append(("bullet_list", items))
+            continue
+
+        # Ordered list — same logic as bullet, different marker.
+        if _ORDERED_RE.match(line):
+            items, i = _collect_list(lines, i, _ORDERED_RE)
+            blocks.append(("ordered_list", items))
+            continue
+
+        # Paragraph — consume contiguous non-blank lines that don't
+        # start another block. Soft newlines join with a single space.
+        para_lines: list[str] = []
+        while i < len(lines):
+            cur = lines[i]
+            if not cur.strip():
+                break
+            if _starts_new_block(cur):
+                break
+            para_lines.append(cur.strip())
+            i += 1
+        if para_lines:
+            blocks.append(("paragraph", " ".join(para_lines)))
+
+    return blocks
+
+
+def _starts_new_block(line: str) -> bool:
+    """Cheap check: would this line open a new block (and so terminate
+    the current paragraph)? Mirrors the dispatch order in
+    `_parse_blocks` so a paragraph stops at the first block-starter."""
+    if _FENCE_RE.match(line):
+        return True
+    if _HEADING_RE.match(line):
+        return True
+    if _BLOCKQUOTE_RE.match(line):
+        return True
+    if _BULLET_RE.match(line):
+        return True
+    if _ORDERED_RE.match(line):
+        return True
+    return False
+
+
+def _collect_list(lines: list[str], start: int, marker_re: re.Pattern) -> tuple[list[str], int]:
+    """Gather contiguous list items starting at `lines[start]` until a
+    line breaks the list (blank, different marker, or another block).
+
+    Returns (item_texts, next_index). Each item's text is what follows
+    the marker on its line; continuation lines that are indented (≥ 2
+    spaces) are folded into the previous item with a leading space.
+    """
+    items: list[str] = []
+    i = start
+    while i < len(lines):
+        line = lines[i]
+        m = marker_re.match(line)
+        if m:
+            items.append(m.group(3))
+            i += 1
+            continue
+        # Continuation: indented line attached to the previous item.
+        if items and line.startswith(("  ", "\t")) and line.strip():
+            items[-1] += " " + line.strip()
+            i += 1
+            continue
+        break
+    return items, i
+
+
+# --- block → ADF node ---------------------------------------------------
+
+
+def _block_to_adf(block: tuple[str, Any]) -> dict[str, Any]:
+    kind, payload = block
+    if kind == "heading":
+        return {
+            "type": "heading",
+            "attrs": {"level": payload["level"]},
+            "content": _inline_to_nodes(payload["text"]),
+        }
+    if kind == "paragraph":
+        return {"type": "paragraph", "content": _inline_to_nodes(payload)}
+    if kind == "code_block":
+        # ADF codeBlock requires at least one text child even when
+        # empty. The `language` attr is optional; we only set it when
+        # the fence carried a tag, so renderers default sensibly.
+        attrs: dict[str, Any] = {}
+        if payload.get("lang"):
+            attrs["language"] = payload["lang"]
+        node: dict[str, Any] = {
+            "type": "codeBlock",
+            "content": [{"type": "text", "text": payload.get("code", "")}],
+        }
+        if attrs:
+            node["attrs"] = attrs
+        return node
+    if kind == "blockquote":
+        # Blockquote wraps an inner paragraph (or paragraphs, when the
+        # quoted text contains blank lines). We re-run block parsing on
+        # the inner text to handle the multi-paragraph case.
+        inner_blocks = _parse_blocks(payload)
+        if not inner_blocks:
+            inner_blocks = [("paragraph", "")]
+        return {
+            "type": "blockquote",
+            "content": [_block_to_adf(b) for b in inner_blocks],
+        }
+    if kind in ("bullet_list", "ordered_list"):
+        adf_kind = "bulletList" if kind == "bullet_list" else "orderedList"
+        return {
+            "type": adf_kind,
+            "content": [
+                {
+                    "type": "listItem",
+                    "content": [{"type": "paragraph", "content": _inline_to_nodes(item)}],
+                }
+                for item in payload
+            ],
+        }
+    # Defensive — unknown block kind. Drop to a plain paragraph so we
+    # never emit a malformed ADF tree that fails server-side validation.
+    return {"type": "paragraph", "content": [{"type": "text", "text": str(payload)}]}
+
+
+# --- inline parsing -----------------------------------------------------
+
+
+def _inline_to_nodes(text: str) -> list[dict[str, Any]]:
+    """Parse `text` as inline markdown and return ADF text nodes with
+    appropriate marks. Always returns at least one node (an empty text
+    node) so consumers can rely on a non-empty list."""
+    if not text:
+        return [{"type": "text", "text": ""}]
+    out: list[dict[str, Any]] = []
+    _scan_inline(text, [], out)
+    if not out:
+        out = [{"type": "text", "text": ""}]
+    return out
+
+
+def _scan_inline(text: str, marks: list[dict[str, Any]], out: list[dict[str, Any]]) -> None:
+    """Recursive-descent inline scanner. `marks` is the stack of marks
+    currently in effect (passed down when we enter a strong/em region);
+    matched leaves (text spans, code, links) are appended to `out`.
+
+    The algorithm: find the earliest match across all inline patterns.
+    Whatever's before that match is plain text (subject to URL
+    auto-linkification). The match itself is converted to a node
+    (or recursed-into for strong/em), then we continue from the end of
+    the match.
+    """
+    pos = 0
+    while pos < len(text):
+        match = _find_earliest_inline(text, pos)
+        if match is None:
+            _emit_text_span(text[pos:], marks, out)
+            return
+        kind, span_start, span_end, payload = match
+        if span_start > pos:
+            _emit_text_span(text[pos:span_start], marks, out)
+        if kind == "code":
+            out.append({
+                "type": "text",
+                "text": payload,
+                "marks": [*marks, {"type": "code"}],
+            })
+        elif kind == "link":
+            label, href = payload
+            # Link contents go through inline parsing too (so
+            # `[**bold**](u)` renders a bold-inside-link). The link
+            # mark stacks on top of any inherited marks.
+            _scan_inline(label, [*marks, {"type": "link", "attrs": {"href": href}}], out)
+        elif kind == "strong":
+            _scan_inline(payload, [*marks, {"type": "strong"}], out)
+        elif kind == "em":
+            _scan_inline(payload, [*marks, {"type": "em"}], out)
+        pos = span_end
+
+
+def _find_earliest_inline(text: str, start: int) -> tuple[str, int, int, Any] | None:
+    """Look for the earliest inline marker at-or-after `start`. Ties
+    are broken by priority (code > link > strong > em) so e.g.
+    ``**\`foo\`**`` parses as strong(code(foo)), not code-with-stars.
+    """
+    candidates: list[tuple[int, int, str, int, int, Any]] = []
+    for prio, (kind, pattern, extractor) in enumerate([
+        ("code", _INLINE_CODE_RE, lambda m: m.group(1)),
+        ("link", _INLINE_LINK_RE, lambda m: (m.group(1), m.group(2))),
+        ("strong", _INLINE_STRONG_RE, lambda m: m.group(1)),
+        ("strong", _INLINE_STRONG_US_RE, lambda m: m.group(1)),
+        ("em", _INLINE_EM_RE, lambda m: m.group(1)),
+        ("em", _INLINE_EM_US_RE, lambda m: m.group(1)),
+    ]):
+        m = pattern.search(text, start)
+        if m:
+            candidates.append((m.start(), prio, kind, m.start(), m.end(), extractor(m)))
+    if not candidates:
+        return None
+    candidates.sort()  # earliest match wins; ties broken by priority
+    _, _, kind, s, e, payload = candidates[0]
+    return kind, s, e, payload
+
+
+def _emit_text_span(text: str, marks: list[dict[str, Any]], out: list[dict[str, Any]]) -> None:
+    """Emit a plain-text span (possibly carrying inherited marks) with
+    bare URLs split out into link-marked sub-nodes. Empty spans are
+    dropped — ADF doesn't reject them, but they bulk up the tree
+    needlessly."""
+    if not text:
+        return
+    pos = 0
+    for m in _URL_RE.finditer(text):
+        if m.start() > pos:
+            out.append(_text_node(text[pos:m.start()], marks))
+        url = m.group(0)
+        trailer = ""
+        while url and url[-1] in ".,;:!?":
+            trailer = url[-1] + trailer
+            url = url[:-1]
+        if url:
+            # The auto-linkified URL stacks a link mark on top of any
+            # inherited marks (so a bare URL inside **bold** stays
+            # bold-and-linked).
+            out.append(_text_node(url, [*marks, {"type": "link", "attrs": {"href": url}}]))
+        if trailer:
+            out.append(_text_node(trailer, marks))
+        pos = m.end()
+    if pos < len(text):
+        out.append(_text_node(text[pos:], marks))
+
+
+def _text_node(text: str, marks: list[dict[str, Any]]) -> dict[str, Any]:
+    node: dict[str, Any] = {"type": "text", "text": text}
+    if marks:
+        node["marks"] = list(marks)
+    return node

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34; do  # …33: mutation primitives (#55), 34: versioned board config (#57)
+for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35; do  # …34: versioned board config (#57), 35: markdown → ADF
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase35.py
+++ b/plugins/kanban/scripts/test_phase35.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Phase 35 regression checks for kanban v0.3.30 — markdown → ADF
+(bug filed after #57).
+
+Background: agents emit markdown freely (headings, lists, code,
+links), but `text_to_adf` used to wrap everything as one flat
+paragraph — Jira UI then showed the literal markdown (`## Heading`
+instead of a styled h2). This phase verifies the new
+`lib/markdown_adf.py` parser produces the right ADF shapes for each
+markdown construct, that the existing call sites (`text_to_adf`,
+`text_to_adf_with_mention`) now route through it, and that plain-text
+payloads stay equivalent to the old single-paragraph + URL-auto-link
+behavior so callers that don't use markdown see no regression.
+
+Cases:
+  (a) Heading levels 1–6 → `heading` nodes with the matching `level`.
+  (b) Bold (`**x**` and `__x__`) → text with a `strong` mark.
+  (c) Italic (`*x*` and `_x_`) → text with an `em` mark.
+  (d) Inline code (`\`x\``) → text with a `code` mark.
+  (e) Fenced code block, with and without language tag.
+  (f) Bullet list (mixed `-`, `*`, `+` markers across items).
+  (g) Ordered list (1. 2. 3.).
+  (h) Blockquote, including multi-line.
+  (i) Inline link `[text](url)` and bare-URL auto-link inside a
+      paragraph coexist.
+  (j) Plain-text input round-trips: no markdown markers ⇒ a single
+      paragraph with the original text (same shape as the pre-fix
+      `text_to_adf`).
+  (k) Mixed multi-block document: heading + paragraph + bullet list
+      + code block produces blocks in document order.
+  (l) `text_to_adf_with_mention` single-line body inlines next to the
+      mention chip (preserves chat-bubble look).
+  (m) `text_to_adf_with_mention` multi-block body splits: mention sits
+      alone in its paragraph, body blocks come after as siblings.
+  (n) `text_to_adf_with_mention` prefix is NOT markdown-parsed —
+      `**...**` in the prefix would render verbatim, so the prefix
+      stays whole + carries a `strong` mark (preserves #27 behavior).
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+PLUGIN = REPO / "plugins" / "kanban"
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from lib.jira_client import text_to_adf, text_to_adf_with_mention  # noqa: E402
+from lib.markdown_adf import markdown_to_adf, inline_to_adf  # noqa: E402
+
+
+def _blocks(doc):
+    return doc.get("content") or []
+
+
+def _first_block(doc):
+    blocks = _blocks(doc)
+    assert blocks, doc
+    return blocks[0]
+
+
+def _text_in(node):
+    """Concatenate all text nodes inside `node` (recursive)."""
+    out = []
+
+    def walk(n):
+        if isinstance(n, dict):
+            if n.get("type") == "text":
+                out.append(n.get("text", ""))
+            for c in n.get("content", []) or []:
+                walk(c)
+        elif isinstance(n, list):
+            for c in n:
+                walk(c)
+    walk(node)
+    return "".join(out)
+
+
+def _has_mark(node, mark_type):
+    return any(m.get("type") == mark_type for m in (node.get("marks") or []))
+
+
+# --- (a) headings --------------------------------------------------------
+
+
+def test_headings_levels_1_to_6():
+    for lvl in range(1, 7):
+        md = "#" * lvl + " Title " + str(lvl)
+        doc = markdown_to_adf(md)
+        b = _first_block(doc)
+        assert b["type"] == "heading", b
+        assert b["attrs"]["level"] == lvl, (lvl, b)
+        assert _text_in(b) == f"Title {lvl}"
+
+
+def test_heading_requires_space_after_hashes():
+    """`#foo` (no space) is NOT a heading — would otherwise mis-parse
+    issue refs like ``#123`` as h1."""
+    doc = markdown_to_adf("#123 is the issue")
+    b = _first_block(doc)
+    assert b["type"] == "paragraph", b
+
+
+# --- (b) (c) (d) inline marks -------------------------------------------
+
+
+def test_bold_star_and_underscore():
+    for md in ("**bold**", "__bold__"):
+        doc = markdown_to_adf(md)
+        b = _first_block(doc)
+        assert b["type"] == "paragraph"
+        inline = b["content"][0]
+        assert inline["text"] == "bold"
+        assert _has_mark(inline, "strong"), (md, inline)
+
+
+def test_italic_star_and_underscore():
+    for md in ("*italic*", "_italic_"):
+        doc = markdown_to_adf(md)
+        inline = _first_block(doc)["content"][0]
+        assert inline["text"] == "italic"
+        assert _has_mark(inline, "em"), (md, inline)
+
+
+def test_inline_code():
+    doc = markdown_to_adf("see `foo.bar()` here")
+    inline = _first_block(doc)["content"]
+    code_node = next(n for n in inline if n.get("text") == "foo.bar()")
+    assert _has_mark(code_node, "code")
+    # Surrounding text stays plain.
+    others = [n for n in inline if not _has_mark(n, "code")]
+    assert any("see " in n["text"] for n in others)
+    assert any(" here" in n["text"] for n in others)
+
+
+def test_bold_inside_text():
+    """Bold sandwiched between plain text: plain + strong + plain."""
+    doc = markdown_to_adf("plain **bold** plain")
+    nodes = _first_block(doc)["content"]
+    assert nodes[0]["text"] == "plain "
+    assert not nodes[0].get("marks")
+    assert nodes[1]["text"] == "bold"
+    assert _has_mark(nodes[1], "strong")
+    assert nodes[2]["text"] == " plain"
+
+
+# --- (e) code blocks ----------------------------------------------------
+
+
+def test_code_block_with_language():
+    md = "```python\nprint('x')\n```"
+    doc = markdown_to_adf(md)
+    b = _first_block(doc)
+    assert b["type"] == "codeBlock"
+    assert b["attrs"]["language"] == "python"
+    assert _text_in(b) == "print('x')"
+
+
+def test_code_block_without_language():
+    md = "```\nplain\n```"
+    doc = markdown_to_adf(md)
+    b = _first_block(doc)
+    assert b["type"] == "codeBlock"
+    # `attrs` may be omitted when no language tag.
+    assert "language" not in (b.get("attrs") or {})
+    assert _text_in(b) == "plain"
+
+
+# --- (f) (g) lists ------------------------------------------------------
+
+
+def test_bullet_list_mixed_markers():
+    md = "- one\n* two\n+ three"
+    doc = markdown_to_adf(md)
+    b = _first_block(doc)
+    assert b["type"] == "bulletList"
+    items = b["content"]
+    assert [_text_in(it) for it in items] == ["one", "two", "three"]
+    # Each item is a listItem wrapping a paragraph.
+    for it in items:
+        assert it["type"] == "listItem"
+        assert it["content"][0]["type"] == "paragraph"
+
+
+def test_ordered_list():
+    md = "1. first\n2. second\n3. third"
+    doc = markdown_to_adf(md)
+    b = _first_block(doc)
+    assert b["type"] == "orderedList"
+    items = b["content"]
+    assert [_text_in(it) for it in items] == ["first", "second", "third"]
+
+
+def test_list_items_carry_inline_marks():
+    """`- **bold** item` ⇒ listItem > paragraph > [strong("bold"),
+    " item"]."""
+    doc = markdown_to_adf("- **bold** item")
+    item_para = _first_block(doc)["content"][0]["content"][0]
+    nodes = item_para["content"]
+    assert nodes[0]["text"] == "bold"
+    assert _has_mark(nodes[0], "strong")
+    assert nodes[1]["text"] == " item"
+
+
+# --- (h) blockquote -----------------------------------------------------
+
+
+def test_blockquote_single_line():
+    doc = markdown_to_adf("> a quote")
+    b = _first_block(doc)
+    assert b["type"] == "blockquote"
+    assert _text_in(b) == "a quote"
+
+
+def test_blockquote_multi_line():
+    doc = markdown_to_adf("> line one\n> line two")
+    b = _first_block(doc)
+    assert b["type"] == "blockquote"
+    # The two lines should be joined into one paragraph inside the quote.
+    inner = b["content"]
+    assert inner[0]["type"] == "paragraph"
+    assert _text_in(b) == "line one line two"
+
+
+# --- (i) links and URLs -------------------------------------------------
+
+
+def test_explicit_link_and_bare_url_coexist():
+    md = "click [here](https://example.com) or see https://other.com/x"
+    doc = markdown_to_adf(md)
+    nodes = _first_block(doc)["content"]
+    # Explicit link
+    link_nodes = [n for n in nodes if _has_mark(n, "link")]
+    assert any(n["text"] == "here" for n in link_nodes)
+    here = next(n for n in link_nodes if n["text"] == "here")
+    href = next(m for m in here["marks"] if m["type"] == "link")["attrs"]["href"]
+    assert href == "https://example.com"
+    # Bare URL auto-linkified
+    assert any(n["text"] == "https://other.com/x" for n in link_nodes)
+
+
+def test_url_with_trailing_punctuation_stripped():
+    """A trailing `.` belongs to the sentence, not the URL — pre-fix
+    behavior preserved (#57's _text_to_inline_nodes logic carried into
+    the markdown parser)."""
+    doc = markdown_to_adf("see https://x.com.")
+    nodes = _first_block(doc)["content"]
+    url_node = next(n for n in nodes if _has_mark(n, "link"))
+    assert url_node["text"] == "https://x.com"
+
+
+# --- (j) plain-text round-trip ------------------------------------------
+
+
+def test_plain_text_unchanged_shape():
+    """Input with no markdown markers produces one paragraph with the
+    original text — equivalent to pre-fix `text_to_adf`."""
+    doc = text_to_adf("just plain words here")
+    blocks = _blocks(doc)
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "paragraph"
+    assert _text_in(doc) == "just plain words here"
+
+
+def test_empty_input_yields_empty_paragraph():
+    doc = text_to_adf("")
+    blocks = _blocks(doc)
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "paragraph"
+
+
+# --- (k) mixed document --------------------------------------------------
+
+
+def test_mixed_document_block_order():
+    md = """# Title
+
+Intro paragraph with **bold**.
+
+- one
+- two
+
+```sh
+echo hi
+```"""
+    doc = markdown_to_adf(md)
+    blocks = _blocks(doc)
+    types = [b["type"] for b in blocks]
+    assert types == ["heading", "paragraph", "bulletList", "codeBlock"], types
+    assert blocks[0]["attrs"]["level"] == 1
+    assert _text_in(blocks[1]) == "Intro paragraph with bold."
+    assert [_text_in(it) for it in blocks[2]["content"]] == ["one", "two"]
+    assert _text_in(blocks[3]) == "echo hi"
+
+
+# --- (l) (m) text_to_adf_with_mention body parsing ----------------------
+
+
+def test_mention_single_line_body_inlines_with_chip():
+    """Common case: short reply inlines next to the @mention chip in
+    a single paragraph (preserves chat-bubble look)."""
+    doc = text_to_adf_with_mention(
+        prefix_text="SPEC §9: agent reply",
+        mention_account_id="alice-id",
+        mention_display="Alice",
+        body_text="thanks for the heads-up",
+    )
+    blocks = _blocks(doc)
+    # prefix paragraph + body paragraph
+    assert len(blocks) == 2
+    body_para = blocks[1]
+    assert body_para["type"] == "paragraph"
+    types = [n["type"] for n in body_para["content"]]
+    assert types[0] == "mention"
+    # Body text follows the mention as plain text nodes (no separate
+    # leading-space node since we merged the space into the first text).
+    assert _text_in(body_para).replace("@Alice", "").strip() == "thanks for the heads-up"
+
+
+def test_mention_multi_block_body_splits():
+    """Body with a heading + list ⇒ mention sits alone, body blocks
+    follow as siblings so each renders with its proper ADF shape."""
+    body = "## Plan\n\n- step one\n- step two"
+    doc = text_to_adf_with_mention(
+        prefix_text="",
+        mention_account_id="alice-id",
+        mention_display="Alice",
+        body_text=body,
+    )
+    blocks = _blocks(doc)
+    # Mention paragraph + heading + bulletList = 3 blocks (no prefix).
+    types = [b["type"] for b in blocks]
+    assert types == ["paragraph", "heading", "bulletList"], types
+    # The mention paragraph contains ONLY the mention chip (no inline
+    # body text), since the body was multi-block.
+    mention_para = blocks[0]
+    assert len(mention_para["content"]) == 1
+    assert mention_para["content"][0]["type"] == "mention"
+    # Heading carries the level.
+    assert blocks[1]["attrs"]["level"] == 2
+
+
+def test_mention_prefix_stays_literal_not_markdown_parsed():
+    """The SPEC §9 prefix is intentionally NOT markdown-parsed — it's
+    a fixed-shape label that renders as bold via an explicit ADF
+    `strong` mark (#27). Markdown in prefix_text would render literally
+    (and that's correct: the prefix shouldn't contain markdown)."""
+    doc = text_to_adf_with_mention(
+        prefix_text="**not parsed as bold**",
+        mention_account_id="alice-id",
+        mention_display="Alice",
+        body_text="hi",
+    )
+    prefix_para = _blocks(doc)[0]
+    assert prefix_para["type"] == "paragraph"
+    # The literal asterisks survive; the whole thing carries one strong mark.
+    inline = prefix_para["content"][0]
+    assert inline["text"] == "**not parsed as bold**"
+    assert _has_mark(inline, "strong")
+
+
+# --- (n) inline_to_adf helper -------------------------------------------
+
+
+def test_inline_to_adf_returns_inline_nodes_only():
+    """`inline_to_adf` is the entry point for callers that already
+    have their own block structure (e.g. when building a paragraph
+    that should sit next to a mention chip)."""
+    nodes = inline_to_adf("plain **bold** and `code`")
+    # Three nodes: "plain ", strong("bold"), " and ", code("code")
+    # (depending on tokenizer's text-merging behavior; assert by mark
+    # rather than exact node count).
+    assert any(_has_mark(n, "strong") and n["text"] == "bold" for n in nodes)
+    assert any(_has_mark(n, "code") and n["text"] == "code" for n in nodes)
+
+
+def main() -> int:
+    cases = [
+        ("headings_levels_1_to_6", test_headings_levels_1_to_6),
+        ("heading_requires_space_after_hashes",
+         test_heading_requires_space_after_hashes),
+        ("bold_star_and_underscore", test_bold_star_and_underscore),
+        ("italic_star_and_underscore", test_italic_star_and_underscore),
+        ("inline_code", test_inline_code),
+        ("bold_inside_text", test_bold_inside_text),
+        ("code_block_with_language", test_code_block_with_language),
+        ("code_block_without_language", test_code_block_without_language),
+        ("bullet_list_mixed_markers", test_bullet_list_mixed_markers),
+        ("ordered_list", test_ordered_list),
+        ("list_items_carry_inline_marks",
+         test_list_items_carry_inline_marks),
+        ("blockquote_single_line", test_blockquote_single_line),
+        ("blockquote_multi_line", test_blockquote_multi_line),
+        ("explicit_link_and_bare_url_coexist",
+         test_explicit_link_and_bare_url_coexist),
+        ("url_with_trailing_punctuation_stripped",
+         test_url_with_trailing_punctuation_stripped),
+        ("plain_text_unchanged_shape", test_plain_text_unchanged_shape),
+        ("empty_input_yields_empty_paragraph",
+         test_empty_input_yields_empty_paragraph),
+        ("mixed_document_block_order", test_mixed_document_block_order),
+        ("mention_single_line_body_inlines_with_chip",
+         test_mention_single_line_body_inlines_with_chip),
+        ("mention_multi_block_body_splits",
+         test_mention_multi_block_body_splits),
+        ("mention_prefix_stays_literal_not_markdown_parsed",
+         test_mention_prefix_stays_literal_not_markdown_parsed),
+        ("inline_to_adf_returns_inline_nodes_only",
+         test_inline_to_adf_returns_inline_nodes_only),
+    ]
+    failed = 0
+    for name, fn in cases:
+        try:
+            fn()
+        except Exception as e:
+            print(f"FAIL  {name}: {e}", file=sys.stderr)
+            failed += 1
+        else:
+            print(f"ok    {name}")
+    if failed:
+        print(f"phase35: {failed} failure(s)", file=sys.stderr)
+        return 1
+    print("phase35: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes the bug reported after #57: agents emit markdown (`## Heading`, `- list`, fenced code) but Jira showed the literal source instead of styled blocks, because `text_to_adf` was wrapping everything in a single flat paragraph.

## Summary
- New `lib/markdown_adf.py` parses a markdown subset → proper ADF nodes (headings, bold/italic/code, fenced code blocks, bullet & ordered lists, blockquotes, `[text](url)` links).
- `text_to_adf()` now routes through it. Plain-text input still produces the same single-paragraph + URL-auto-link shape as before, so non-markdown payloads see zero regression.
- `text_to_adf_with_mention()` body markdown-parses too. Single-paragraph bodies inline with the @mention chip (chat-bubble look preserved); multi-block bodies put the mention alone and emit body blocks as siblings so lists / code fences render correctly.
- SPEC §9 prefix (#27) intentionally stays literal — it's a fixed-shape bold label, not user-supplied markdown.

## Files
- `lib/markdown_adf.py` (new) — stdlib-only parser, ~350 LOC.
- `lib/jira_client.py` — `text_to_adf` and the body branch of `text_to_adf_with_mention` delegate to the new module.
- `scripts/test_phase35.py` (new) — 22 cases covering every supported markdown construct, plain-text round-trip, mention single-line vs multi-block routing, and prefix-stays-literal.
- `plugin.json` + `marketplace.json` → `0.3.30`; CHANGELOG entry.

## Out of scope
Tables, setext-style headings, reference links, nested lists, escape sequences, HTML passthrough — would need a real CommonMark parser. Documented as such in `markdown_adf.py`.

## Test plan
- [x] `bash plugins/kanban/scripts/test_all.sh` — all 35 phases pass (phase 2 ADF round-trip unchanged, phase 35 new).
- [ ] Manual: on a real Jira project, post a comment / edit a description containing `## Heading`, a bullet list, and a fenced code block — confirm styled rendering in Jira UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)