### PR TITLE
fix(kanban): 0.3.31 — list_tasks honours addLabels so BLOCKED/DOING JQL stop colliding (#63)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "kanban",
       "source": "./plugins/kanban",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "description": "Kanban workflow for Claude Code — local kanban.json or Jira Cloud as the storage backend",
       "category": "productivity",
       "keywords": ["kanban", "tasks", "workflow"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ For earlier history, see the git log.
 
 ## Unreleased
 
+### Fixed
+- **kanban 0.3.31** — `JiraDriver.list_tasks(column=…)` now honours
+  `transitions[col].addLabels` when building JQL, so BLOCKED and DOING
+  no longer return the same result set when both map to the same Jira
+  status (the canonical "BLOCKED = In Progress + label `kanban:blocked`"
+  setup). `/kanban:sync` no longer duplicates In-Progress cards under
+  BLOCKED. The new `_column_jql_clauses` helper mirrors `disambiguate`'s
+  semantics: it AND-includes each `addLabels` label, AND-excludes each
+  `removeLabels` label, and AND-excludes any same-status sibling whose
+  `addLabels` is a strict superset of the queried column's. Closes #63.
+
 ### Added
 - **chat 0.1.0** — new lightweight plugin for logged conversation threads.
   `/chat:new` starts recording the session to `doc/chat/{name}.md` via a

--- a/plugins/kanban/.claude-plugin/plugin.json
+++ b/plugins/kanban/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Kanban-driven workflow for Claude Code. Local kanban.json or Jira Cloud as the storage backend.",
   "author": { "name": "kirin" },
   "homepage": "https://github.com/kirin/claude-workbench",

--- a/plugins/kanban/drivers/jira.py
+++ b/plugins/kanban/drivers/jira.py
@@ -119,6 +119,61 @@ class JiraDriver:
         spec = self._canonical_spec(column)
         return spec.get("status") if spec else None
 
+    def _column_jql_clauses(self, column: str) -> list[str]:
+        """Return JQL conjunct clauses that match exactly the issues
+        `disambiguate()` would classify as `column`.
+
+        Pure `status =` is not enough when several columns share a Jira
+        status and differ only by `addLabels` — the canonical
+        BLOCKED/DOING pattern, where both map to "In Progress" and
+        BLOCKED is tagged with `kanban:blocked`. Without label-aware
+        clauses, `list_tasks(column=BLOCKED)` returns every "In Progress"
+        card and `/kanban:sync` shows DOING cards duplicated under
+        BLOCKED (#63).
+
+        This helper:
+          * AND-includes `labels = "X"` for each of `column`'s `addLabels`,
+          * AND-excludes `labels = "X"` for each of `column`'s `removeLabels`,
+          * AND-excludes any same-status sibling whose `addLabels` is a
+            strict superset of `column`'s — those cards belong to the
+            more-specific sibling per `disambiguate`.
+
+        Returns an empty list when `column` has no transitions-map spec,
+        letting the caller fall through to legacy `label_fallback`.
+        """
+        spec = self._canonical_spec(column)
+        if not spec:
+            return []
+        status = spec.get("status")
+        add_labels = list(spec.get("addLabels") or [])
+        remove_labels = list(spec.get("removeLabels") or [])
+        clauses: list[str] = []
+        if status:
+            clauses.append(f'status = "{status}"')
+        for lbl in add_labels:
+            clauses.append(f'labels = "{lbl}"')
+        for lbl in remove_labels:
+            clauses.append(f'NOT labels = "{lbl}"')
+
+        if status:
+            my_add = set(add_labels)
+            for other, other_spec in self.transitions_map.items():
+                if other == column or not isinstance(other_spec, dict):
+                    continue
+                if other_spec.get("status") != status:
+                    continue
+                other_add = list(other_spec.get("addLabels") or [])
+                if not other_add or not (my_add < set(other_add)):
+                    continue
+                # Cards carrying ALL of the sibling's distinguishing labels
+                # belong to the sibling. Exclude them from our result.
+                terms = [f'labels = "{lbl}"' for lbl in other_add]
+                if len(terms) == 1:
+                    clauses.append(f"NOT {terms[0]}")
+                else:
+                    clauses.append("NOT (" + " AND ".join(terms) + ")")
+        return clauses
+
     def _get_status_category(self, status_name: str) -> str | None:
         """Return the Jira statusCategory key (`new`, `indeterminate`,
         `done`) for the given status display name, or None if the
@@ -290,9 +345,9 @@ class JiraDriver:
         clauses = [f'project = "{self.project_key}"']
         if filter:
             if filter.column:
-                status = self._canonical_to_status(filter.column)
-                if status:
-                    clauses.append(f'status = "{status}"')
+                col_clauses = self._column_jql_clauses(filter.column)
+                if col_clauses:
+                    clauses.extend(col_clauses)
                 elif getattr(self, "partial", False) and filter.column in getattr(self, "label_fallback", {}):
                     clauses.append(f'labels = "{self.label_fallback[filter.column]}"')
             if filter.assignee:

--- a/plugins/kanban/scripts/test_all.sh
+++ b/plugins/kanban/scripts/test_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35; do  # …34: versioned board config (#57), 35: markdown → ADF
+for n in 1 2 3 4 5 6 7 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36; do  # …35: markdown → ADF, 36: list_tasks addLabels (#63)
   echo "----- phase $n -----"
   python3 "$DIR/test_phase$n.py"
 done

--- a/plugins/kanban/scripts/test_phase36.py
+++ b/plugins/kanban/scripts/test_phase36.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Phase 36 regression checks for kanban v0.3.31 — list_tasks JQL honours
+addLabels on columns that share a Jira status.
+
+Closes #63. Pre-fix, `JiraDriver.list_tasks(column=BLOCKED)` and
+`list_tasks(column=DOING)` produced identical JQL when BLOCKED/DOING both
+mapped to "In Progress" (BLOCKED disambiguated by `kanban:blocked`):
+
+    project = "BZK" AND status = "In Progress"
+
+That made `/kanban:sync` count every In-Progress card twice and list it
+under both DOING and BLOCKED. `disambiguate()` was already label-aware on
+the read-back side, but the JQL on the fetch side was status-only.
+
+The fix routes column filtering through `_column_jql_clauses`, which
+mirrors `disambiguate`'s semantics:
+
+  * AND-includes `labels = "X"` for each of the column's `addLabels`.
+  * AND-excludes `labels = "X"` for each of the column's `removeLabels`.
+  * AND-excludes same-status siblings whose `addLabels` is a strict
+    superset of ours — those cards belong to the more-specific sibling.
+
+Cases:
+  (a) BLOCKED JQL includes its addLabels positively.
+  (b) DOING (bare on shared status) excludes every more-specific sibling's
+      label, so it never returns BLOCKED or REVIEW cards.
+  (c) REVIEW only includes its own addLabel — BLOCKED's label is NOT a
+      strict superset of REVIEW's (they are disjoint), so it is not
+      excluded.
+  (d) A column whose status no other column shares emits exactly the
+      legacy status-only clause — no spurious `labels` clauses (backward
+      compatibility).
+  (e) removeLabels surface as `NOT labels = "X"` clauses.
+  (f) An unmapped column (no transitions entry) falls back to legacy
+      label_fallback behaviour and does NOT inject status / labels
+      clauses on its own.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO / "plugins" / "kanban"))
+
+from drivers.base import TaskFilter  # noqa: E402
+from drivers.jira import JiraDriver  # noqa: E402
+from lib.jira_client import JiraClient, _Response  # noqa: E402
+
+
+def _build_driver(transitions: dict, *, project_key: str = "BZK") -> tuple[JiraDriver, list]:
+    """Construct a JiraDriver with a mocked transport that records the
+    JSON body of every request and replies with an empty issue list.
+
+    Returns (driver, calls). `calls[-1]["body"]["jql"]` is the JQL of the
+    most recent `search_jql`.
+    """
+    calls: list[dict] = []
+
+    def transport(method, url, headers, body):
+        calls.append({
+            "method": method,
+            "url": url,
+            "body": json.loads(body) if body else None,
+        })
+        return _Response(200, b'{"issues": []}', {})
+
+    kanban_data = {
+        "backend": {
+            "driver": "jira",
+            "jira": {
+                "projectKey": project_key,
+                "transitions": transitions,
+            },
+        }
+    }
+    with tempfile.TemporaryDirectory() as td:
+        drv = JiraDriver(kanban_data, pathlib.Path(td))
+
+    # Inject the mock client. _client_or_raise gates on truthy
+    # base_url/email/_token before returning the cached client.
+    drv.base_url = "https://x.atlassian.net"
+    drv.email = "agent@example.com"
+    drv._token = "tok"
+    drv._client = JiraClient(
+        drv.base_url, drv.email, drv._token,
+        transport=transport, sleep=lambda _: None,
+    )
+    return drv, calls
+
+
+# The canonical shared-status setup from the issue report.
+SHARED = {
+    "TODO":     {"status": "Selected for Development"},
+    "DOING":    {"status": "In Progress"},
+    "BLOCKED":  {"status": "In Progress", "addLabels": ["kanban:blocked"]},
+    "REVIEW":   {"status": "In Progress", "addLabels": ["kanban:review"]},
+    "APPROVED": {"status": "Done"},
+}
+
+
+def _jql_for(transitions: dict, column: str) -> str:
+    drv, calls = _build_driver(transitions)
+    drv.list_tasks(TaskFilter(column=column))
+    return calls[-1]["body"]["jql"]
+
+
+def test_blocked_jql_includes_addlabels():
+    jql = _jql_for(SHARED, "BLOCKED")
+    assert 'status = "In Progress"' in jql, jql
+    assert 'labels = "kanban:blocked"' in jql, jql
+
+
+def test_doing_jql_excludes_every_competing_label():
+    """The bug case from #63 — bare DOING must not return BLOCKED or
+    REVIEW cards just because they all live on "In Progress"."""
+    jql = _jql_for(SHARED, "DOING")
+    assert 'status = "In Progress"' in jql, jql
+    assert 'NOT labels = "kanban:blocked"' in jql, jql
+    assert 'NOT labels = "kanban:review"' in jql, jql
+
+
+def test_review_jql_only_includes_own_addlabel():
+    """REVIEW's addLabels = {kanban:review} is disjoint from BLOCKED's
+    {kanban:blocked} — neither is a strict superset of the other, so
+    REVIEW must not exclude BLOCKED's label. Disambiguate's
+    alphabetical tie-break handles cards carrying both labels."""
+    jql = _jql_for(SHARED, "REVIEW")
+    assert 'status = "In Progress"' in jql, jql
+    assert 'labels = "kanban:review"' in jql, jql
+    assert 'NOT labels = "kanban:blocked"' not in jql, jql
+
+
+def test_unshared_status_emits_only_status_clause():
+    """Backward-compatibility: a column whose status no other column
+    shares produces exactly the legacy status-only JQL — no spurious
+    `labels` clauses."""
+    jql = _jql_for(SHARED, "TODO")
+    assert 'status = "Selected for Development"' in jql, jql
+    assert "labels" not in jql, jql
+
+
+def test_remove_labels_become_not_clauses():
+    """`removeLabels` surface as `NOT labels = "X"` clauses."""
+    transitions = {
+        "DOING":   {"status": "In Progress",
+                    "removeLabels": ["kanban:archived"]},
+        "BLOCKED": {"status": "In Progress",
+                    "addLabels": ["kanban:blocked"]},
+    }
+    jql = _jql_for(transitions, "DOING")
+    assert 'NOT labels = "kanban:archived"' in jql, jql
+    # Sibling exclusion still applies on top of removeLabels.
+    assert 'NOT labels = "kanban:blocked"' in jql, jql
+
+
+def test_unmapped_column_falls_through_without_clauses():
+    """A column not in `transitions` produces no clauses from the helper;
+    list_tasks then falls back to the legacy label_fallback path (which
+    is a no-op for v0.3 configs)."""
+    transitions = {"DOING": {"status": "In Progress"}}
+    drv, calls = _build_driver(transitions)
+    drv.list_tasks(TaskFilter(column="CANCELLED"))
+    jql = calls[-1]["body"]["jql"]
+    # Only the `project = ...` and ORDER BY clauses remain — no
+    # status/labels filter for the unmapped column.
+    assert 'status' not in jql, jql
+    assert 'labels' not in jql, jql
+    assert 'project = "BZK"' in jql, jql
+
+
+def test_legacy_single_status_per_column_unchanged():
+    """A pre-#63 transitions map (every column on its own status) emits
+    exactly one `status = ...` clause per column. No regressions."""
+    transitions = {
+        "TODO":     {"status": "To Do"},
+        "DOING":    {"status": "In Progress"},
+        "APPROVED": {"status": "Done"},
+    }
+    jql = _jql_for(transitions, "DOING")
+    assert 'status = "In Progress"' in jql, jql
+    assert "labels" not in jql, jql
+
+
+def main() -> None:
+    tests = [
+        ("blocked_jql_includes_addlabels",
+         test_blocked_jql_includes_addlabels),
+        ("doing_jql_excludes_every_competing_label",
+         test_doing_jql_excludes_every_competing_label),
+        ("review_jql_only_includes_own_addlabel",
+         test_review_jql_only_includes_own_addlabel),
+        ("unshared_status_emits_only_status_clause",
+         test_unshared_status_emits_only_status_clause),
+        ("remove_labels_become_not_clauses",
+         test_remove_labels_become_not_clauses),
+        ("unmapped_column_falls_through_without_clauses",
+         test_unmapped_column_falls_through_without_clauses),
+        ("legacy_single_status_per_column_unchanged",
+         test_legacy_single_status_per_column_unchanged),
+    ]
+    for name, fn in tests:
+        fn()
+        print(f"ok    {name}")
+    print("phase36: all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #63.

## Root cause

`JiraDriver.list_tasks(column=…)` only emitted `status = "X"` when
translating a column to JQL. When two columns share a Jira status and
disambiguate by labels — the canonical *"BLOCKED = In Progress + label
`kanban:blocked`"* setup — both columns produced **identical** JQL and
returned the same issue set.

`/kanban:sync` therefore counted every In-Progress card twice and listed
each one under both DOING and BLOCKED (see the reproduction in #63).

The read-back path was already label-aware via `disambiguate()` in
`lib/transitions.py`; only the fetch-side JQL ignored `addLabels`.

## Fix

New `_column_jql_clauses` helper mirrors `disambiguate`'s
most-specific-wins semantics:

- AND-include `labels = "X"` for each of the column's `addLabels`.
- AND-exclude `labels = "X"` for each of the column's `removeLabels`.
- AND-exclude any same-status sibling whose `addLabels` is a strict
  superset of the queried column's — those cards belong to the
  more-specific sibling.

For the BLOCKED/DOING/REVIEW-share-In-Progress case:

```
BLOCKED → status = "In Progress" AND labels = "kanban:blocked"
DOING   → status = "In Progress" AND NOT labels = "kanban:blocked"
                                 AND NOT labels = "kanban:review"
REVIEW  → status = "In Progress" AND labels = "kanban:review"
```

A column whose status no other column shares produces exactly the
legacy status-only clause, so transitions maps without label
disambiguation are unaffected.

## Testing

New `plugins/kanban/scripts/test_phase36.py` — 7 cases driving
`JiraDriver.list_tasks` through a mocked transport and asserting the
emitted JQL include/exclude clauses on:

1. BLOCKED includes its `addLabels` positively.
2. DOING (the bug case) excludes every more-specific sibling's label.
3. REVIEW only includes its own label — BLOCKED's label is disjoint, not
   a strict superset, so it is **not** excluded (the alphabetical
   tie-break inside `disambiguate` handles the rare two-label card).
4. Unshared-status column → exactly the legacy `status = "X"` clause,
   no spurious `labels` clauses.
5. `removeLabels` surface as `NOT labels = "X"`.
6. Unmapped column falls through with no clauses (legacy
   `label_fallback` path preserved).
7. Pre-#63 single-status-per-column maps behave exactly as before.

`bash plugins/kanban/scripts/test_all.sh` — **all 36 phases green**,
including the new phase 36. No regressions.

## Versioning

- `plugins/kanban/.claude-plugin/plugin.json` and
  `.claude-plugin/marketplace.json` both bumped 0.3.30 → 0.3.31
  (pre-commit hook satisfied).
- `CHANGELOG.md` Unreleased → Fixed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)