### PR TITLE
feat(chat): 0.1.0 — lightweight logged chat threads plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,14 @@
       "keywords": ["onboarding", "framework", "epic", "sprint", "issue", "adr", "workflow"]
     },
     {
+      "name": "chat",
+      "source": "./plugins/chat",
+      "version": "0.1.0",
+      "description": "Lightweight logged chat threads — record a conversation to doc/chat/, summarise to doc/note/, resume any time",
+      "category": "productivity",
+      "keywords": ["chat", "notes", "logging", "conversation"]
+    },
+    {
       "name": "workbench",
       "source": "./plugins/workbench",
       "version": "0.0.3",

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Claude Code local (session-specific permissions, not for sharing)
 .claude/settings.local.json
 
+# chat plugin — per-session runtime state (threads themselves live in doc/chat/)
+.claude/chat/
+
 # Runtime logs
 *.log
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+### Added
+- **chat 0.1.0** — new lightweight plugin for logged conversation threads.
+  `/chat:new` starts recording the session to `doc/chat/{name}.md` via a
+  `Stop` hook; `/chat:exit` stops; `/chat:note` summarises a thread into
+  `doc/note/`; `/chat:resume` re-opens a saved thread (by name, index, or
+  keyword). Chat mode is session-scoped — the `SessionEnd` hook clears it, so
+  it never leaks into the next session. Logging only; agent behaviour is
+  unchanged.
+
 ## 2026-05-16 (kanban markdown → ADF — bug after #57)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A family of Claude Code plugins that turn the CLI into a persistent, event-drive
 | [`notify`](./plugins/notify) | core | Push notifications (Pushover) when Claude needs your attention | **v0.1.1 ready** |
 | [`memory`](./plugins/memory) | core | Cross-session RAG memory (SQLite + embeddings, local only) | v0.0.1 stub |
 | [`mentor`](./plugins/mentor) | dev | Onboarding mentor — prescribes bootstrap docs, Epic/Sprint/Issue/ADR hierarchy, agent workflow (replaces `docsync`) | **v0.2.2 ready** |
+| [`chat`](./plugins/chat) | standalone | Logged conversation threads — record a chat to `doc/chat/`, summarise to `doc/note/`, resume any time | **v0.1.0 ready** |
 | [`workbench`](./plugins/workbench) | — | ★ Core bundle (kanban + notify + memory) | meta, stub |
 | [`workbench-dev`](./plugins/workbench-dev) | — | ★ Dev bundle (workbench + docsync) | meta, stub |
 
@@ -158,12 +159,13 @@ Per [`SPEC.md §13`](./SPEC.md):
 claude-workbench/
 ├── SPEC.md                             # design doc (workbench family)
 ├── current_state.md                    # implementation snapshot
-├── .claude-plugin/marketplace.json     # 6 plugin entries
+├── .claude-plugin/marketplace.json     # 7 plugin entries
 ├── plugins/
 │   ├── kanban/                         # v0.1.0 (ready)
 │   ├── notify/                         # v0.1.0 (ready — Pushover)
 │   ├── memory/                         # v0.0.1 (stub)
 │   ├── mentor/                         # v0.1.0 (ready — dev profile, replaces docsync)
+│   ├── chat/                           # v0.1.0 (ready — logged chat threads)
 │   ├── workbench/                      # v0.0.1 (meta stub)
 │   └── workbench-dev/                  # v0.0.1 (meta stub)
 └── schema/

--- a/README_zhtw.md
+++ b/README_zhtw.md
@@ -18,6 +18,7 @@
 | [`notify`](./plugins/notify) | core | 當 Claude 需要你回應時推播通知（Pushover） | **v0.1.1 可用** |
 | [`memory`](./plugins/memory) | core | 跨 session 的 RAG 記憶（SQLite + embeddings，純本機） | v0.0.1 stub |
 | [`mentor`](./plugins/mentor) | dev | Onboarding 顧問 — 規範 bootstrap 文件、Epic/Sprint/Issue/ADR 階層、agent 工作流程（取代 `docsync`） | **v0.2.2 可用** |
+| [`chat`](./plugins/chat) | 獨立 | 記錄式對話串 — 把對話寫進 `doc/chat/`、總結到 `doc/note/`、隨時續聊 | **v0.1.0 可用** |
 | [`workbench`](./plugins/workbench) | — | ★ 核心組合包（kanban + notify + memory） | meta，stub |
 | [`workbench-dev`](./plugins/workbench-dev) | — | ★ 開發者組合包（workbench + docsync） | meta，stub |
 
@@ -158,12 +159,13 @@ Claude 對 `kanban.json` **會做的**：
 claude-workbench/
 ├── SPEC.md                             # 設計文件（workbench 全家族）
 ├── current_state.md                    # 實作快照
-├── .claude-plugin/marketplace.json     # 6 個 plugin 條目
+├── .claude-plugin/marketplace.json     # 7 個 plugin 條目
 ├── plugins/
 │   ├── kanban/                         # v0.1.0（可用）
 │   ├── notify/                         # v0.1.0（可用 — Pushover）
 │   ├── memory/                         # v0.0.1（stub）
 │   ├── mentor/                         # v0.1.0（可用 — dev 分類，取代 docsync）
+│   ├── chat/                           # v0.1.0（可用 — 記錄式對話串）
 │   ├── workbench/                      # v0.0.1（meta stub）
 │   └── workbench-dev/                  # v0.0.1（meta stub）
 └── schema/

--- a/plugins/chat/.claude-plugin/plugin.json
+++ b/plugins/chat/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "chat",
+  "version": "0.1.0",
+  "description": "Lightweight logged chat threads for Claude Code — record a conversation to doc/chat/, summarise to doc/note/, resume any time.",
+  "author": { "name": "kirin" },
+  "homepage": "https://github.com/kirin/claude-workbench",
+  "license": "MIT"
+}

--- a/plugins/chat/README.md
+++ b/plugins/chat/README.md
@@ -1,0 +1,53 @@
+# chat
+
+Lightweight conversation threads for Claude Code. Start a chat, and every turn
+is logged to a markdown file you can re-read, summarise, and resume later.
+
+`chat` is **logging only** — it does not change how Claude behaves. "Chat mode"
+is just a per-session recording marker.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `/chat:new [name]` | Start a thread. Records this session to `doc/chat/{name}.md`. |
+| `/chat:exit` | Stop recording. The thread file is kept. |
+| `/chat:list` | List saved threads, newest first, marking the one recording now. |
+| `/chat:note [name]` | Summarise the active thread into `doc/note/{name}.md`. |
+| `/chat:resume <name\|N\|keyword>` | Re-open a saved thread and record into it again. |
+
+## How it works
+
+```
+/chat:new ──> doc/chat/{name}.md                 (thread, committed to git)
+          └─> .claude/chat/sessions/{id}.json     (session state, git-ignored)
+
+every turn ──> Stop hook ──> chat-logger.py ──> append to doc/chat/{name}.md
+```
+
+- The `Stop` hook appends user messages and Claude's text replies after every
+  turn. Thinking, tool calls, and system noise are filtered out.
+- Chat mode is **session-scoped**: it ends when the Claude Code session ends
+  (the `SessionEnd` hook clears the state). Use `/chat:resume` to continue in a
+  new session.
+- The `/chat:new` turn itself is not logged — recording starts with your next
+  message.
+
+## Files
+
+| Path | Tracked | Purpose |
+|---|---|---|
+| `doc/chat/{name}.md` | git | The conversation log. |
+| `doc/note/{name}.md` | git | Summaries produced by `/chat:note`. |
+| `.claude/chat/sessions/*.json` | ignored | Per-session runtime state. |
+
+## Resume lookup
+
+`/chat:resume` resolves its argument as: exact thread name → a number (the
+N-th most recent thread) → case-insensitive keyword match on the file name.
+
+## Install
+
+Part of the [claude-workbench](https://github.com/kirin/claude-workbench)
+marketplace. Enable the `chat` plugin — no setup, tokens, or dependencies
+required.

--- a/plugins/chat/README_zhtw.md
+++ b/plugins/chat/README_zhtw.md
@@ -1,0 +1,50 @@
+# chat
+
+Claude Code 的輕量對話串（thread）。開一個 chat，之後每一輪對話都會被記錄到一個
+markdown 檔，可以重讀、總結、隨時續聊。
+
+`chat` **只負責記錄** —— 它不會改變 Claude 的行為。「chat 模式」純粹是一個綁定
+單一 session 的記錄標記。
+
+## 指令
+
+| 指令 | 作用 |
+|---|---|
+| `/chat:new [name]` | 開一個對話串，把這個 session 記錄到 `doc/chat/{name}.md`。 |
+| `/chat:exit` | 停止記錄（對話串檔案會保留）。 |
+| `/chat:list` | 列出已存的對話串（最新在前），標出正在記錄的那一個。 |
+| `/chat:note [name]` | 把目前的對話串總結成 `doc/note/{name}.md`。 |
+| `/chat:resume <name\|N\|關鍵字>` | 重新開啟一個已存的對話串並繼續記錄。 |
+
+## 運作方式
+
+```
+/chat:new ──> doc/chat/{name}.md                 (對話串，會進 git)
+          └─> .claude/chat/sessions/{id}.json     (session 狀態，git ignore)
+
+每一輪 ──> Stop hook ──> chat-logger.py ──> 接到 doc/chat/{name}.md 後面
+```
+
+- `Stop` hook 在每一輪結束後，把使用者訊息與 Claude 的文字回覆接進對話串。
+  thinking、工具呼叫、系統雜訊都會被過濾掉。
+- chat 模式**綁定單一 session**：Claude Code session 結束時（`SessionEnd`
+  hook）狀態就會被清掉。要在新的 session 接續，請用 `/chat:resume`。
+- `/chat:new` 這一輪本身不會被記錄 —— 記錄從你的下一則訊息開始。
+
+## 檔案
+
+| 路徑 | 進 git | 用途 |
+|---|---|---|
+| `doc/chat/{name}.md` | 是 | 對話記錄。 |
+| `doc/note/{name}.md` | 是 | `/chat:note` 產生的總結。 |
+| `.claude/chat/sessions/*.json` | 否 | 每個 session 的執行期狀態。 |
+
+## resume 的查找規則
+
+`/chat:resume` 依序解析參數：完全相符的對話串名稱 → 數字（第 N 新的對話串）→
+對檔名做不分大小寫的關鍵字比對。
+
+## 安裝
+
+屬於 [claude-workbench](https://github.com/kirin/claude-workbench) marketplace。
+啟用 `chat` plugin 即可 —— 不需設定、不需 token、沒有相依套件。

--- a/plugins/chat/commands/exit.md
+++ b/plugins/chat/commands/exit.md
@@ -1,0 +1,37 @@
+---
+description: Leave chat mode — stop recording the current session's chat thread.
+allowed-tools: Read, Bash(echo:*), Bash(rm:*)
+---
+
+# /chat:exit
+
+Stop recording the chat thread for this session. The thread file itself is
+kept — only the recording marker is removed.
+
+## 1. Find the session state
+
+```bash
+echo "$CLAUDE_CODE_SESSION_ID"
+```
+
+Then `Read` the file `.claude/chat/sessions/{that session id}.json`.
+
+- If the file does not exist → this session is not in a chat thread. Tell the
+  user that and stop here.
+- If it exists → note its `chat` and `file` fields.
+
+## 2. Remove the recording marker
+
+```bash
+rm -f ".claude/chat/sessions/{session id}.json"
+```
+
+## 3. Confirm
+
+Tell the user:
+
+- Recording stopped — the thread is saved at `doc/chat/{chat}.md`.
+- `/chat:note` summarises it into `doc/note/`.
+- `/chat:resume {chat}` re-opens it later (in this or a future session).
+
+The conversation can continue normally — it just won't be logged anymore.

--- a/plugins/chat/commands/list.md
+++ b/plugins/chat/commands/list.md
@@ -1,0 +1,50 @@
+---
+description: List saved chat threads under doc/chat/, newest first, marking the one recording in this session.
+allowed-tools: Read, Bash(echo:*), Bash(ls:*), Bash(grep:*)
+---
+
+# /chat:list
+
+Show the saved chat threads so the user can pick one to `/chat:resume` or
+`/chat:note`.
+
+## 1. Gather
+
+```bash
+echo "session=$CLAUDE_CODE_SESSION_ID"
+ls -t doc/chat/*.md 2>/dev/null || echo "NO_THREADS"
+```
+
+- `NO_THREADS` (or no `doc/chat/` directory) → tell the user there are no chat
+  threads yet, and that `/chat:new` starts one. Stop here.
+- Otherwise the `ls -t` order is newest-first — that index is exactly what
+  `/chat:resume <N>` uses.
+
+`Read` `.claude/chat/sessions/{session id}.json` if it exists — its `file`
+field is the thread currently recording in *this* session.
+
+## 2. Describe each thread
+
+For every `doc/chat/*.md`, read its `> Started …` header line for the start
+time, and count `## ` turn headers for a rough size (`grep -c '^## ' <file>`).
+
+## 3. Print the list
+
+Newest first, as a compact table — index, name, started, turns, and a marker
+on the thread recording in this session:
+
+```
+Chat threads (doc/chat/):
+
+  #  thread             started            turns
+  1  refactor-plan   ●  2026-05-20 14:30      12   ← recording now
+  2  api-questions      2026-05-19 09:05      31
+  3  chat-2026-05-18     2026-05-18 16:40       4
+
+Resume:  /chat:resume <name | number | keyword>
+Summary: /chat:note
+```
+
+Mark `← recording now` only on the thread matching this session's state file.
+If no thread is active in this session, omit the marker and add a one-line note
+that nothing is recording right now.

--- a/plugins/chat/commands/new.md
+++ b/plugins/chat/commands/new.md
@@ -1,0 +1,79 @@
+---
+description: Start a new logged chat thread — the conversation is recorded to doc/chat/{name}.md until /chat:exit.
+argument-hint: [chat-name]
+allowed-tools: Read, Write, Bash(echo:*), Bash(mkdir:*), Bash(date:*), Bash(ls:*), Bash(test:*)
+---
+
+# /chat:new
+
+Start a new **chat thread**. From now until `/chat:exit` (or the session
+ends), every conversational turn in *this* session is appended to a markdown
+log by the plugin's `Stop` hook.
+
+This command **only turns on logging** — your behaviour, tools, and tone do
+not change. "Chat mode" is purely a recording marker scoped to this session.
+
+## 1. Gather facts
+
+Run one bash block:
+
+```bash
+echo "session=$CLAUDE_CODE_SESSION_ID"
+date '+%Y-%m-%d %H:%M'
+date '+%Y-%m-%dT%H:%M:%S%z'
+mkdir -p doc/chat .claude/chat/sessions
+ls doc/chat 2>/dev/null
+```
+
+## 2. Resolve the chat name
+
+- If `$ARGUMENTS` is non-empty, slugify it: lowercase, trim, spaces and
+  punctuation → `-`, collapse repeats, keep only `[a-z0-9-]`.
+- If `$ARGUMENTS` is empty, use `chat-YYYY-MM-DD`. If that file already exists
+  in `doc/chat/`, append `-2`, `-3`, … until the name is free.
+
+The thread file is `doc/chat/{name}.md`.
+
+## 3. Refuse to clobber
+
+If `doc/chat/{name}.md` already exists and the user gave an explicit name,
+STOP. Do not overwrite it. Tell the user it exists and suggest
+`/chat:resume {name}` to continue it, or `/chat:new {other-name}`.
+
+## 4. Write the thread file
+
+Create `doc/chat/{name}.md`:
+
+```
+# Chat: {name}
+
+> Started {YYYY-MM-DD HH:MM} · session `{first 8 chars of the session id}`
+```
+
+## 5. Write the session state
+
+Create `.claude/chat/sessions/{session id from step 1}.json`:
+
+```json
+{
+  "chat": "{name}",
+  "file": "doc/chat/{name}.md",
+  "transcript_cursor": null,
+  "started_at": "{ISO-8601 timestamp from step 1}"
+}
+```
+
+`transcript_cursor: null` is intentional — it tells the `Stop` hook to set its
+watermark on the next turn, so *this* `/chat:new` turn is not logged. Recording
+begins with the user's next message.
+
+## 6. Confirm
+
+Tell the user briefly:
+
+- Thread started: `doc/chat/{name}.md` — it records automatically every turn,
+  nothing else to do.
+- `/chat:exit` stops recording · `/chat:note` summarises the thread into
+  `doc/note/` · `/chat:resume {name}` re-opens it later.
+
+Then just continue the conversation normally.

--- a/plugins/chat/commands/note.md
+++ b/plugins/chat/commands/note.md
@@ -1,0 +1,70 @@
+---
+description: Summarise the active chat thread into a durable note under doc/note/.
+argument-hint: [note-name]
+allowed-tools: Read, Write, Bash(echo:*), Bash(ls:*), Bash(mkdir:*), Bash(date:*), AskUserQuestion
+---
+
+# /chat:note
+
+Distil a chat thread into a durable note: `doc/chat/{chat}.md` →
+`doc/note/{note}.md`. This does **not** leave chat mode — recording continues,
+so this command's own turn will also land in the thread.
+
+## 1. Find the source thread
+
+```bash
+echo "$CLAUDE_CODE_SESSION_ID"
+date '+%Y-%m-%d %H:%M'
+ls doc/chat/*.md 2>/dev/null
+```
+
+`Read` `.claude/chat/sessions/{that session id}.json`:
+
+- If it exists → the source thread is its `chat` / `file`.
+- If it does not exist (this session is not in a chat): if `$ARGUMENTS` names
+  an existing `doc/chat/*.md` thread, use that; otherwise list the threads and
+  ask the user which one to summarise (`AskUserQuestion`).
+
+## 2. Resolve the note name
+
+- `note` = `$ARGUMENTS` if given, slugified the same way as `/chat:new`;
+  otherwise the source chat's name.
+- The note file is `doc/note/{note}.md`.
+- If it already exists, ask the user whether to overwrite it or pick another
+  name.
+
+## 3. Read and summarise
+
+`Read` the full `doc/chat/{chat}.md`, then:
+
+```bash
+mkdir -p doc/note
+```
+
+Write `doc/note/{note}.md`:
+
+```
+# Note: {note}
+
+> Summarised from doc/chat/{chat}.md on {YYYY-MM-DD HH:MM}
+
+## TL;DR
+
+<2–4 sentences capturing what the conversation was about and where it landed>
+
+## Key points
+
+- <decisions, facts, answers and conclusions that matter>
+
+## Open questions / next steps
+
+- <anything left unresolved — omit this whole section if there is none>
+```
+
+Summarise the *substance* — decisions, answers, conclusions. Drop greetings,
+tangents, and tool chatter. Keep it skimmable.
+
+## 4. Confirm
+
+Tell the user where the note landed, and that the chat thread is still
+recording (run `/chat:exit` first next time if a clean cut is wanted).

--- a/plugins/chat/commands/resume.md
+++ b/plugins/chat/commands/resume.md
@@ -1,0 +1,71 @@
+---
+description: Re-open a saved chat thread and resume recording into it.
+argument-hint: <chat-name | number | keyword>
+allowed-tools: Read, Write, Bash(echo:*), Bash(ls:*), Bash(mkdir:*), Bash(date:*), AskUserQuestion
+---
+
+# /chat:resume
+
+Re-open a previously saved thread from `doc/chat/` and start recording new
+turns into it again — for example, to continue it in a fresh session.
+
+## 1. Gather facts
+
+```bash
+echo "session=$CLAUDE_CODE_SESSION_ID"
+date '+%Y-%m-%d %H:%M'
+date '+%Y-%m-%dT%H:%M:%S%z'
+ls -t doc/chat/*.md 2>/dev/null
+```
+
+`ls -t` lists threads newest-first — that is the order used for numeric lookup.
+
+## 2. Resolve `$ARGUMENTS` to exactly one thread
+
+Match in this order:
+
+1. **Exact** — `doc/chat/{$ARGUMENTS}.md` exists → use it.
+2. **Number** — `$ARGUMENTS` is an integer N → the N-th file in the `ls -t`
+   list (1 = most recent).
+3. **Keyword** — case-insensitive substring of a thread's base name:
+   - exactly one match → use it,
+   - several matches → list them and ask the user to pick (`AskUserQuestion`),
+   - no match → tell the user, show the available threads, and stop.
+
+If `$ARGUMENTS` is empty, list the threads and ask which one to resume.
+
+## 3. Load the thread into context
+
+`Read` the resolved `doc/chat/{name}.md` in full. This is the conversation
+history — use it so you can pick the thread up naturally.
+
+## 4. Re-arm recording
+
+Write `.claude/chat/sessions/{session id from step 1}.json`:
+
+```json
+{
+  "chat": "{name}",
+  "file": "doc/chat/{name}.md",
+  "transcript_cursor": null,
+  "started_at": "{ISO-8601 timestamp from step 1}"
+}
+```
+
+`transcript_cursor: null` keeps the `/chat:resume` turn itself out of the log —
+recording resumes with the user's next message.
+
+If a state file already exists for this session (a different thread was
+active), overwrite it — one session records into one thread at a time — and
+mention the switch to the user.
+
+Append a resume marker to the end of `doc/chat/{name}.md`:
+
+```
+> _— resumed {YYYY-MM-DD HH:MM} —_
+```
+
+## 5. Confirm
+
+Briefly tell the user the thread is re-opened and recording, give a one-line
+recap of where the conversation left off, and continue.

--- a/plugins/chat/hooks/hooks.json
+++ b/plugins/chat/hooks/hooks.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/chat-logger.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/chat-logger.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/chat/scripts/chat-logger.py
+++ b/plugins/chat/scripts/chat-logger.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""chat-logger.py — Stop / SessionEnd hook for the `chat` plugin.
+
+On every `Stop`, if the current session has an active chat thread, the
+conversational turns added since the last run are appended to the thread's
+markdown log. On `SessionEnd`, the session's chat-mode state is cleared — chat
+mode is session-scoped and never leaks into the next session.
+
+The hook is silent and always exits 0: a logging plugin must never block the
+agent or inject anything into the model's context.
+
+State lives at  .claude/chat/sessions/{session_id}.json  (relative to cwd):
+
+    {
+      "chat": "my-thread",
+      "file": "doc/chat/my-thread.md",
+      "transcript_cursor": null,   # null => set the watermark, log nothing yet
+      "started_at": "2026-05-20T14:30:00+08:00"
+    }
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+
+_SYS_REMINDER = re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)
+
+
+def read_payload() -> dict:
+    try:
+        data = json.load(sys.stdin)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def state_path(cwd: str, session_id: str) -> str:
+    return os.path.join(cwd, ".claude", "chat", "sessions", f"{session_id}.json")
+
+
+def load_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def save_json(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.replace(tmp, path)
+
+
+def hhmm(ts: str) -> str:
+    if not ts:
+        return ""
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone().strftime("%H:%M")
+    except Exception:
+        return ""
+
+
+def turn_text(record: dict):
+    """Return (speaker, text, timestamp) for a loggable turn, else None.
+
+    speaker is 'you' or 'claude'. Thinking, tool calls, tool results,
+    slash-command echoes, sidechain (subagent) turns and system reminders are
+    all filtered out — only human-readable conversation survives.
+    """
+    rtype = record.get("type")
+    message = record.get("message") or {}
+    content = message.get("content")
+    ts = record.get("timestamp", "")
+
+    if rtype == "user":
+        if record.get("isMeta") or record.get("isSidechain"):
+            return None
+        if not isinstance(content, str):
+            return None  # list content == tool_result, not a real turn
+        text = _SYS_REMINDER.sub("", content).strip()
+        if not text or "<command-name>" in text or text.startswith("<local-command-"):
+            return None
+        return ("you", text, ts)
+
+    if rtype == "assistant":
+        if record.get("isSidechain"):
+            return None
+        if not isinstance(content, list):
+            return None
+        parts = [
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        text = "".join(parts).strip()
+        return ("claude", text, ts) if text else None
+
+    return None
+
+
+def render(records: list) -> str:
+    turns = [t for t in (turn_text(r) for r in records if isinstance(r, dict)) if t]
+    if not turns:
+        return ""
+    # Merge consecutive turns from the same speaker into one block.
+    merged: list[list] = []
+    for speaker, text, ts in turns:
+        if merged and merged[-1][0] == speaker:
+            merged[-1][1] += "\n\n" + text
+        else:
+            merged.append([speaker, text, ts])
+
+    out = []
+    for speaker, text, ts in merged:
+        label = "\U0001f9d1 You" if speaker == "you" else "\U0001f916 Claude"
+        stamp = hhmm(ts)
+        head = f"## {label} · {stamp}" if stamp else f"## {label}"
+        out.append(f"\n{head}\n\n{text}\n")
+    return "".join(out)
+
+
+def read_transcript(path: str) -> list:
+    records = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                records.append({})
+    return records
+
+
+def handle_stop(payload: dict) -> None:
+    cwd = payload.get("cwd") or os.getcwd()
+    session_id = payload.get("session_id") or ""
+    if not session_id:
+        return
+
+    sp = state_path(cwd, session_id)
+    state = load_json(sp)
+    if not isinstance(state, dict):
+        return  # this session is not in chat mode
+
+    transcript = payload.get("transcript_path")
+    if not transcript or not os.path.exists(transcript):
+        return
+
+    records = read_transcript(transcript)
+    total = len(records)
+    cursor = state.get("transcript_cursor")
+
+    if not isinstance(cursor, int) or cursor > total:
+        # First Stop after /chat:new or /chat:resume (or the transcript was
+        # compacted): drop the watermark here, log nothing this turn.
+        state["transcript_cursor"] = total
+        save_json(sp, state)
+        return
+
+    block = render(records[cursor:total])
+    if block:
+        chat_file = os.path.join(cwd, state.get("file", ""))
+        try:
+            with open(chat_file, "a", encoding="utf-8") as fh:
+                fh.write(block)
+        except OSError:
+            pass
+
+    state["transcript_cursor"] = total
+    save_json(sp, state)
+
+
+def handle_session_end(payload: dict) -> None:
+    cwd = payload.get("cwd") or os.getcwd()
+    session_id = payload.get("session_id") or ""
+    if not session_id:
+        return
+
+    sp = state_path(cwd, session_id)
+    state = load_json(sp)
+    if isinstance(state, dict) and state.get("file"):
+        chat_file = os.path.join(cwd, state["file"])
+        try:
+            with open(chat_file, "a", encoding="utf-8") as fh:
+                fh.write(f"\n> _— session ended {datetime.now():%Y-%m-%d %H:%M} —_\n")
+        except OSError:
+            pass
+    try:
+        os.remove(sp)
+    except OSError:
+        pass
+
+
+def main() -> int:
+    payload = read_payload()
+    try:
+        if payload.get("hook_event_name") == "SessionEnd":
+            handle_session_end(payload)
+        else:  # Stop
+            handle_stop(payload)
+    except Exception:
+        pass  # a logging hook must never break the agent
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/chat/skills/chat-usage/SKILL.md
+++ b/plugins/chat/skills/chat-usage/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: chat-usage
+description: Use when the user asks how the `chat` plugin works, mentions /chat:new /chat:exit /chat:note /chat:resume, asks where a chat log went, or reports that a chat thread is not being recorded.
+---
+
+# Chat plugin — logged conversation threads
+
+The `chat` plugin records a Claude Code conversation to a markdown file so it
+can be re-read, summarised, and resumed later. It is **logging only** — it does
+not change how Claude behaves or what tools it uses.
+
+## Model
+
+- A **thread** is `doc/chat/{name}.md` — plain markdown, committed to git.
+- "Chat mode" is a per-session marker:
+  `.claude/chat/sessions/{session_id}.json` (runtime state, git-ignored).
+  While that file exists, the `Stop` hook appends each new turn to the thread.
+- Chat mode is **session-scoped**. It does not carry into a new Claude Code
+  session — the `SessionEnd` hook clears the state file.
+
+## Commands
+
+| Command | Effect |
+|---|---|
+| `/chat:new [name]` | Create `doc/chat/{name}.md`, start recording this session. |
+| `/chat:exit` | Stop recording (the thread file is kept). |
+| `/chat:list` | List saved threads, newest first, marking the active one. |
+| `/chat:note [name]` | Summarise the active thread → `doc/note/{name}.md`. |
+| `/chat:resume <name\|N\|keyword>` | Re-open a saved thread and record into it again. |
+
+## How recording works
+
+`scripts/chat-logger.py` runs on every `Stop`. If this session has a state
+file, it reads the session transcript and appends turns added since the last
+run — user messages and Claude's text replies only. Thinking, tool calls, tool
+results, slash-command echoes, subagent turns and system reminders are filtered
+out.
+
+`transcript_cursor` in the state file is the watermark. `/chat:new` and
+`/chat:resume` set it to `null`, which makes the next `Stop` set the watermark
+without logging — so the command's own turn never appears in the thread.
+
+## Resume lookup
+
+`/chat:resume` resolves its argument as: exact thread name → an integer (N-th
+most recent thread) → case-insensitive keyword match on the file name. No index
+file is kept; the filesystem under `doc/chat/` is the source of truth.
+
+## Common issues
+
+- **"My chat isn't being recorded."** Check `.claude/chat/sessions/` for a file
+  named with the current session id (`echo $CLAUDE_CODE_SESSION_ID`). No file →
+  not in chat mode; run `/chat:new` or `/chat:resume`.
+- **"Recording stopped after I restarted Claude Code."** Expected — chat mode
+  is session-scoped. Run `/chat:resume {name}` in the new session.
+- **The first turn isn't logged.** Also expected — the watermark is set on the
+  turn after `/chat:new`, so logging starts with the next message.
+- **`/chat:note` output appears in the thread too.** `/chat:note` does not exit
+  chat mode, so its confirmation is part of the still-recording session. Run
+  `/chat:exit` first for a clean cut.


### PR DESCRIPTION
## Summary

New **`chat`** plugin — turn a Claude Code session into a recorded
conversation thread that can be re-read, summarised, and resumed.

| Command | Effect |
|---|---|
| `/chat:new [name]` | Start a thread; record this session to `doc/chat/{name}.md`. |
| `/chat:exit` | Stop recording (thread file kept). |
| `/chat:list` | List saved threads, newest first, marking the active one. |
| `/chat:note [name]` | Summarise the active thread → `doc/note/{name}.md`. |
| `/chat:resume <name\|N\|keyword>` | Re-open a saved thread and record into it again. |

## Design

- **Logging only** — agent behaviour, tools, and tone are unchanged. "Chat
  mode" is purely a recording marker.
- **Session-scoped** — state lives in
  `.claude/chat/sessions/{session_id}.json`; the `SessionEnd` hook clears it,
  so chat mode never leaks into the next session. `/chat:resume` continues a
  thread in a fresh session.
- **Reliable capture** — `scripts/chat-logger.py` runs on every `Stop`, reads
  the session transcript incrementally (`transcript_cursor` watermark), and
  appends user messages + Claude's text replies only. Thinking, tool calls,
  tool results, slash-command echoes, subagent turns and system reminders are
  filtered out. The `/chat:new` turn itself is not logged — recording starts
  with the next message.
- **git tracking** — `doc/chat/` and `doc/note/` are committed; `.claude/chat/`
  is git-ignored (runtime state).

## Changes

- New `plugins/chat/` — plugin.json, 5 commands, `Stop`+`SessionEnd` hooks,
  `chat-logger.py`, `chat-usage` skill, README (EN + zh-TW).
- Registered in `.claude-plugin/marketplace.json` (now 7 entries).
- `.gitignore` ignores `.claude/chat/`; `CHANGELOG.md` and both top-level
  READMEs updated.

## Testing

`chat-logger.py` smoke-tested against a real Claude Code transcript: renders
clean `## You` / `## Claude` blocks, advances the cursor, is idempotent on
re-run, and `SessionEnd` appends a footer + clears state. JSON files and
Python syntax validated.

Not yet exercised end-to-end as an installed plugin (hooks load at session
start) — recommend a manual `/chat:new` run after enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)